### PR TITLE
Fix getLayer on layers with expression properties. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Expose `package:turf/helpers.dart`.
 * Bump platform Maps SDK dependencies to 10.10.0.
 * Fix issue with multiple maps overriding platform channels of the previous instances.
+* Fix exception accessing `style.getLayer` when layer property is an Expression.
 
 ## 0.4.0 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.4.1 
+## 0.4.1
 
 ### Common
 * Expose `package:turf/helpers.dart`.

--- a/example/integration_test/animation_test.dart
+++ b/example/integration_test/animation_test.dart
@@ -4,7 +4,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
 import 'package:mapbox_maps_example/empty_map_widget.dart' as app;
-import 'package:turf/helpers.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();

--- a/example/integration_test/annotations/circle_annotation_manager_test.dart
+++ b/example/integration_test/annotations/circle_annotation_manager_test.dart
@@ -4,7 +4,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
 import 'package:mapbox_maps_example/empty_map_widget.dart' as app;
-import 'package:turf/helpers.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();

--- a/example/integration_test/annotations/circle_annotation_test.dart
+++ b/example/integration_test/annotations/circle_annotation_test.dart
@@ -4,7 +4,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
 import 'package:mapbox_maps_example/empty_map_widget.dart' as app;
-import 'package:turf/helpers.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();

--- a/example/integration_test/annotations/point_annotation_manager_test.dart
+++ b/example/integration_test/annotations/point_annotation_manager_test.dart
@@ -4,7 +4,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
 import 'package:mapbox_maps_example/empty_map_widget.dart' as app;
-import 'package:turf/helpers.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();

--- a/example/integration_test/annotations/point_annotation_test.dart
+++ b/example/integration_test/annotations/point_annotation_test.dart
@@ -4,7 +4,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
 import 'package:mapbox_maps_example/empty_map_widget.dart' as app;
-import 'package:turf/helpers.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();

--- a/example/integration_test/annotations/polygon_annotation_manager_test.dart
+++ b/example/integration_test/annotations/polygon_annotation_manager_test.dart
@@ -4,7 +4,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
 import 'package:mapbox_maps_example/empty_map_widget.dart' as app;
-import 'package:turf/helpers.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();

--- a/example/integration_test/annotations/polygon_annotation_test.dart
+++ b/example/integration_test/annotations/polygon_annotation_test.dart
@@ -4,7 +4,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
 import 'package:mapbox_maps_example/empty_map_widget.dart' as app;
-import 'package:turf/helpers.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();

--- a/example/integration_test/annotations/polyline_annotation_manager_test.dart
+++ b/example/integration_test/annotations/polyline_annotation_manager_test.dart
@@ -4,7 +4,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
 import 'package:mapbox_maps_example/empty_map_widget.dart' as app;
-import 'package:turf/helpers.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();

--- a/example/integration_test/annotations/polyline_annotation_test.dart
+++ b/example/integration_test/annotations/polyline_annotation_test.dart
@@ -4,7 +4,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
 import 'package:mapbox_maps_example/empty_map_widget.dart' as app;
-import 'package:turf/helpers.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();

--- a/example/integration_test/projection_test.dart
+++ b/example/integration_test/projection_test.dart
@@ -2,7 +2,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
 import 'package:mapbox_maps_example/empty_map_widget.dart' as app;
-import 'package:turf/helpers.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2,18 +2,18 @@ PODS:
   - Flutter (1.0.0)
   - integration_test (0.0.1):
     - Flutter
-  - mapbox_maps_flutter (0.4.0):
+  - mapbox_maps_flutter (0.4.1):
     - Flutter
-    - MapboxMaps (~> 10.9.0)
-  - MapboxCommon (23.1.0)
-  - MapboxCoreMaps (10.9.1):
-    - MapboxCommon (~> 23.1)
-  - MapboxMaps (10.9.1):
-    - MapboxCommon (= 23.1.0)
-    - MapboxCoreMaps (= 10.9.1)
-    - MapboxMobileEvents (= 1.0.8)
+    - MapboxMaps (~> 10.10.0)
+  - MapboxCommon (23.2.1)
+  - MapboxCoreMaps (10.10.0):
+    - MapboxCommon (~> 23.2)
+  - MapboxMaps (10.10.0):
+    - MapboxCommon (= 23.2.1)
+    - MapboxCoreMaps (= 10.10.0)
+    - MapboxMobileEvents (= 1.0.10)
     - Turf (~> 2.0)
-  - MapboxMobileEvents (1.0.8)
+  - MapboxMobileEvents (1.0.10)
   - permission_handler_apple (9.0.4):
     - Flutter
   - Turf (2.6.1)
@@ -45,11 +45,11 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   integration_test: a1e7d09bd98eca2fc37aefd79d4f41ad37bdbbe5
-  mapbox_maps_flutter: 97a05e7827337bdd8931c42ee8cee9584e6c860f
-  MapboxCommon: bfffb68226f650df065cf24e307576267ebc75e8
-  MapboxCoreMaps: c74e3dd1d7d2b8c0ca5503d8c3e8ef79a8feccd5
-  MapboxMaps: f5e3858e71a923f0e2fc168a93397cfd98341dc5
-  MapboxMobileEvents: febdd92835daa258ca1c1faad0821c0b3394ef40
+  mapbox_maps_flutter: e1e956d927c4cdbfc88add67bd8e375f735c0908
+  MapboxCommon: 235bb9c27a8985d982e17f216795b1f7ab526782
+  MapboxCoreMaps: 4075a9e415b9b3ab6229d09623fef5f791826a5b
+  MapboxMaps: a5ad1977764731f97ba04bb7815b6b367e56039c
+  MapboxMobileEvents: de50b3a4de180dd129c326e09cd12c8adaaa46d6
   permission_handler_apple: 44366e37eaf29454a1e7b1b7d736c2cceaeb17ce
   Turf: 469ce2c3d22e5e8e4818d5a3b254699a5c89efa4
 

--- a/example/lib/full_map.dart
+++ b/example/lib/full_map.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
-import 'package:turf/helpers.dart';
 
 import 'main.dart';
 import 'page.dart';

--- a/lib/src/style/layer/background_layer.dart
+++ b/lib/src/style/layer/background_layer.dart
@@ -80,8 +80,8 @@ class BackgroundLayer extends Layer {
               .toLowerCase()
               .contains(map["layout"]["visibility"])),
       backgroundColor: (map["paint"]["background-color"] as List?)?.toRGBAInt(),
-      backgroundOpacity: map["paint"]["background-opacity"] is double
-          ? map["paint"]["background-opacity"] as double
+      backgroundOpacity: map["paint"]["background-opacity"] is double?
+          ? map["paint"]["background-opacity"] as double?
           : null,
       backgroundPattern: map["paint"]["background-pattern"],
     );

--- a/lib/src/style/layer/background_layer.dart
+++ b/lib/src/style/layer/background_layer.dart
@@ -80,7 +80,9 @@ class BackgroundLayer extends Layer {
               .toLowerCase()
               .contains(map["layout"]["visibility"])),
       backgroundColor: (map["paint"]["background-color"] as List?)?.toRGBAInt(),
-      backgroundOpacity: map["paint"]["background-opacity"]?.toDouble(),
+      backgroundOpacity: map["paint"]["background-opacity"] is double
+          ? map["paint"]["background-opacity"] as double
+          : null,
       backgroundPattern: map["paint"]["background-pattern"],
     );
   }

--- a/lib/src/style/layer/circle_layer.dart
+++ b/lib/src/style/layer/circle_layer.dart
@@ -159,15 +159,15 @@ class CircleLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["layout"]["visibility"])),
-      circleSortKey: map["layout"]["circle-sort-key"] is double
-          ? map["paint"]["circle-sort-key"] as double
+      circleSortKey: map["layout"]["circle-sort-key"] is double?
+          ? map["paint"]["circle-sort-key"] as double?
           : null,
