### PR TITLE
Fix camera.pixelsForCoordinates iOS implementation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 * Fix issue with multiple maps overriding platform channels of the previous instances.
 * Fix exception accessing `style.getLayer` when layer property is an Expression.
 
+### iOS
+* Fix `pixelsForCoordinates` implementation.
+
 ## 0.4.0 
 
 ### Common

--- a/ios/Classes/CameraController.swift
+++ b/ios/Classes/CameraController.swift
@@ -54,7 +54,7 @@ class CameraController: NSObject, FLT_CameraManager {
     }
 
     func pixels(forCoordinatesCoordinates coordinates: [[String: Any]], error: AutoreleasingUnsafeMutablePointer<FlutterError?>) -> [FLTScreenCoordinate]? {
-        let points = self.mapboxMap.coordinates(for: coordinates.map({convertDictionaryToCGPoint(dict: $0)!}) )
+        let points = self.mapboxMap.points(for: coordinates.map({convertDictionaryToCLLocationCoordinate2D(dict: $0)!}))
         return points.map({$0.toFLTScreenCoordinate()})
     }
 

--- a/lib/src/style/layer/background_layer.dart
+++ b/lib/src/style/layer/background_layer.dart
@@ -80,8 +80,8 @@ class BackgroundLayer extends Layer {
               .toLowerCase()
               .contains(map["layout"]["visibility"])),
       backgroundColor: (map["paint"]["background-color"] as List?)?.toRGBAInt(),
-      backgroundOpacity: map["paint"]["background-opacity"] is double?
-          ? map["paint"]["background-opacity"] as double?
+      backgroundOpacity: map["paint"]["background-opacity"] is num?
+          ? (map["paint"]["background-opacity"] as num?)?.toDouble()
           : null,
       backgroundPattern: map["paint"]["background-pattern"],
     );

--- a/lib/src/style/layer/circle_layer.dart
+++ b/lib/src/style/layer/circle_layer.dart
@@ -159,15 +159,15 @@ class CircleLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["layout"]["visibility"])),
-      circleSortKey: map["layout"]["circle-sort-key"] is double?
-          ? map["paint"]["circle-sort-key"] as double?
+      circleSortKey: map["layout"]["circle-sort-key"] is num?
+          ? (map["layout"]["circle-sort-key"] as num?)?.toDouble()
           : null,
-      circleBlur: map["paint"]["circle-blur"] is double?
-          ? map["paint"]["circle-blur"] as double?
+      circleBlur: map["paint"]["circle-blur"] is num?
+          ? (map["paint"]["circle-blur"] as num?)?.toDouble()
           : null,
       circleColor: (map["paint"]["circle-color"] as List?)?.toRGBAInt(),
-      circleOpacity: map["paint"]["circle-opacity"] is double?
-          ? map["paint"]["circle-opacity"] as double?
+      circleOpacity: map["paint"]["circle-opacity"] is num?
+          ? (map["paint"]["circle-opacity"] as num?)?.toDouble()
           : null,
       circlePitchAlignment: map["paint"]["circle-pitch-alignment"] == null
           ? null
@@ -185,16 +185,16 @@ class CircleLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["paint"]["circle-pitch-scale"])),
-      circleRadius: map["paint"]["circle-radius"] is double?
-          ? map["paint"]["circle-radius"] as double?
+      circleRadius: map["paint"]["circle-radius"] is num?
+          ? (map["paint"]["circle-radius"] as num?)?.toDouble()
           : null,
       circleStrokeColor:
           (map["paint"]["circle-stroke-color"] as List?)?.toRGBAInt(),
-      circleStrokeOpacity: map["paint"]["circle-stroke-opacity"] is double?
-          ? map["paint"]["circle-stroke-opacity"] as double?
+      circleStrokeOpacity: map["paint"]["circle-stroke-opacity"] is num?
+          ? (map["paint"]["circle-stroke-opacity"] as num?)?.toDouble()
           : null,
-      circleStrokeWidth: map["paint"]["circle-stroke-width"] is double?
-          ? map["paint"]["circle-stroke-width"] as double?
+      circleStrokeWidth: map["paint"]["circle-stroke-width"] is num?
+          ? (map["paint"]["circle-stroke-width"] as num?)?.toDouble()
           : null,
       circleTranslate: (map["paint"]["circle-translate"] as List?)
           ?.map<double?>((e) => e.toDouble())

