### PR TITLE
Fix GestureListener not being disposed

### DIFF
--- a/lib/src/map_widget.dart
+++ b/lib/src/map_widget.dart
@@ -197,11 +197,11 @@ class _MapWidgetState extends State<MapWidget> {
 
   @override
   void dispose() async {
-    super.dispose();
     if (_controller.isCompleted) {
       final controller = await _controller.future;
       controller.dispose();
     }
+    super.dispose();
   }
 
   @override

--- a/lib/src/map_widget.dart
+++ b/lib/src/map_widget.dart
@@ -197,11 +197,11 @@ class _MapWidgetState extends State<MapWidget> {
 
   @override
   void dispose() async {
+    super.dispose();
     if (_controller.isCompleted) {
       final controller = await _controller.future;
       controller.dispose();
     }
-    super.dispose();
   }
 
   @override

--- a/lib/src/mapbox_map.dart
+++ b/lib/src/mapbox_map.dart
@@ -201,9 +201,16 @@ class MapboxMap extends ChangeNotifier {
 
   @override
   void dispose() {
-    super.dispose();
+    if (onMapTapListener != null ||
+        onMapLongTapListener != null ||
+        onMapScrollListener != null) {
+      GestureListener.setup(
+          null,
+          binaryMessenger: _mapboxMapsPlatform.binaryMessenger);
+    }
     _mapboxMapsPlatform.dispose();
     _observersMap.clear();
+    super.dispose();
   }
 
   var _observersMap = Map<String, List<Observer>>();


### PR DESCRIPTION
## Description

There is a memory leak if we add `onTapListener`, `onLongTapListener` or `onScrollListener` callbacks. `GestureListener` is set up but never disposed.

Also, considering the documentation for dispose method which states:
> Implementations of this method should end with a call to the inherited method, as in super.dispose().

I moved those calls to the end of the method.

Edit: Reverted MapWidget super.dispose() call because, I assume, widget is already disposed and unmounted while _controller.future is being awaiting for, which caused the following assertion `_MapWidgetState.dispose failed to call super.dispose.`

## Type of change
- Bug fix (non-breaking change)