### PR TITLE
fix: Point to FLT ScreenCoordinate conversion

### DIFF
--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/GestureController.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/GestureController.kt
@@ -37,8 +37,8 @@ class GestureController(private val mapView: MapView) :
       override fun success() { }
       override fun error(error: Throwable) { }
     }
-    onClickListener = OnMapClickListener { point ->
-      fltGestureListener.onTap(point.toFLTScreenCoordinate(), result)
+    onClickListener = OnMapClickListener {
+      fltGestureListener.onTap(it.toFLTScreenCoordinate(), result)
       false
     }.also { mapView.gestures.addOnMapClickListener(it) }
 
@@ -50,9 +50,7 @@ class GestureController(private val mapView: MapView) :
     onMoveListener = object : OnMoveListener {
       override fun onMove(detector: MoveGestureDetector): Boolean {
         fltGestureListener.onScroll(
-          mapView.mapboxMap.coordinateForPixel(
-            ScreenCoordinate(detector.currentEvent.x.toDouble(), detector.currentEvent.y.toDouble())
-          ).toFLTScreenCoordinate(),
+          ScreenCoordinate(detector.currentEvent.x.toDouble(), detector.currentEvent.y.toDouble()).toFLTScreenCoordinate(),
           result
         )
         return false
@@ -69,11 +67,15 @@ class GestureController(private val mapView: MapView) :
     onLongClickListener?.let { mapView.gestures.removeOnMapLongClickListener(it) }
     onMoveListener?.let { mapView.gestures.removeOnMoveListener(it) }
   }
-}
 
-private fun Point.toFLTScreenCoordinate(): FLTGestureListeners.ScreenCoordinate {
-  return FLTGestureListeners.ScreenCoordinate.Builder()
-    .setX(this.latitude())
-    .setY(this.longitude())
-    .build()
+  private fun Point.toFLTScreenCoordinate(): FLTGestureListeners.ScreenCoordinate {
+    return mapView.getMapboxMap().pixelForCoordinate(this).toFLTScreenCoordinate();
+  }
+
+  private fun ScreenCoordinate.toFLTScreenCoordinate(): FLTGestureListeners.ScreenCoordinate {
+    return FLTGestureListeners.ScreenCoordinate.Builder()
+      .setX(this.x)
+      .setY(this.y)
+      .build()
+  }
 }


### PR DESCRIPTION
This PR fixes #81 and #190 (Android only).

Currently the `onTap`, `onLongTap` and `onScroll` callbacks get a `ScreenCoordinate`. However the `x` and `y` values do not correspond to the pixels on the screen but are actually the latitude and longitude. This is cause by a incorrect conversion in the GestureController, which takes the point (latitude and longitude) values to build the `ScreenCoordinate`. This PR fixes that by converting the point to a `ScreenCoordinate` using `pixelForCoordinate`.

It seems like the ios code suffers from the same problem. However I have no knowledge of Swift and also no means to test a potential fix for ios. Therefore I'm leaving that for someone else to fix.

Since we have the point (latitude and longitude) already, I'm going to create a follow up PR (#195) that additionally to the `ScreenCoordinate` also provides the point (as `Map<String?, Object?>` like in other places) to the callback.