-      circleBlur: map["paint"]["circle-blur"] is double
-          ? map["paint"]["circle-blur"] as double
+      circleBlur: map["paint"]["circle-blur"] is double?
+          ? map["paint"]["circle-blur"] as double?
           : null,
       circleColor: (map["paint"]["circle-color"] as List?)?.toRGBAInt(),
-      circleOpacity: map["paint"]["circle-opacity"] is double
-          ? map["paint"]["circle-opacity"] as double
+      circleOpacity: map["paint"]["circle-opacity"] is double?
+          ? map["paint"]["circle-opacity"] as double?
           : null,
       circlePitchAlignment: map["paint"]["circle-pitch-alignment"] == null
           ? null
@@ -185,16 +185,16 @@ class CircleLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["paint"]["circle-pitch-scale"])),
-      circleRadius: map["paint"]["circle-radius"] is double
-          ? map["paint"]["circle-radius"] as double
+      circleRadius: map["paint"]["circle-radius"] is double?
+          ? map["paint"]["circle-radius"] as double?
           : null,
       circleStrokeColor:
           (map["paint"]["circle-stroke-color"] as List?)?.toRGBAInt(),
-      circleStrokeOpacity: map["paint"]["circle-stroke-opacity"] is double
-          ? map["paint"]["circle-stroke-opacity"] as double
+      circleStrokeOpacity: map["paint"]["circle-stroke-opacity"] is double?
+          ? map["paint"]["circle-stroke-opacity"] as double?
           : null,
-      circleStrokeWidth: map["paint"]["circle-stroke-width"] is double
-          ? map["paint"]["circle-stroke-width"] as double
+      circleStrokeWidth: map["paint"]["circle-stroke-width"] is double?
+          ? map["paint"]["circle-stroke-width"] as double?
           : null,
       circleTranslate: (map["paint"]["circle-translate"] as List?)
           ?.map<double?>((e) => e.toDouble())

--- a/lib/src/style/layer/circle_layer.dart
+++ b/lib/src/style/layer/circle_layer.dart
@@ -159,7 +159,7 @@ class CircleLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["layout"]["visibility"])),
-      circleSortKey: map["paint"]["circle-sort-key"] is double
+      circleSortKey: map["layout"]["circle-sort-key"] is double
           ? map["paint"]["circle-sort-key"] as double
           : null,
       circleBlur: map["paint"]["circle-blur"] is double

--- a/lib/src/style/layer/circle_layer.dart
+++ b/lib/src/style/layer/circle_layer.dart
@@ -159,10 +159,16 @@ class CircleLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["layout"]["visibility"])),
-      circleSortKey: map["layout"]["circle-sort-key"]?.toDouble(),
-      circleBlur: map["paint"]["circle-blur"]?.toDouble(),
+      circleSortKey: map["paint"]["circle-sort-key"] is double
+          ? map["paint"]["circle-sort-key"] as double
+          : null,
+      circleBlur: map["paint"]["circle-blur"] is double
+          ? map["paint"]["circle-blur"] as double
+          : null,
       circleColor: (map["paint"]["circle-color"] as List?)?.toRGBAInt(),
-      circleOpacity: map["paint"]["circle-opacity"]?.toDouble(),
+      circleOpacity: map["paint"]["circle-opacity"] is double
+          ? map["paint"]["circle-opacity"] as double
+          : null,
       circlePitchAlignment: map["paint"]["circle-pitch-alignment"] == null
           ? null
           : CirclePitchAlignment.values.firstWhere((e) => e
@@ -179,11 +185,17 @@ class CircleLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["paint"]["circle-pitch-scale"])),
-      circleRadius: map["paint"]["circle-radius"]?.toDouble(),
+      circleRadius: map["paint"]["circle-radius"] is double
+          ? map["paint"]["circle-radius"] as double
+          : null,
       circleStrokeColor:
           (map["paint"]["circle-stroke-color"] as List?)?.toRGBAInt(),
-      circleStrokeOpacity: map["paint"]["circle-stroke-opacity"]?.toDouble(),
-      circleStrokeWidth: map["paint"]["circle-stroke-width"]?.toDouble(),
+      circleStrokeOpacity: map["paint"]["circle-stroke-opacity"] is double
+          ? map["paint"]["circle-stroke-opacity"] as double
+          : null,
+      circleStrokeWidth: map["paint"]["circle-stroke-width"] is double
+          ? map["paint"]["circle-stroke-width"] as double
+          : null,
       circleTranslate: (map["paint"]["circle-translate"] as List?)
           ?.map<double?>((e) => e.toDouble())
           .toList(),

--- a/lib/src/style/layer/fill_extrusion_layer.dart
+++ b/lib/src/style/layer/fill_extrusion_layer.dart
@@ -132,11 +132,17 @@ class FillExtrusionLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["layout"]["visibility"])),
-      fillExtrusionBase: map["paint"]["fill-extrusion-base"]?.toDouble(),
+      fillExtrusionBase: map["paint"]["fill-extrusion-base"] is double
+          ? map["paint"]["fill-extrusion-base"] as double
+          : null,
       fillExtrusionColor:
           (map["paint"]["fill-extrusion-color"] as List?)?.toRGBAInt(),
-      fillExtrusionHeight: map["paint"]["fill-extrusion-height"]?.toDouble(),
-      fillExtrusionOpacity: map["paint"]["fill-extrusion-opacity"]?.toDouble(),
+      fillExtrusionHeight: map["paint"]["fill-extrusion-height"] is double
+          ? map["paint"]["fill-extrusion-height"] as double
+          : null,
+      fillExtrusionOpacity: map["paint"]["fill-extrusion-opacity"] is double
+          ? map["paint"]["fill-extrusion-opacity"] as double
+          : null,
       fillExtrusionPattern: map["paint"]["fill-extrusion-pattern"],
       fillExtrusionTranslate:
           (map["paint"]["fill-extrusion-translate"] as List?)

--- a/lib/src/style/layer/fill_extrusion_layer.dart
+++ b/lib/src/style/layer/fill_extrusion_layer.dart
@@ -132,16 +132,16 @@ class FillExtrusionLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["layout"]["visibility"])),
-      fillExtrusionBase: map["paint"]["fill-extrusion-base"] is double
-          ? map["paint"]["fill-extrusion-base"] as double
+      fillExtrusionBase: map["paint"]["fill-extrusion-base"] is double?
+          ? map["paint"]["fill-extrusion-base"] as double?
           : null,
       fillExtrusionColor:
           (map["paint"]["fill-extrusion-color"] as List?)?.toRGBAInt(),
-      fillExtrusionHeight: map["paint"]["fill-extrusion-height"] is double
-          ? map["paint"]["fill-extrusion-height"] as double
+      fillExtrusionHeight: map["paint"]["fill-extrusion-height"] is double?
+          ? map["paint"]["fill-extrusion-height"] as double?
           : null,
-      fillExtrusionOpacity: map["paint"]["fill-extrusion-opacity"] is double
-          ? map["paint"]["fill-extrusion-opacity"] as double
+      fillExtrusionOpacity: map["paint"]["fill-extrusion-opacity"] is double?
+          ? map["paint"]["fill-extrusion-opacity"] as double?
           : null,
       fillExtrusionPattern: map["paint"]["fill-extrusion-pattern"],
       fillExtrusionTranslate:

--- a/lib/src/style/layer/fill_layer.dart
+++ b/lib/src/style/layer/fill_layer.dart
@@ -129,13 +129,13 @@ class FillLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["layout"]["visibility"])),
-      fillSortKey: map["layout"]["fill-sort-key"] is double
-          ? map["paint"]["fill-sort-key"] as double
+      fillSortKey: map["layout"]["fill-sort-key"] is double?
+          ? map["paint"]["fill-sort-key"] as double?
           : null,
       fillAntialias: map["paint"]["fill-antialias"],
       fillColor: (map["paint"]["fill-color"] as List?)?.toRGBAInt(),
