### PR TITLE
Fix mapCreated callback called on every build

### DIFF
--- a/lib/src/map_widget.dart
+++ b/lib/src/map_widget.dart
@@ -186,10 +186,6 @@ class _MapWidgetState extends State<MapWidget> {
       'mapboxPluginVersion': '0.4.0'
     };
 
-    if (widget.onMapCreated != null && mapboxMap != null) {
-      widget.onMapCreated!(mapboxMap!);
-    }
-
     return _mapboxMapsPlatform.buildView(
         creationParams, onPlatformViewCreated, widget.gestureRecognizers);
   }


### PR DESCRIPTION
# Description

Considering flutters posibility for calling build method on every frame as stated in the docs,

> This method can potentially be called in every frame and should not have any side effects beyond building a widget.

we can say that `MapWidget`s build method has side effects of calling `onMapCreated` callback which should be called only the first time map is created, which is already done from `onPlatformViewCreated` callback.

Fixes: #26 
Fixes: #57 
Fixes: #68

## Type of change

- [x] Bug fix (non-breaking change)