--- a/lib/src/style/layer/fill_extrusion_layer.dart
+++ b/lib/src/style/layer/fill_extrusion_layer.dart
@@ -132,16 +132,16 @@ class FillExtrusionLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["layout"]["visibility"])),
-      fillExtrusionBase: map["paint"]["fill-extrusion-base"] is double?
-          ? map["paint"]["fill-extrusion-base"] as double?
+      fillExtrusionBase: map["paint"]["fill-extrusion-base"] is num?
+          ? (map["paint"]["fill-extrusion-base"] as num?)?.toDouble()
           : null,
       fillExtrusionColor:
           (map["paint"]["fill-extrusion-color"] as List?)?.toRGBAInt(),
-      fillExtrusionHeight: map["paint"]["fill-extrusion-height"] is double?
-          ? map["paint"]["fill-extrusion-height"] as double?
+      fillExtrusionHeight: map["paint"]["fill-extrusion-height"] is num?
+          ? (map["paint"]["fill-extrusion-height"] as num?)?.toDouble()
           : null,
-      fillExtrusionOpacity: map["paint"]["fill-extrusion-opacity"] is double?
-          ? map["paint"]["fill-extrusion-opacity"] as double?
+      fillExtrusionOpacity: map["paint"]["fill-extrusion-opacity"] is num?
+          ? (map["paint"]["fill-extrusion-opacity"] as num?)?.toDouble()
           : null,
       fillExtrusionPattern: map["paint"]["fill-extrusion-pattern"],
       fillExtrusionTranslate:

--- a/lib/src/style/layer/fill_layer.dart
+++ b/lib/src/style/layer/fill_layer.dart
@@ -129,13 +129,13 @@ class FillLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["layout"]["visibility"])),
-      fillSortKey: map["layout"]["fill-sort-key"] is double?
-          ? map["paint"]["fill-sort-key"] as double?
+      fillSortKey: map["layout"]["fill-sort-key"] is num?
+          ? (map["layout"]["fill-sort-key"] as num?)?.toDouble()
           : null,
       fillAntialias: map["paint"]["fill-antialias"],
       fillColor: (map["paint"]["fill-color"] as List?)?.toRGBAInt(),
-      fillOpacity: map["paint"]["fill-opacity"] is double?
-          ? map["paint"]["fill-opacity"] as double?
+      fillOpacity: map["paint"]["fill-opacity"] is num?
+          ? (map["paint"]["fill-opacity"] as num?)?.toDouble()
           : null,
       fillOutlineColor:
           (map["paint"]["fill-outline-color"] as List?)?.toRGBAInt(),

--- a/lib/src/style/layer/heatmap_layer.dart
+++ b/lib/src/style/layer/heatmap_layer.dart
@@ -108,17 +108,17 @@ class HeatmapLayer extends Layer {
               .toLowerCase()
               .contains(map["layout"]["visibility"])),
       heatmapColor: (map["paint"]["heatmap-color"] as List?)?.toRGBAInt(),
-      heatmapIntensity: map["paint"]["heatmap-intensity"] is double?
-          ? map["paint"]["heatmap-intensity"] as double?
+      heatmapIntensity: map["paint"]["heatmap-intensity"] is num?
+          ? (map["paint"]["heatmap-intensity"] as num?)?.toDouble()
           : null,
-      heatmapOpacity: map["paint"]["heatmap-opacity"] is double?
-          ? map["paint"]["heatmap-opacity"] as double?
+      heatmapOpacity: map["paint"]["heatmap-opacity"] is num?
+          ? (map["paint"]["heatmap-opacity"] as num?)?.toDouble()
           : null,
-      heatmapRadius: map["paint"]["heatmap-radius"] is double?
-          ? map["paint"]["heatmap-radius"] as double?
+      heatmapRadius: map["paint"]["heatmap-radius"] is num?
+          ? (map["paint"]["heatmap-radius"] as num?)?.toDouble()
           : null,
-      heatmapWeight: map["paint"]["heatmap-weight"] is double?
-          ? map["paint"]["heatmap-weight"] as double?
+      heatmapWeight: map["paint"]["heatmap-weight"] is num?
+          ? (map["paint"]["heatmap-weight"] as num?)?.toDouble()
           : null,
     );
   }