-      fillOpacity: map["paint"]["fill-opacity"] is double
-          ? map["paint"]["fill-opacity"] as double
+      fillOpacity: map["paint"]["fill-opacity"] is double?
+          ? map["paint"]["fill-opacity"] as double?
           : null,
       fillOutlineColor:
           (map["paint"]["fill-outline-color"] as List?)?.toRGBAInt(),

--- a/lib/src/style/layer/fill_layer.dart
+++ b/lib/src/style/layer/fill_layer.dart
@@ -129,10 +129,14 @@ class FillLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["layout"]["visibility"])),
-      fillSortKey: map["layout"]["fill-sort-key"]?.toDouble(),
+      fillSortKey: map["paint"]["fill-sort-key"] is double
+          ? map["paint"]["fill-sort-key"] as double
+          : null,
       fillAntialias: map["paint"]["fill-antialias"],
       fillColor: (map["paint"]["fill-color"] as List?)?.toRGBAInt(),
-      fillOpacity: map["paint"]["fill-opacity"]?.toDouble(),
+      fillOpacity: map["paint"]["fill-opacity"] is double
+          ? map["paint"]["fill-opacity"] as double
+          : null,
       fillOutlineColor:
           (map["paint"]["fill-outline-color"] as List?)?.toRGBAInt(),
       fillPattern: map["paint"]["fill-pattern"],

--- a/lib/src/style/layer/fill_layer.dart
+++ b/lib/src/style/layer/fill_layer.dart
@@ -129,7 +129,7 @@ class FillLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["layout"]["visibility"])),
-      fillSortKey: map["paint"]["fill-sort-key"] is double
+      fillSortKey: map["layout"]["fill-sort-key"] is double
           ? map["paint"]["fill-sort-key"] as double
           : null,
       fillAntialias: map["paint"]["fill-antialias"],

--- a/lib/src/style/layer/heatmap_layer.dart
+++ b/lib/src/style/layer/heatmap_layer.dart
@@ -108,10 +108,18 @@ class HeatmapLayer extends Layer {
               .toLowerCase()
               .contains(map["layout"]["visibility"])),
       heatmapColor: (map["paint"]["heatmap-color"] as List?)?.toRGBAInt(),
-      heatmapIntensity: map["paint"]["heatmap-intensity"]?.toDouble(),
-      heatmapOpacity: map["paint"]["heatmap-opacity"]?.toDouble(),
-      heatmapRadius: map["paint"]["heatmap-radius"]?.toDouble(),
-      heatmapWeight: map["paint"]["heatmap-weight"]?.toDouble(),
+      heatmapIntensity: map["paint"]["heatmap-intensity"] is double
+          ? map["paint"]["heatmap-intensity"] as double
+          : null,
+      heatmapOpacity: map["paint"]["heatmap-opacity"] is double
+          ? map["paint"]["heatmap-opacity"] as double
+          : null,
+      heatmapRadius: map["paint"]["heatmap-radius"] is double
+          ? map["paint"]["heatmap-radius"] as double
+          : null,
+      heatmapWeight: map["paint"]["heatmap-weight"] is double
+          ? map["paint"]["heatmap-weight"] as double
+          : null,
     );
   }
 }

--- a/lib/src/style/layer/heatmap_layer.dart
+++ b/lib/src/style/layer/heatmap_layer.dart
@@ -108,17 +108,17 @@ class HeatmapLayer extends Layer {
               .toLowerCase()
               .contains(map["layout"]["visibility"])),
       heatmapColor: (map["paint"]["heatmap-color"] as List?)?.toRGBAInt(),
-      heatmapIntensity: map["paint"]["heatmap-intensity"] is double
-          ? map["paint"]["heatmap-intensity"] as double
+      heatmapIntensity: map["paint"]["heatmap-intensity"] is double?
+          ? map["paint"]["heatmap-intensity"] as double?
           : null,
-      heatmapOpacity: map["paint"]["heatmap-opacity"] is double
-          ? map["paint"]["heatmap-opacity"] as double
+      heatmapOpacity: map["paint"]["heatmap-opacity"] is double?
+          ? map["paint"]["heatmap-opacity"] as double?
           : null,
-      heatmapRadius: map["paint"]["heatmap-radius"] is double
-          ? map["paint"]["heatmap-radius"] as double
+      heatmapRadius: map["paint"]["heatmap-radius"] is double?
+          ? map["paint"]["heatmap-radius"] as double?
           : null,
-      heatmapWeight: map["paint"]["heatmap-weight"] is double
-          ? map["paint"]["heatmap-weight"] as double
+      heatmapWeight: map["paint"]["heatmap-weight"] is double?
+          ? map["paint"]["heatmap-weight"] as double?
           : null,
     );
   }

--- a/lib/src/style/layer/hillshade_layer.dart
+++ b/lib/src/style/layer/hillshade_layer.dart
@@ -118,8 +118,8 @@ class HillshadeLayer extends Layer {
               .contains(map["layout"]["visibility"])),
       hillshadeAccentColor:
           (map["paint"]["hillshade-accent-color"] as List?)?.toRGBAInt(),
-      hillshadeExaggeration: map["paint"]["hillshade-exaggeration"] is double
-          ? map["paint"]["hillshade-exaggeration"] as double
+      hillshadeExaggeration: map["paint"]["hillshade-exaggeration"] is double?
+          ? map["paint"]["hillshade-exaggeration"] as double?
           : null,
       hillshadeHighlightColor:
           (map["paint"]["hillshade-highlight-color"] as List?)?.toRGBAInt(),
@@ -133,8 +133,8 @@ class HillshadeLayer extends Layer {
                   .toLowerCase()
                   .contains(map["paint"]["hillshade-illumination-anchor"])),
       hillshadeIlluminationDirection:
-          map["paint"]["hillshade-illumination-direction"] is double
-              ? map["paint"]["hillshade-illumination-direction"] as double
+          map["paint"]["hillshade-illumination-direction"] is double?
+              ? map["paint"]["hillshade-illumination-direction"] as double?
               : null,
       hillshadeShadowColor:
           (map["paint"]["hillshade-shadow-color"] as List?)?.toRGBAInt(),

--- a/lib/src/style/layer/hillshade_layer.dart
+++ b/lib/src/style/layer/hillshade_layer.dart
@@ -118,7 +118,9 @@ class HillshadeLayer extends Layer {
               .contains(map["layout"]["visibility"])),
       hillshadeAccentColor:
           (map["paint"]["hillshade-accent-color"] as List?)?.toRGBAInt(),
-      hillshadeExaggeration: map["paint"]["hillshade-exaggeration"]?.toDouble(),
+      hillshadeExaggeration: map["paint"]["hillshade-exaggeration"] is double
+          ? map["paint"]["hillshade-exaggeration"] as double
+          : null,
       hillshadeHighlightColor:
           (map["paint"]["hillshade-highlight-color"] as List?)?.toRGBAInt(),
       hillshadeIlluminationAnchor:
@@ -131,7 +133,9 @@ class HillshadeLayer extends Layer {
                   .toLowerCase()
                   .contains(map["paint"]["hillshade-illumination-anchor"])),
       hillshadeIlluminationDirection:
-          map["paint"]["hillshade-illumination-direction"]?.toDouble(),
+          map["paint"]["hillshade-illumination-direction"] is double
+              ? map["paint"]["hillshade-illumination-direction"] as double
+              : null,
       hillshadeShadowColor:
           (map["paint"]["hillshade-shadow-color"] as List?)?.toRGBAInt(),
     );

--- a/lib/src/style/layer/line_layer.dart
+++ b/lib/src/style/layer/line_layer.dart
@@ -208,13 +208,13 @@ class LineLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["layout"]["line-join"])),
-      lineMiterLimit: map["paint"]["line-miter-limit"] is double
+      lineMiterLimit: map["layout"]["line-miter-limit"] is double
           ? map["paint"]["line-miter-limit"] as double
           : null,
-      lineRoundLimit: map["paint"]["line-round-limit"] is double
+      lineRoundLimit: map["layout"]["line-round-limit"] is double
           ? map["paint"]["line-round-limit"] as double
           : null,
