### PR TITLE
Export package turf.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.1
+
+### Common
+* Expose `package:turf/helpers.dart`.
+
 ## 0.4.0 
 
 ### Common

--- a/lib/mapbox_maps_flutter.dart
+++ b/lib/mapbox_maps_flutter.dart
@@ -46,3 +46,5 @@ part 'src/style/source/raster_source.dart';
 part 'src/style/source/rasterdem_source.dart';
 part 'src/style/source/vector_source.dart';
 part 'src/style/style.dart';
+
+export   'package:turf/helpers.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mapbox_maps_flutter
 description: A Flutter plugin for integrating Mapbox Maps SDK v10 in Android/iOS application.
-version: 0.4.0
+version: 0.4.0+1
 homepage: https://github.com/mapbox/mapbox-maps-flutter
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mapbox_maps_flutter
 description: A Flutter plugin for integrating Mapbox Maps SDK v10 in Android/iOS application.
-version: 0.4.0+1
+version: 0.4.1
 homepage: https://github.com/mapbox/mapbox-maps-flutter
 
 environment:


### PR DESCRIPTION
It is needed export the turf package, for use the **Postion** class and others. Otherwise, this package can't be used with the turfs types.