--- a/lib/src/style/layer/hillshade_layer.dart
+++ b/lib/src/style/layer/hillshade_layer.dart
@@ -118,8 +118,8 @@ class HillshadeLayer extends Layer {
               .contains(map["layout"]["visibility"])),
       hillshadeAccentColor:
           (map["paint"]["hillshade-accent-color"] as List?)?.toRGBAInt(),
-      hillshadeExaggeration: map["paint"]["hillshade-exaggeration"] is double?
-          ? map["paint"]["hillshade-exaggeration"] as double?
+      hillshadeExaggeration: map["paint"]["hillshade-exaggeration"] is num?
+          ? (map["paint"]["hillshade-exaggeration"] as num?)?.toDouble()
           : null,
       hillshadeHighlightColor:
           (map["paint"]["hillshade-highlight-color"] as List?)?.toRGBAInt(),
@@ -133,8 +133,9 @@ class HillshadeLayer extends Layer {
                   .toLowerCase()
                   .contains(map["paint"]["hillshade-illumination-anchor"])),
       hillshadeIlluminationDirection:
-          map["paint"]["hillshade-illumination-direction"] is double?
-              ? map["paint"]["hillshade-illumination-direction"] as double?
+          map["paint"]["hillshade-illumination-direction"] is num?
+              ? (map["paint"]["hillshade-illumination-direction"] as num?)
+                  ?.toDouble()
               : null,
       hillshadeShadowColor:
           (map["paint"]["hillshade-shadow-color"] as List?)?.toRGBAInt(),

--- a/lib/src/style/layer/line_layer.dart
+++ b/lib/src/style/layer/line_layer.dart
@@ -208,31 +208,31 @@ class LineLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["layout"]["line-join"])),
-      lineMiterLimit: map["layout"]["line-miter-limit"] is double?
-          ? map["paint"]["line-miter-limit"] as double?
+      lineMiterLimit: map["layout"]["line-miter-limit"] is num?
+          ? (map["layout"]["line-miter-limit"] as num?)?.toDouble()
           : null,
-      lineRoundLimit: map["layout"]["line-round-limit"] is double?
-          ? map["paint"]["line-round-limit"] as double?
+      lineRoundLimit: map["layout"]["line-round-limit"] is num?
+          ? (map["layout"]["line-round-limit"] as num?)?.toDouble()
           : null,
-      lineSortKey: map["layout"]["line-sort-key"] is double?
-          ? map["paint"]["line-sort-key"] as double?
+      lineSortKey: map["layout"]["line-sort-key"] is num?
+          ? (map["layout"]["line-sort-key"] as num?)?.toDouble()
           : null,
-      lineBlur: map["paint"]["line-blur"] is double?
-          ? map["paint"]["line-blur"] as double?
+      lineBlur: map["paint"]["line-blur"] is num?
+          ? (map["paint"]["line-blur"] as num?)?.toDouble()
           : null,
       lineColor: (map["paint"]["line-color"] as List?)?.toRGBAInt(),
       lineDasharray: (map["paint"]["line-dasharray"] as List?)
           ?.map<double?>((e) => e.toDouble())
           .toList(),
-      lineGapWidth: map["paint"]["line-gap-width"] is double?
-          ? map["paint"]["line-gap-width"] as double?
+      lineGapWidth: map["paint"]["line-gap-width"] is num?
+          ? (map["paint"]["line-gap-width"] as num?)?.toDouble()
           : null,
       lineGradient: (map["paint"]["line-gradient"] as List?)?.toRGBAInt(),
-      lineOffset: map["paint"]["line-offset"] is double?
-          ? map["paint"]["line-offset"] as double?
+      lineOffset: map["paint"]["line-offset"] is num?
+          ? (map["paint"]["line-offset"] as num?)?.toDouble()
           : null,
-      lineOpacity: map["paint"]["line-opacity"] is double?
-          ? map["paint"]["line-opacity"] as double?
+      lineOpacity: map["paint"]["line-opacity"] is num?
+          ? (map["paint"]["line-opacity"] as num?)?.toDouble()
           : null,
       linePattern: map["paint"]["line-pattern"],
       lineTranslate: (map["paint"]["line-translate"] as List?)