-      lineSortKey: map["paint"]["line-sort-key"] is double
+      lineSortKey: map["layout"]["line-sort-key"] is double
           ? map["paint"]["line-sort-key"] as double
           : null,
       lineBlur: map["paint"]["line-blur"] is double

--- a/lib/src/style/layer/line_layer.dart
+++ b/lib/src/style/layer/line_layer.dart
@@ -208,18 +208,32 @@ class LineLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["layout"]["line-join"])),
-      lineMiterLimit: map["layout"]["line-miter-limit"]?.toDouble(),
-      lineRoundLimit: map["layout"]["line-round-limit"]?.toDouble(),
-      lineSortKey: map["layout"]["line-sort-key"]?.toDouble(),
-      lineBlur: map["paint"]["line-blur"]?.toDouble(),
+      lineMiterLimit: map["paint"]["line-miter-limit"] is double
+          ? map["paint"]["line-miter-limit"] as double
+          : null,
+      lineRoundLimit: map["paint"]["line-round-limit"] is double
+          ? map["paint"]["line-round-limit"] as double
+          : null,
+      lineSortKey: map["paint"]["line-sort-key"] is double
+          ? map["paint"]["line-sort-key"] as double
+          : null,
+      lineBlur: map["paint"]["line-blur"] is double
+          ? map["paint"]["line-blur"] as double
+          : null,
       lineColor: (map["paint"]["line-color"] as List?)?.toRGBAInt(),
       lineDasharray: (map["paint"]["line-dasharray"] as List?)
           ?.map<double?>((e) => e.toDouble())
           .toList(),
-      lineGapWidth: map["paint"]["line-gap-width"]?.toDouble(),
+      lineGapWidth: map["paint"]["line-gap-width"] is double
+          ? map["paint"]["line-gap-width"] as double
+          : null,
       lineGradient: (map["paint"]["line-gradient"] as List?)?.toRGBAInt(),
-      lineOffset: map["paint"]["line-offset"]?.toDouble(),
-      lineOpacity: map["paint"]["line-opacity"]?.toDouble(),
+      lineOffset: map["paint"]["line-offset"] is double
+          ? map["paint"]["line-offset"] as double
+          : null,
+      lineOpacity: map["paint"]["line-opacity"] is double
+          ? map["paint"]["line-opacity"] as double
+          : null,
       linePattern: map["paint"]["line-pattern"],
       lineTranslate: (map["paint"]["line-translate"] as List?)
           ?.map<double?>((e) => e.toDouble())
@@ -235,7 +249,9 @@ class LineLayer extends Layer {
       lineTrimOffset: (map["paint"]["line-trim-offset"] as List?)
           ?.map<double?>((e) => e.toDouble())
           .toList(),
-      lineWidth: map["paint"]["line-width"]?.toDouble(),
+      lineWidth: map["paint"]["line-width"] is double
+          ? map["paint"]["line-width"] as double
+          : null,
     );
   }
 }

--- a/lib/src/style/layer/line_layer.dart
+++ b/lib/src/style/layer/line_layer.dart
@@ -208,31 +208,31 @@ class LineLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["layout"]["line-join"])),
-      lineMiterLimit: map["layout"]["line-miter-limit"] is double
-          ? map["paint"]["line-miter-limit"] as double
+      lineMiterLimit: map["layout"]["line-miter-limit"] is double?
+          ? map["paint"]["line-miter-limit"] as double?
           : null,
-      lineRoundLimit: map["layout"]["line-round-limit"] is double
-          ? map["paint"]["line-round-limit"] as double
+      lineRoundLimit: map["layout"]["line-round-limit"] is double?
+          ? map["paint"]["line-round-limit"] as double?
           : null,
-      lineSortKey: map["layout"]["line-sort-key"] is double
-          ? map["paint"]["line-sort-key"] as double
+      lineSortKey: map["layout"]["line-sort-key"] is double?
+          ? map["paint"]["line-sort-key"] as double?
           : null,
-      lineBlur: map["paint"]["line-blur"] is double
-          ? map["paint"]["line-blur"] as double
+      lineBlur: map["paint"]["line-blur"] is double?
+          ? map["paint"]["line-blur"] as double?
           : null,
       lineColor: (map["paint"]["line-color"] as List?)?.toRGBAInt(),
       lineDasharray: (map["paint"]["line-dasharray"] as List?)
           ?.map<double?>((e) => e.toDouble())
           .toList(),
-      lineGapWidth: map["paint"]["line-gap-width"] is double
-          ? map["paint"]["line-gap-width"] as double
+      lineGapWidth: map["paint"]["line-gap-width"] is double?
+          ? map["paint"]["line-gap-width"] as double?
           : null,
       lineGradient: (map["paint"]["line-gradient"] as List?)?.toRGBAInt(),
-      lineOffset: map["paint"]["line-offset"] is double
-          ? map["paint"]["line-offset"] as double
+      lineOffset: map["paint"]["line-offset"] is double?
+          ? map["paint"]["line-offset"] as double?
           : null,
-      lineOpacity: map["paint"]["line-opacity"] is double
-          ? map["paint"]["line-opacity"] as double
+      lineOpacity: map["paint"]["line-opacity"] is double?
+          ? map["paint"]["line-opacity"] as double?
           : null,
       linePattern: map["paint"]["line-pattern"],
       lineTranslate: (map["paint"]["line-translate"] as List?)
@@ -249,8 +249,8 @@ class LineLayer extends Layer {
       lineTrimOffset: (map["paint"]["line-trim-offset"] as List?)
           ?.map<double?>((e) => e.toDouble())
           .toList(),
-      lineWidth: map["paint"]["line-width"] is double
-          ? map["paint"]["line-width"] as double
+      lineWidth: map["paint"]["line-width"] is double?
+          ? map["paint"]["line-width"] as double?
           : null,
     );
   }

--- a/lib/src/style/layer/location_indicator_layer.dart
+++ b/lib/src/style/layer/location_indicator_layer.dart
@@ -167,25 +167,40 @@ class LocationIndicatorLayer extends Layer {
       bearingImage: map["layout"]["bearing-image"],
       shadowImage: map["layout"]["shadow-image"],
       topImage: map["layout"]["top-image"],
-      accuracyRadius: map["paint"]["accuracy-radius"]?.toDouble(),
+      accuracyRadius: map["paint"]["accuracy-radius"] is double
+          ? map["paint"]["accuracy-radius"] as double
+          : null,
       accuracyRadiusBorderColor:
           (map["paint"]["accuracy-radius-border-color"] as List?)?.toRGBAInt(),
       accuracyRadiusColor:
           (map["paint"]["accuracy-radius-color"] as List?)?.toRGBAInt(),
-      bearing: map["paint"]["bearing"]?.toDouble(),
-      bearingImageSize: map["paint"]["bearing-image-size"]?.toDouble(),
+      bearing: map["paint"]["bearing"] is double
+          ? map["paint"]["bearing"] as double
+          : null,
+      bearingImageSize: map["paint"]["bearing-image-size"] is double
+          ? map["paint"]["bearing-image-size"] as double
+          : null,
       emphasisCircleColor:
           (map["paint"]["emphasis-circle-color"] as List?)?.toRGBAInt(),
-      emphasisCircleRadius: map["paint"]["emphasis-circle-radius"]?.toDouble(),
-      imagePitchDisplacement:
-          map["paint"]["image-pitch-displacement"]?.toDouble(),
+      emphasisCircleRadius: map["paint"]["emphasis-circle-radius"] is double
+          ? map["paint"]["emphasis-circle-radius"] as double
+          : null,
+      imagePitchDisplacement: map["paint"]["image-pitch-displacement"] is double
+          ? map["paint"]["image-pitch-displacement"] as double
+          : null,
       location: (map["paint"]["location"] as List?)
           ?.map<double?>((e) => e.toDouble())
           .toList(),
       perspectiveCompensation:
-          map["paint"]["perspective-compensation"]?.toDouble(),
-      shadowImageSize: map["paint"]["shadow-image-size"]?.toDouble(),
-      topImageSize: map["paint"]["top-image-size"]?.toDouble(),
+          map["paint"]["perspective-compensation"] is double
+              ? map["paint"]["perspective-compensation"] as double
+              : null,
+      shadowImageSize: map["paint"]["shadow-image-size"] is double
+          ? map["paint"]["shadow-image-size"] as double
+          : null,
+      topImageSize: map["paint"]["top-image-size"] is double
+          ? map["paint"]["top-image-size"] as double
+          : null,
     );
   }
 }