@@ -249,8 +249,8 @@ class LineLayer extends Layer {
       lineTrimOffset: (map["paint"]["line-trim-offset"] as List?)
           ?.map<double?>((e) => e.toDouble())
           .toList(),
-      lineWidth: map["paint"]["line-width"] is double?
-          ? map["paint"]["line-width"] as double?
+      lineWidth: map["paint"]["line-width"] is num?
+          ? (map["paint"]["line-width"] as num?)?.toDouble()
           : null,
     );
   }

--- a/lib/src/style/layer/location_indicator_layer.dart
+++ b/lib/src/style/layer/location_indicator_layer.dart
@@ -167,40 +167,38 @@ class LocationIndicatorLayer extends Layer {
       bearingImage: map["layout"]["bearing-image"],
       shadowImage: map["layout"]["shadow-image"],
       topImage: map["layout"]["top-image"],
-      accuracyRadius: map["paint"]["accuracy-radius"] is double?
-          ? map["paint"]["accuracy-radius"] as double?
+      accuracyRadius: map["paint"]["accuracy-radius"] is num?
+          ? (map["paint"]["accuracy-radius"] as num?)?.toDouble()
           : null,
       accuracyRadiusBorderColor:
           (map["paint"]["accuracy-radius-border-color"] as List?)?.toRGBAInt(),
       accuracyRadiusColor:
           (map["paint"]["accuracy-radius-color"] as List?)?.toRGBAInt(),
-      bearing: map["paint"]["bearing"] is double?
-          ? map["paint"]["bearing"] as double?
+      bearing: map["paint"]["bearing"] is num?
+          ? (map["paint"]["bearing"] as num?)?.toDouble()
           : null,
-      bearingImageSize: map["paint"]["bearing-image-size"] is double?
-          ? map["paint"]["bearing-image-size"] as double?
+      bearingImageSize: map["paint"]["bearing-image-size"] is num?
+          ? (map["paint"]["bearing-image-size"] as num?)?.toDouble()
           : null,
       emphasisCircleColor:
           (map["paint"]["emphasis-circle-color"] as List?)?.toRGBAInt(),
-      emphasisCircleRadius: map["paint"]["emphasis-circle-radius"] is double?
-          ? map["paint"]["emphasis-circle-radius"] as double?
+      emphasisCircleRadius: map["paint"]["emphasis-circle-radius"] is num?
+          ? (map["paint"]["emphasis-circle-radius"] as num?)?.toDouble()
           : null,
-      imagePitchDisplacement:
-          map["paint"]["image-pitch-displacement"] is double?
-              ? map["paint"]["image-pitch-displacement"] as double?
-              : null,
+      imagePitchDisplacement: map["paint"]["image-pitch-displacement"] is num?
+          ? (map["paint"]["image-pitch-displacement"] as num?)?.toDouble()
+          : null,
       location: (map["paint"]["location"] as List?)
           ?.map<double?>((e) => e.toDouble())
           .toList(),
-      perspectiveCompensation:
-          map["paint"]["perspective-compensation"] is double?
-              ? map["paint"]["perspective-compensation"] as double?
-              : null,
-      shadowImageSize: map["paint"]["shadow-image-size"] is double?
-          ? map["paint"]["shadow-image-size"] as double?
+      perspectiveCompensation: map["paint"]["perspective-compensation"] is num?
+          ? (map["paint"]["perspective-compensation"] as num?)?.toDouble()
           : null,
-      topImageSize: map["paint"]["top-image-size"] is double?
-          ? map["paint"]["top-image-size"] as double?
+      shadowImageSize: map["paint"]["shadow-image-size"] is num?
+          ? (map["paint"]["shadow-image-size"] as num?)?.toDouble()
+          : null,
+      topImageSize: map["paint"]["top-image-size"] is num?
+          ? (map["paint"]["top-image-size"] as num?)?.toDouble()
           : null,
     );
   }