--- a/lib/src/style/layer/location_indicator_layer.dart
+++ b/lib/src/style/layer/location_indicator_layer.dart
@@ -167,39 +167,40 @@ class LocationIndicatorLayer extends Layer {
       bearingImage: map["layout"]["bearing-image"],
       shadowImage: map["layout"]["shadow-image"],
       topImage: map["layout"]["top-image"],
-      accuracyRadius: map["paint"]["accuracy-radius"] is double
-          ? map["paint"]["accuracy-radius"] as double
+      accuracyRadius: map["paint"]["accuracy-radius"] is double?
+          ? map["paint"]["accuracy-radius"] as double?
           : null,
       accuracyRadiusBorderColor:
           (map["paint"]["accuracy-radius-border-color"] as List?)?.toRGBAInt(),
       accuracyRadiusColor:
           (map["paint"]["accuracy-radius-color"] as List?)?.toRGBAInt(),
-      bearing: map["paint"]["bearing"] is double
-          ? map["paint"]["bearing"] as double
+      bearing: map["paint"]["bearing"] is double?
+          ? map["paint"]["bearing"] as double?
           : null,
-      bearingImageSize: map["paint"]["bearing-image-size"] is double
-          ? map["paint"]["bearing-image-size"] as double
+      bearingImageSize: map["paint"]["bearing-image-size"] is double?
+          ? map["paint"]["bearing-image-size"] as double?
           : null,
       emphasisCircleColor:
           (map["paint"]["emphasis-circle-color"] as List?)?.toRGBAInt(),
-      emphasisCircleRadius: map["paint"]["emphasis-circle-radius"] is double
-          ? map["paint"]["emphasis-circle-radius"] as double
+      emphasisCircleRadius: map["paint"]["emphasis-circle-radius"] is double?
+          ? map["paint"]["emphasis-circle-radius"] as double?
           : null,
-      imagePitchDisplacement: map["paint"]["image-pitch-displacement"] is double
-          ? map["paint"]["image-pitch-displacement"] as double
-          : null,
+      imagePitchDisplacement:
+          map["paint"]["image-pitch-displacement"] is double?
+              ? map["paint"]["image-pitch-displacement"] as double?
+              : null,
       location: (map["paint"]["location"] as List?)
           ?.map<double?>((e) => e.toDouble())
           .toList(),
       perspectiveCompensation:
-          map["paint"]["perspective-compensation"] is double
-              ? map["paint"]["perspective-compensation"] as double
+          map["paint"]["perspective-compensation"] is double?
+              ? map["paint"]["perspective-compensation"] as double?
               : null,
-      shadowImageSize: map["paint"]["shadow-image-size"] is double
-          ? map["paint"]["shadow-image-size"] as double
+      shadowImageSize: map["paint"]["shadow-image-size"] is double?
+          ? map["paint"]["shadow-image-size"] as double?
           : null,
-      topImageSize: map["paint"]["top-image-size"] is double
-          ? map["paint"]["top-image-size"] as double
+      topImageSize: map["paint"]["top-image-size"] is double?
+          ? map["paint"]["top-image-size"] as double?
           : null,
     );
   }

--- a/lib/src/style/layer/raster_layer.dart
+++ b/lib/src/style/layer/raster_layer.dart
@@ -129,12 +129,24 @@ class RasterLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["layout"]["visibility"])),
-      rasterBrightnessMax: map["paint"]["raster-brightness-max"]?.toDouble(),
-      rasterBrightnessMin: map["paint"]["raster-brightness-min"]?.toDouble(),
-      rasterContrast: map["paint"]["raster-contrast"]?.toDouble(),
-      rasterFadeDuration: map["paint"]["raster-fade-duration"]?.toDouble(),
-      rasterHueRotate: map["paint"]["raster-hue-rotate"]?.toDouble(),
-      rasterOpacity: map["paint"]["raster-opacity"]?.toDouble(),
+      rasterBrightnessMax: map["paint"]["raster-brightness-max"] is double
+          ? map["paint"]["raster-brightness-max"] as double
+          : null,
+      rasterBrightnessMin: map["paint"]["raster-brightness-min"] is double
+          ? map["paint"]["raster-brightness-min"] as double
+          : null,
+      rasterContrast: map["paint"]["raster-contrast"] is double
+          ? map["paint"]["raster-contrast"] as double
+          : null,
+      rasterFadeDuration: map["paint"]["raster-fade-duration"] is double
+          ? map["paint"]["raster-fade-duration"] as double
+          : null,
+      rasterHueRotate: map["paint"]["raster-hue-rotate"] is double
+          ? map["paint"]["raster-hue-rotate"] as double
+          : null,
+      rasterOpacity: map["paint"]["raster-opacity"] is double
+          ? map["paint"]["raster-opacity"] as double
+          : null,
       rasterResampling: map["paint"]["raster-resampling"] == null
           ? null
           : RasterResampling.values.firstWhere((e) => e
@@ -143,7 +155,9 @@ class RasterLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["paint"]["raster-resampling"])),
-      rasterSaturation: map["paint"]["raster-saturation"]?.toDouble(),
+      rasterSaturation: map["paint"]["raster-saturation"] is double
+          ? map["paint"]["raster-saturation"] as double
+          : null,
     );
   }
 }

--- a/lib/src/style/layer/raster_layer.dart
+++ b/lib/src/style/layer/raster_layer.dart
@@ -129,23 +129,23 @@ class RasterLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["layout"]["visibility"])),
-      rasterBrightnessMax: map["paint"]["raster-brightness-max"] is double
-          ? map["paint"]["raster-brightness-max"] as double
+      rasterBrightnessMax: map["paint"]["raster-brightness-max"] is double?
+          ? map["paint"]["raster-brightness-max"] as double?
           : null,
-      rasterBrightnessMin: map["paint"]["raster-brightness-min"] is double
-          ? map["paint"]["raster-brightness-min"] as double
+      rasterBrightnessMin: map["paint"]["raster-brightness-min"] is double?
+          ? map["paint"]["raster-brightness-min"] as double?
           : null,
-      rasterContrast: map["paint"]["raster-contrast"] is double
-          ? map["paint"]["raster-contrast"] as double
+      rasterContrast: map["paint"]["raster-contrast"] is double?
+          ? map["paint"]["raster-contrast"] as double?
           : null,
-      rasterFadeDuration: map["paint"]["raster-fade-duration"] is double
-          ? map["paint"]["raster-fade-duration"] as double
+      rasterFadeDuration: map["paint"]["raster-fade-duration"] is double?
+          ? map["paint"]["raster-fade-duration"] as double?
           : null,
-      rasterHueRotate: map["paint"]["raster-hue-rotate"] is double
-          ? map["paint"]["raster-hue-rotate"] as double
+      rasterHueRotate: map["paint"]["raster-hue-rotate"] is double?
+          ? map["paint"]["raster-hue-rotate"] as double?
           : null,
-      rasterOpacity: map["paint"]["raster-opacity"] is double
-          ? map["paint"]["raster-opacity"] as double
+      rasterOpacity: map["paint"]["raster-opacity"] is double?
+          ? map["paint"]["raster-opacity"] as double?
           : null,
       rasterResampling: map["paint"]["raster-resampling"] == null
           ? null