--- a/lib/src/style/layer/raster_layer.dart
+++ b/lib/src/style/layer/raster_layer.dart
@@ -129,23 +129,23 @@ class RasterLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["layout"]["visibility"])),
-      rasterBrightnessMax: map["paint"]["raster-brightness-max"] is double?
-          ? map["paint"]["raster-brightness-max"] as double?
+      rasterBrightnessMax: map["paint"]["raster-brightness-max"] is num?
+          ? (map["paint"]["raster-brightness-max"] as num?)?.toDouble()
           : null,
-      rasterBrightnessMin: map["paint"]["raster-brightness-min"] is double?
-          ? map["paint"]["raster-brightness-min"] as double?
+      rasterBrightnessMin: map["paint"]["raster-brightness-min"] is num?
+          ? (map["paint"]["raster-brightness-min"] as num?)?.toDouble()
           : null,
-      rasterContrast: map["paint"]["raster-contrast"] is double?
-          ? map["paint"]["raster-contrast"] as double?
+      rasterContrast: map["paint"]["raster-contrast"] is num?
+          ? (map["paint"]["raster-contrast"] as num?)?.toDouble()
           : null,
-      rasterFadeDuration: map["paint"]["raster-fade-duration"] is double?
-          ? map["paint"]["raster-fade-duration"] as double?
+      rasterFadeDuration: map["paint"]["raster-fade-duration"] is num?
+          ? (map["paint"]["raster-fade-duration"] as num?)?.toDouble()
           : null,
-      rasterHueRotate: map["paint"]["raster-hue-rotate"] is double?
-          ? map["paint"]["raster-hue-rotate"] as double?
+      rasterHueRotate: map["paint"]["raster-hue-rotate"] is num?
+          ? (map["paint"]["raster-hue-rotate"] as num?)?.toDouble()
           : null,
-      rasterOpacity: map["paint"]["raster-opacity"] is double?
-          ? map["paint"]["raster-opacity"] as double?
+      rasterOpacity: map["paint"]["raster-opacity"] is num?
+          ? (map["paint"]["raster-opacity"] as num?)?.toDouble()
           : null,
       rasterResampling: map["paint"]["raster-resampling"] == null
           ? null
@@ -155,8 +155,8 @@ class RasterLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["paint"]["raster-resampling"])),
-      rasterSaturation: map["paint"]["raster-saturation"] is double?
-          ? map["paint"]["raster-saturation"] as double?
+      rasterSaturation: map["paint"]["raster-saturation"] is num?
+          ? (map["paint"]["raster-saturation"] as num?)?.toDouble()
           : null,
     );
   }

--- a/lib/src/style/layer/sky_layer.dart
+++ b/lib/src/style/layer/sky_layer.dart
@@ -128,19 +128,19 @@ class SkyLayer extends Layer {
       skyAtmosphereSun: (map["paint"]["sky-atmosphere-sun"] as List?)
           ?.map<double?>((e) => e.toDouble())
           .toList(),
-      skyAtmosphereSunIntensity:
-          map["paint"]["sky-atmosphere-sun-intensity"] is double?
-              ? map["paint"]["sky-atmosphere-sun-intensity"] as double?
-              : null,
+      skyAtmosphereSunIntensity: map["paint"]["sky-atmosphere-sun-intensity"]
+              is num?
+          ? (map["paint"]["sky-atmosphere-sun-intensity"] as num?)?.toDouble()
+          : null,
       skyGradient: (map["paint"]["sky-gradient"] as List?)?.toRGBAInt(),
       skyGradientCenter: (map["paint"]["sky-gradient-center"] as List?)
           ?.map<double?>((e) => e.toDouble())
           .toList(),
-      skyGradientRadius: map["paint"]["sky-gradient-radius"] is double?
-          ? map["paint"]["sky-gradient-radius"] as double?
+      skyGradientRadius: map["paint"]["sky-gradient-radius"] is num?
+          ? (map["paint"]["sky-gradient-radius"] as num?)?.toDouble()
           : null,
-      skyOpacity: map["paint"]["sky-opacity"] is double?
-          ? map["paint"]["sky-opacity"] as double?
+      skyOpacity: map["paint"]["sky-opacity"] is num?
+          ? (map["paint"]["sky-opacity"] as num?)?.toDouble()
           : null,
       skyType: map["paint"]["sky-type"] == null
           ? null

--- a/lib/src/style/layer/symbol_layer.dart
+++ b/lib/src/style/layer/symbol_layer.dart
@@ -479,8 +479,8 @@ class SymbolLayer extends Layer {
           ?.map<double?>((e) => e.toDouble())
           .toList(),
       iconOptional: map["layout"]["icon-optional"],
-      iconPadding: map["layout"]["icon-padding"] is double?
-          ? map["paint"]["icon-padding"] as double?
+      iconPadding: map["layout"]["icon-padding"] is num?
+          ? (map["layout"]["icon-padding"] as num?)?.toDouble()
           : null,
       iconPitchAlignment: map["layout"]["icon-pitch-alignment"] == null
           ? null
@@ -490,8 +490,8 @@ class SymbolLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["layout"]["icon-pitch-alignment"])),
-      iconRotate: map["layout"]["icon-rotate"] is double?
-          ? map["paint"]["icon-rotate"] as double?
+      iconRotate: map["layout"]["icon-rotate"] is num?
+          ? (map["layout"]["icon-rotate"] as num?)?.toDouble()
           : null,
       iconRotationAlignment: map["layout"]["icon-rotation-alignment"] == null
           ? null
@@ -501,8 +501,8 @@ class SymbolLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["layout"]["icon-rotation-alignment"])),
-      iconSize: map["layout"]["icon-size"] is double?
-          ? map["paint"]["icon-size"] as double?
+      iconSize: map["layout"]["icon-size"] is num?
+          ? (map["layout"]["icon-size"] as num?)?.toDouble()
           : null,
       iconTextFit: map["layout"]["icon-text-fit"] == null
           ? null
@@ -524,11 +524,11 @@ class SymbolLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["layout"]["symbol-placement"])),
-      symbolSortKey: map["layout"]["symbol-sort-key"] is double?
-          ? map["paint"]["symbol-sort-key"] as double?
+      symbolSortKey: map["layout"]["symbol-sort-key"] is num?
+          ? (map["layout"]["symbol-sort-key"] as num?)?.toDouble()
           : null,
-      symbolSpacing: map["layout"]["symbol-spacing"] is double?
-          ? map["paint"]["symbol-spacing"] as double?
+      symbolSpacing: map["layout"]["symbol-spacing"] is num?
+          ? (map["layout"]["symbol-spacing"] as num?)?.toDouble()
           : null,
       symbolZOrder: map["layout"]["symbol-z-order"] == null
           ? null
@@ -560,24 +560,24 @@ class SymbolLayer extends Layer {
               .toLowerCase()
               .contains(map["layout"]["text-justify"])),
       textKeepUpright: map["layout"]["text-keep-upright"],
-      textLetterSpacing: map["layout"]["text-letter-spacing"] is double?
-          ? map["paint"]["text-letter-spacing"] as double?
+      textLetterSpacing: map["layout"]["text-letter-spacing"] is num?
+          ? (map["layout"]["text-letter-spacing"] as num?)?.toDouble()
           : null,
-      textLineHeight: map["layout"]["text-line-height"] is double?
-          ? map["paint"]["text-line-height"] as double?
+      textLineHeight: map["layout"]["text-line-height"] is num?
+          ? (map["layout"]["text-line-height"] as num?)?.toDouble()
           : null,
-      textMaxAngle: map["layout"]["text-max-angle"] is double?
-          ? map["paint"]["text-max-angle"] as double?
+      textMaxAngle: map["layout"]["text-max-angle"] is num?
+          ? (map["layout"]["text-max-angle"] as num?)?.toDouble()
           : null,
-      textMaxWidth: map["layout"]["text-max-width"] is double?
-          ? map["paint"]["text-max-width"] as double?
+      textMaxWidth: map["layout"]["text-max-width"] is num?
+          ? (map["layout"]["text-max-width"] as num?)?.toDouble()
           : null,
       textOffset: (map["layout"]["text-offset"] as List?)
           ?.map<double?>((e) => e.toDouble())
           .toList(),
       textOptional: map["layout"]["text-optional"],
-      textPadding: map["layout"]["text-padding"] is double?
-          ? map["paint"]["text-padding"] as double?
+      textPadding: map["layout"]["text-padding"] is num?
+          ? (map["layout"]["text-padding"] as num?)?.toDouble()
           : null,
       textPitchAlignment: map["layout"]["text-pitch-alignment"] == null
           ? null