@@ -155,8 +155,8 @@ class RasterLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["paint"]["raster-resampling"])),
-      rasterSaturation: map["paint"]["raster-saturation"] is double
-          ? map["paint"]["raster-saturation"] as double
+      rasterSaturation: map["paint"]["raster-saturation"] is double?
+          ? map["paint"]["raster-saturation"] as double?
           : null,
     );
   }

--- a/lib/src/style/layer/sky_layer.dart
+++ b/lib/src/style/layer/sky_layer.dart
@@ -129,13 +129,19 @@ class SkyLayer extends Layer {
           ?.map<double?>((e) => e.toDouble())
           .toList(),
       skyAtmosphereSunIntensity:
-          map["paint"]["sky-atmosphere-sun-intensity"]?.toDouble(),
+          map["paint"]["sky-atmosphere-sun-intensity"] is double
+              ? map["paint"]["sky-atmosphere-sun-intensity"] as double
+              : null,
       skyGradient: (map["paint"]["sky-gradient"] as List?)?.toRGBAInt(),
       skyGradientCenter: (map["paint"]["sky-gradient-center"] as List?)
           ?.map<double?>((e) => e.toDouble())
           .toList(),
-      skyGradientRadius: map["paint"]["sky-gradient-radius"]?.toDouble(),
-      skyOpacity: map["paint"]["sky-opacity"]?.toDouble(),
+      skyGradientRadius: map["paint"]["sky-gradient-radius"] is double
+          ? map["paint"]["sky-gradient-radius"] as double
+          : null,
+      skyOpacity: map["paint"]["sky-opacity"] is double
+          ? map["paint"]["sky-opacity"] as double
+          : null,
       skyType: map["paint"]["sky-type"] == null
           ? null
           : SkyType.values.firstWhere((e) => e

--- a/lib/src/style/layer/sky_layer.dart
+++ b/lib/src/style/layer/sky_layer.dart
@@ -129,18 +129,18 @@ class SkyLayer extends Layer {
           ?.map<double?>((e) => e.toDouble())
           .toList(),
       skyAtmosphereSunIntensity:
-          map["paint"]["sky-atmosphere-sun-intensity"] is double
-              ? map["paint"]["sky-atmosphere-sun-intensity"] as double
+          map["paint"]["sky-atmosphere-sun-intensity"] is double?
+              ? map["paint"]["sky-atmosphere-sun-intensity"] as double?
               : null,
       skyGradient: (map["paint"]["sky-gradient"] as List?)?.toRGBAInt(),
       skyGradientCenter: (map["paint"]["sky-gradient-center"] as List?)
           ?.map<double?>((e) => e.toDouble())
           .toList(),
-      skyGradientRadius: map["paint"]["sky-gradient-radius"] is double
-          ? map["paint"]["sky-gradient-radius"] as double
+      skyGradientRadius: map["paint"]["sky-gradient-radius"] is double?
+          ? map["paint"]["sky-gradient-radius"] as double?
           : null,
-      skyOpacity: map["paint"]["sky-opacity"] is double
-          ? map["paint"]["sky-opacity"] as double
+      skyOpacity: map["paint"]["sky-opacity"] is double?
+          ? map["paint"]["sky-opacity"] as double?
           : null,
       skyType: map["paint"]["sky-type"] == null
           ? null

--- a/lib/src/style/layer/symbol_layer.dart
+++ b/lib/src/style/layer/symbol_layer.dart
@@ -479,8 +479,8 @@ class SymbolLayer extends Layer {
           ?.map<double?>((e) => e.toDouble())
           .toList(),
       iconOptional: map["layout"]["icon-optional"],
-      iconPadding: map["layout"]["icon-padding"] is double
-          ? map["paint"]["icon-padding"] as double
+      iconPadding: map["layout"]["icon-padding"] is double?
+          ? map["paint"]["icon-padding"] as double?
           : null,
       iconPitchAlignment: map["layout"]["icon-pitch-alignment"] == null
           ? null
@@ -490,8 +490,8 @@ class SymbolLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["layout"]["icon-pitch-alignment"])),
-      iconRotate: map["layout"]["icon-rotate"] is double
-          ? map["paint"]["icon-rotate"] as double
+      iconRotate: map["layout"]["icon-rotate"] is double?
+          ? map["paint"]["icon-rotate"] as double?
           : null,
       iconRotationAlignment: map["layout"]["icon-rotation-alignment"] == null
           ? null
@@ -501,8 +501,8 @@ class SymbolLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["layout"]["icon-rotation-alignment"])),
-      iconSize: map["layout"]["icon-size"] is double
-          ? map["paint"]["icon-size"] as double
+      iconSize: map["layout"]["icon-size"] is double?
+          ? map["paint"]["icon-size"] as double?
           : null,
       iconTextFit: map["layout"]["icon-text-fit"] == null
           ? null
@@ -524,11 +524,11 @@ class SymbolLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["layout"]["symbol-placement"])),
-      symbolSortKey: map["layout"]["symbol-sort-key"] is double
-          ? map["paint"]["symbol-sort-key"] as double
+      symbolSortKey: map["layout"]["symbol-sort-key"] is double?
+          ? map["paint"]["symbol-sort-key"] as double?
           : null,
-      symbolSpacing: map["layout"]["symbol-spacing"] is double
-          ? map["paint"]["symbol-spacing"] as double
+      symbolSpacing: map["layout"]["symbol-spacing"] is double?
+          ? map["paint"]["symbol-spacing"] as double?
           : null,
       symbolZOrder: map["layout"]["symbol-z-order"] == null
           ? null
@@ -560,24 +560,24 @@ class SymbolLayer extends Layer {
               .toLowerCase()
               .contains(map["layout"]["text-justify"])),
       textKeepUpright: map["layout"]["text-keep-upright"],
-      textLetterSpacing: map["layout"]["text-letter-spacing"] is double
-          ? map["paint"]["text-letter-spacing"] as double
+      textLetterSpacing: map["layout"]["text-letter-spacing"] is double?
+          ? map["paint"]["text-letter-spacing"] as double?
           : null,
-      textLineHeight: map["layout"]["text-line-height"] is double
-          ? map["paint"]["text-line-height"] as double
+      textLineHeight: map["layout"]["text-line-height"] is double?
+          ? map["paint"]["text-line-height"] as double?
           : null,
-      textMaxAngle: map["layout"]["text-max-angle"] is double
-          ? map["paint"]["text-max-angle"] as double
+      textMaxAngle: map["layout"]["text-max-angle"] is double?
+          ? map["paint"]["text-max-angle"] as double?
           : null,
-      textMaxWidth: map["layout"]["text-max-width"] is double
-          ? map["paint"]["text-max-width"] as double
+      textMaxWidth: map["layout"]["text-max-width"] is double?
+          ? map["paint"]["text-max-width"] as double?
           : null,
       textOffset: (map["layout"]["text-offset"] as List?)
           ?.map<double?>((e) => e.toDouble())
           .toList(),
       textOptional: map["layout"]["text-optional"],
-      textPadding: map["layout"]["text-padding"] is double
-          ? map["paint"]["text-padding"] as double
+      textPadding: map["layout"]["text-padding"] is double?
+          ? map["paint"]["text-padding"] as double?
           : null,
       textPitchAlignment: map["layout"]["text-pitch-alignment"] == null
           ? null
@@ -587,11 +587,11 @@ class SymbolLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["layout"]["text-pitch-alignment"])),
-      textRadialOffset: map["layout"]["text-radial-offset"] is double
-          ? map["paint"]["text-radial-offset"] as double
+      textRadialOffset: map["layout"]["text-radial-offset"] is double?
+          ? map["paint"]["text-radial-offset"] as double?
           : null,
-      textRotate: map["layout"]["text-rotate"] is double
-          ? map["paint"]["text-rotate"] as double
+      textRotate: map["layout"]["text-rotate"] is double?
+          ? map["paint"]["text-rotate"] as double?
           : null,
       textRotationAlignment: map["layout"]["text-rotation-alignment"] == null
           ? null