@@ -587,11 +587,11 @@ class SymbolLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["layout"]["text-pitch-alignment"])),
-      textRadialOffset: map["layout"]["text-radial-offset"] is double?
-          ? map["paint"]["text-radial-offset"] as double?
+      textRadialOffset: map["layout"]["text-radial-offset"] is num?
+          ? (map["layout"]["text-radial-offset"] as num?)?.toDouble()
           : null,
-      textRotate: map["layout"]["text-rotate"] is double?
-          ? map["paint"]["text-rotate"] as double?
+      textRotate: map["layout"]["text-rotate"] is num?
+          ? (map["layout"]["text-rotate"] as num?)?.toDouble()
           : null,
       textRotationAlignment: map["layout"]["text-rotation-alignment"] == null
           ? null
@@ -601,8 +601,8 @@ class SymbolLayer extends Layer {
               .last
               .toLowerCase()
               .contains(map["layout"]["text-rotation-alignment"])),
-      textSize: map["layout"]["text-size"] is double?
-          ? map["paint"]["text-size"] as double?
+      textSize: map["layout"]["text-size"] is num?
+          ? (map["layout"]["text-size"] as num?)?.toDouble()
           : null,
       textTransform: map["layout"]["text-transform"] == null
           ? null
@@ -619,15 +619,15 @@ class SymbolLayer extends Layer {
           ?.map<String?>((e) => e.toString())
           .toList(),
       iconColor: (map["paint"]["icon-color"] as List?)?.toRGBAInt(),
-      iconHaloBlur: map["paint"]["icon-halo-blur"] is double?
-          ? map["paint"]["icon-halo-blur"] as double?
+      iconHaloBlur: map["paint"]["icon-halo-blur"] is num?
+          ? (map["paint"]["icon-halo-blur"] as num?)?.toDouble()
           : null,
       iconHaloColor: (map["paint"]["icon-halo-color"] as List?)?.toRGBAInt(),
-      iconHaloWidth: map["paint"]["icon-halo-width"] is double?
-          ? map["paint"]["icon-halo-width"] as double?
+      iconHaloWidth: map["paint"]["icon-halo-width"] is num?
+          ? (map["paint"]["icon-halo-width"] as num?)?.toDouble()
           : null,
-      iconOpacity: map["paint"]["icon-opacity"] is double?
-          ? map["paint"]["icon-opacity"] as double?
+      iconOpacity: map["paint"]["icon-opacity"] is num?
+          ? (map["paint"]["icon-opacity"] as num?)?.toDouble()
           : null,
       iconTranslate: (map["paint"]["icon-translate"] as List?)
           ?.map<double?>((e) => e.toDouble())
@@ -641,15 +641,15 @@ class SymbolLayer extends Layer {
               .toLowerCase()
               .contains(map["paint"]["icon-translate-anchor"])),
       textColor: (map["paint"]["text-color"] as List?)?.toRGBAInt(),
-      textHaloBlur: map["paint"]["text-halo-blur"] is double?
-          ? map["paint"]["text-halo-blur"] as double?
+      textHaloBlur: map["paint"]["text-halo-blur"] is num?
+          ? (map["paint"]["text-halo-blur"] as num?)?.toDouble()
           : null,
       textHaloColor: (map["paint"]["text-halo-color"] as List?)?.toRGBAInt(),
-      textHaloWidth: map["paint"]["text-halo-width"] is double?
-          ? map["paint"]["text-halo-width"] as double?
+      textHaloWidth: map["paint"]["text-halo-width"] is num?
+          ? (map["paint"]["text-halo-width"] as num?)?.toDouble()
           : null,
-      textOpacity: map["paint"]["text-opacity"] is double?
-          ? map["paint"]["text-opacity"] as double?
+      textOpacity: map["paint"]["text-opacity"] is num?
+          ? (map["paint"]["text-opacity"] as num?)?.toDouble()
           : null,
       textTranslate: (map["paint"]["text-translate"] as List?)
           ?.map<double?>((e) => e.toDouble())


### PR DESCRIPTION
Fixes #77.

Also fixed an issue when plugin on iOS maps doubles as ints when the there's no fraction part (e.g. double `1.0` arrives as int   `1`). 