@@ -601,8 +601,8 @@ class SymbolLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["layout"]["text-rotation-alignment"])),
-      textSize: map["layout"]["text-size"] is double
-          ? map["paint"]["text-size"] as double
+      textSize: map["layout"]["text-size"] is double?
+          ? map["paint"]["text-size"] as double?
           : null,
       textTransform: map["layout"]["text-transform"] == null
           ? null
@@ -619,15 +619,15 @@ class SymbolLayer extends Layer {
           ?.map<String?>((e) => e.toString())
           .toList(),
       iconColor: (map["paint"]["icon-color"] as List?)?.toRGBAInt(),
-      iconHaloBlur: map["paint"]["icon-halo-blur"] is double
-          ? map["paint"]["icon-halo-blur"] as double
+      iconHaloBlur: map["paint"]["icon-halo-blur"] is double?
+          ? map["paint"]["icon-halo-blur"] as double?
           : null,
       iconHaloColor: (map["paint"]["icon-halo-color"] as List?)?.toRGBAInt(),
-      iconHaloWidth: map["paint"]["icon-halo-width"] is double
-          ? map["paint"]["icon-halo-width"] as double
+      iconHaloWidth: map["paint"]["icon-halo-width"] is double?
+          ? map["paint"]["icon-halo-width"] as double?
           : null,
-      iconOpacity: map["paint"]["icon-opacity"] is double
-          ? map["paint"]["icon-opacity"] as double
+      iconOpacity: map["paint"]["icon-opacity"] is double?
+          ? map["paint"]["icon-opacity"] as double?
           : null,
       iconTranslate: (map["paint"]["icon-translate"] as List?)
           ?.map<double?>((e) => e.toDouble())
@@ -641,15 +641,15 @@ class SymbolLayer extends Layer {
               .toLowerCase()
               .contains(map["paint"]["icon-translate-anchor"])),
       textColor: (map["paint"]["text-color"] as List?)?.toRGBAInt(),
-      textHaloBlur: map["paint"]["text-halo-blur"] is double
-          ? map["paint"]["text-halo-blur"] as double
+      textHaloBlur: map["paint"]["text-halo-blur"] is double?
+          ? map["paint"]["text-halo-blur"] as double?
           : null,
       textHaloColor: (map["paint"]["text-halo-color"] as List?)?.toRGBAInt(),
-      textHaloWidth: map["paint"]["text-halo-width"] is double
-          ? map["paint"]["text-halo-width"] as double
+      textHaloWidth: map["paint"]["text-halo-width"] is double?
+          ? map["paint"]["text-halo-width"] as double?
           : null,
-      textOpacity: map["paint"]["text-opacity"] is double
-          ? map["paint"]["text-opacity"] as double
+      textOpacity: map["paint"]["text-opacity"] is double?
+          ? map["paint"]["text-opacity"] as double?
           : null,
       textTranslate: (map["paint"]["text-translate"] as List?)
           ?.map<double?>((e) => e.toDouble())

--- a/lib/src/style/layer/symbol_layer.dart
+++ b/lib/src/style/layer/symbol_layer.dart
@@ -479,7 +479,9 @@ class SymbolLayer extends Layer {
           ?.map<double?>((e) => e.toDouble())
           .toList(),
       iconOptional: map["layout"]["icon-optional"],
-      iconPadding: map["layout"]["icon-padding"]?.toDouble(),
+      iconPadding: map["paint"]["icon-padding"] is double
+          ? map["paint"]["icon-padding"] as double
+          : null,
       iconPitchAlignment: map["layout"]["icon-pitch-alignment"] == null
           ? null
           : IconPitchAlignment.values.firstWhere((e) => e
@@ -488,7 +490,9 @@ class SymbolLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["layout"]["icon-pitch-alignment"])),
-      iconRotate: map["layout"]["icon-rotate"]?.toDouble(),
+      iconRotate: map["paint"]["icon-rotate"] is double
+          ? map["paint"]["icon-rotate"] as double
+          : null,
       iconRotationAlignment: map["layout"]["icon-rotation-alignment"] == null
           ? null
           : IconRotationAlignment.values.firstWhere((e) => e
@@ -497,7 +501,9 @@ class SymbolLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["layout"]["icon-rotation-alignment"])),
-      iconSize: map["layout"]["icon-size"]?.toDouble(),
+      iconSize: map["paint"]["icon-size"] is double
+          ? map["paint"]["icon-size"] as double
+          : null,
       iconTextFit: map["layout"]["icon-text-fit"] == null
           ? null
           : IconTextFit.values.firstWhere((e) => e
@@ -518,8 +524,12 @@ class SymbolLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["layout"]["symbol-placement"])),
-      symbolSortKey: map["layout"]["symbol-sort-key"]?.toDouble(),
-      symbolSpacing: map["layout"]["symbol-spacing"]?.toDouble(),
+      symbolSortKey: map["paint"]["symbol-sort-key"] is double
+          ? map["paint"]["symbol-sort-key"] as double
+          : null,
+      symbolSpacing: map["paint"]["symbol-spacing"] is double
+          ? map["paint"]["symbol-spacing"] as double
+          : null,
       symbolZOrder: map["layout"]["symbol-z-order"] == null
           ? null
           : SymbolZOrder.values.firstWhere((e) => e
@@ -550,15 +560,25 @@ class SymbolLayer extends Layer {
               .toLowerCase()
               .contains(map["layout"]["text-justify"])),
       textKeepUpright: map["layout"]["text-keep-upright"],
-      textLetterSpacing: map["layout"]["text-letter-spacing"]?.toDouble(),
-      textLineHeight: map["layout"]["text-line-height"]?.toDouble(),
-      textMaxAngle: map["layout"]["text-max-angle"]?.toDouble(),
-      textMaxWidth: map["layout"]["text-max-width"]?.toDouble(),
+      textLetterSpacing: map["paint"]["text-letter-spacing"] is double
+          ? map["paint"]["text-letter-spacing"] as double
+          : null,
+      textLineHeight: map["paint"]["text-line-height"] is double
+          ? map["paint"]["text-line-height"] as double
+          : null,
+      textMaxAngle: map["paint"]["text-max-angle"] is double
+          ? map["paint"]["text-max-angle"] as double
+          : null,
+      textMaxWidth: map["paint"]["text-max-width"] is double
+          ? map["paint"]["text-max-width"] as double
+          : null,
       textOffset: (map["layout"]["text-offset"] as List?)
           ?.map<double?>((e) => e.toDouble())
           .toList(),
       textOptional: map["layout"]["text-optional"],
-      textPadding: map["layout"]["text-padding"]?.toDouble(),
+      textPadding: map["paint"]["text-padding"] is double
+          ? map["paint"]["text-padding"] as double
+          : null,
       textPitchAlignment: map["layout"]["text-pitch-alignment"] == null
           ? null
           : TextPitchAlignment.values.firstWhere((e) => e
@@ -567,8 +587,12 @@ class SymbolLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["layout"]["text-pitch-alignment"])),
-      textRadialOffset: map["layout"]["text-radial-offset"]?.toDouble(),
-      textRotate: map["layout"]["text-rotate"]?.toDouble(),
+      textRadialOffset: map["paint"]["text-radial-offset"] is double
+          ? map["paint"]["text-radial-offset"] as double
+          : null,
+      textRotate: map["paint"]["text-rotate"] is double
+          ? map["paint"]["text-rotate"] as double
+          : null,
       textRotationAlignment: map["layout"]["text-rotation-alignment"] == null
           ? null
           : TextRotationAlignment.values.firstWhere((e) => e
@@ -577,7 +601,9 @@ class SymbolLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["layout"]["text-rotation-alignment"])),
-      textSize: map["layout"]["text-size"]?.toDouble(),
+      textSize: map["paint"]["text-size"] is double
+          ? map["paint"]["text-size"] as double
+          : null,
       textTransform: map["layout"]["text-transform"] == null
           ? null
           : TextTransform.values.firstWhere((e) => e
@@ -593,10 +619,16 @@ class SymbolLayer extends Layer {
           ?.map<String?>((e) => e.toString())
           .toList(),
       iconColor: (map["paint"]["icon-color"] as List?)?.toRGBAInt(),
-      iconHaloBlur: map["paint"]["icon-halo-blur"]?.toDouble(),
+      iconHaloBlur: map["paint"]["icon-halo-blur"] is double
+          ? map["paint"]["icon-halo-blur"] as double
+          : null,
       iconHaloColor: (map["paint"]["icon-halo-color"] as List?)?.toRGBAInt(),
-      iconHaloWidth: map["paint"]["icon-halo-width"]?.toDouble(),
-      iconOpacity: map["paint"]["icon-opacity"]?.toDouble(),
+      iconHaloWidth: map["paint"]["icon-halo-width"] is double
+          ? map["paint"]["icon-halo-width"] as double
+          : null,
+      iconOpacity: map["paint"]["icon-opacity"] is double
+          ? map["paint"]["icon-opacity"] as double
+          : null,
       iconTranslate: (map["paint"]["icon-translate"] as List?)
           ?.map<double?>((e) => e.toDouble())
           .toList(),
@@ -609,10 +641,16 @@ class SymbolLayer extends Layer {
               .toLowerCase()
               .contains(map["paint"]["icon-translate-anchor"])),
       textColor: (map["paint"]["text-color"] as List?)?.toRGBAInt(),
-      textHaloBlur: map["paint"]["text-halo-blur"]?.toDouble(),
+      textHaloBlur: map["paint"]["text-halo-blur"] is double
+          ? map["paint"]["text-halo-blur"] as double
+          : null,
       textHaloColor: (map["paint"]["text-halo-color"] as List?)?.toRGBAInt(),
-      textHaloWidth: map["paint"]["text-halo-width"]?.toDouble(),
-      textOpacity: map["paint"]["text-opacity"]?.toDouble(),
+      textHaloWidth: map["paint"]["text-halo-width"] is double
+          ? map["paint"]["text-halo-width"] as double
+          : null,
+      textOpacity: map["paint"]["text-opacity"] is double
+          ? map["paint"]["text-opacity"] as double
+          : null,
       textTranslate: (map["paint"]["text-translate"] as List?)
           ?.map<double?>((e) => e.toDouble())
           .toList(),

--- a/lib/src/style/layer/symbol_layer.dart
+++ b/lib/src/style/layer/symbol_layer.dart
@@ -479,7 +479,7 @@ class SymbolLayer extends Layer {
           ?.map<double?>((e) => e.toDouble())
           .toList(),
       iconOptional: map["layout"]["icon-optional"],
-      iconPadding: map["paint"]["icon-padding"] is double
+      iconPadding: map["layout"]["icon-padding"] is double
           ? map["paint"]["icon-padding"] as double
           : null,
       iconPitchAlignment: map["layout"]["icon-pitch-alignment"] == null
@@ -490,7 +490,7 @@ class SymbolLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["layout"]["icon-pitch-alignment"])),
-      iconRotate: map["paint"]["icon-rotate"] is double
+      iconRotate: map["layout"]["icon-rotate"] is double
           ? map["paint"]["icon-rotate"] as double
           : null,
       iconRotationAlignment: map["layout"]["icon-rotation-alignment"] == null
@@ -501,7 +501,7 @@ class SymbolLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["layout"]["icon-rotation-alignment"])),
-      iconSize: map["paint"]["icon-size"] is double
+      iconSize: map["layout"]["icon-size"] is double
           ? map["paint"]["icon-size"] as double
           : null,
       iconTextFit: map["layout"]["icon-text-fit"] == null
@@ -524,10 +524,10 @@ class SymbolLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["layout"]["symbol-placement"])),
-      symbolSortKey: map["paint"]["symbol-sort-key"] is double
+      symbolSortKey: map["layout"]["symbol-sort-key"] is double
           ? map["paint"]["symbol-sort-key"] as double
           : null,
-      symbolSpacing: map["paint"]["symbol-spacing"] is double
+      symbolSpacing: map["layout"]["symbol-spacing"] is double
           ? map["paint"]["symbol-spacing"] as double
           : null,
       symbolZOrder: map["layout"]["symbol-z-order"] == null
@@ -560,23 +560,23 @@ class SymbolLayer extends Layer {
               .toLowerCase()
               .contains(map["layout"]["text-justify"])),
       textKeepUpright: map["layout"]["text-keep-upright"],
-      textLetterSpacing: map["paint"]["text-letter-spacing"] is double
+      textLetterSpacing: map["layout"]["text-letter-spacing"] is double
           ? map["paint"]["text-letter-spacing"] as double
           : null,
-      textLineHeight: map["paint"]["text-line-height"] is double
+      textLineHeight: map["layout"]["text-line-height"] is double
           ? map["paint"]["text-line-height"] as double
           : null,
-      textMaxAngle: map["paint"]["text-max-angle"] is double
+      textMaxAngle: map["layout"]["text-max-angle"] is double
           ? map["paint"]["text-max-angle"] as double
           : null,
-      textMaxWidth: map["paint"]["text-max-width"] is double
+      textMaxWidth: map["layout"]["text-max-width"] is double
           ? map["paint"]["text-max-width"] as double
           : null,
       textOffset: (map["layout"]["text-offset"] as List?)
           ?.map<double?>((e) => e.toDouble())
           .toList(),
       textOptional: map["layout"]["text-optional"],
-      textPadding: map["paint"]["text-padding"] is double
+      textPadding: map["layout"]["text-padding"] is double
           ? map["paint"]["text-padding"] as double
           : null,
       textPitchAlignment: map["layout"]["text-pitch-alignment"] == null
@@ -587,10 +587,10 @@ class SymbolLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["layout"]["text-pitch-alignment"])),
-      textRadialOffset: map["paint"]["text-radial-offset"] is double
+      textRadialOffset: map["layout"]["text-radial-offset"] is double
           ? map["paint"]["text-radial-offset"] as double
           : null,
-      textRotate: map["paint"]["text-rotate"] is double
+      textRotate: map["layout"]["text-rotate"] is double
           ? map["paint"]["text-rotate"] as double
           : null,
       textRotationAlignment: map["layout"]["text-rotation-alignment"] == null
@@ -601,7 +601,7 @@ class SymbolLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["layout"]["text-rotation-alignment"])),
-      textSize: map["paint"]["text-size"] is double
+      textSize: map["layout"]["text-size"] is double
           ? map["paint"]["text-size"] as double
           : null,
       textTransform: map["layout"]["text-transform"] == null

--- a/lib/src/style/style.dart
+++ b/lib/src/style/style.dart
@@ -287,16 +287,17 @@ extension StyleColorInt on int {
   }
 }
 
-/// Extension to convert color format
 extension StyleColorList on List {
-  int _checkInt(num value) => value.toInt();
-
-  /// Convert the color from a list into int format.
+  /// Convert the color from a list `[rgba, $R, $G, $B, $A]` to int.
   int toRGBAInt() {
-    final alpha = _checkInt(this.last * 255);
-    final red = _checkInt(this[1]);
-    final green = _checkInt(this[2]);
-    final blue = _checkInt(this[3]);
-    return Color.fromARGB(alpha, red, green, blue).value;
+    final alpha = this.last is num ? ((this.last as num) * 255).toInt() : null;
+    final red = this[1] is num ? (this[1] as num).toInt() : null;
+    final green = this[2] is num ? (this[2] as num).toInt() : null;
+    final blue = this[3] is num ? (this[3] as num).toInt() : null;
+    if (alpha != null && red != null && green != null && blue != null) {
+      return Color.fromARGB(alpha, red, green, blue).value;
+    } else {
+      return 0;
+    }
   }
 }


### PR DESCRIPTION
Properties that are set to expressions will return nulls. 
To retrieve such properties lower level style apis can be used at the moment, e.g. : `map.style.getStyleLayerProperty(LAYER, PROPERTY);`

Fixes #14 / MAPSFLT-89, cc @LjubiTech-Maxko 