### PR TITLE
Fixed the OrnamentsPage so that when toggle/move actions work.

### DIFF
--- a/example/lib/ornaments.dart
+++ b/example/lib/ornaments.dart
@@ -28,16 +28,24 @@ class OrnamentsPageBodyState extends State<OrnamentsPageBody> {
   final colors = [Colors.amber, Colors.black, Colors.blue];
 
   MapboxMap? mapboxMap;
-  bool showOrnaments = true;
+  bool showCompass = true;
   OrnamentPosition compassPosition = OrnamentPosition.TOP_RIGHT;
   bool showScaleBar = true;
   OrnamentPosition scaleBarPosition = OrnamentPosition.TOP_LEFT;
   OrnamentPosition logoPosition = OrnamentPosition.BOTTOM_LEFT;
   OrnamentPosition attributionPosition = OrnamentPosition.BOTTOM_LEFT;
 
-  _onMapCreated(MapboxMap mapboxMap) {
+  void _onMapCreated(MapboxMap mapboxMap) {
     this.mapboxMap = mapboxMap;
+    _updateSettings();
+  }
 
+  void _updateSettings() {
+    if (this.mapboxMap == null) {
+      return;
+    }
+
+    final mapboxMap = this.mapboxMap!;
     mapboxMap.setCamera(CameraOptions(
       center: Point(
           coordinates: Position(
@@ -53,7 +61,7 @@ class OrnamentsPageBodyState extends State<OrnamentsPageBody> {
 
     mapboxMap.compass.updateSettings(CompassSettings(
       position: compassPosition,
-      enabled: showOrnaments,
+      enabled: showCompass,
       marginBottom: 10,
       marginLeft: 10,
       marginTop: 10,
@@ -117,22 +125,19 @@ class OrnamentsPageBodyState extends State<OrnamentsPageBody> {
     );
   }
 
-  _toggleOrnaments() {
+  _toggleCompass() {
     return TextButton(
       child: Text('toggle compass'),
       onPressed: () {
         setState(() {
-          if (showOrnaments) {
-            showOrnaments = false;
-          } else {
-            showOrnaments = true;
-          }
+          showCompass = !showCompass;
+          _updateSettings();
         });
       },
     );
   }
 
-  Widget _moveOrnaments() {
+  Widget _moveCompass() {
     return TextButton(
       child: Text('move compass'),
       onPressed: () {
@@ -151,6 +156,7 @@ class OrnamentsPageBodyState extends State<OrnamentsPageBody> {
               compassPosition = OrnamentPosition.BOTTOM_LEFT;
               break;
           }
+          _updateSettings();
         });
       },
     );
@@ -161,11 +167,8 @@ class OrnamentsPageBodyState extends State<OrnamentsPageBody> {
       child: Text('toggle scale bar'),
       onPressed: () {
         setState(() {
-          if (showScaleBar) {
-            showScaleBar = false;
-          } else {
-            showScaleBar = true;
-          }
+          showScaleBar = !showScaleBar;
+          _updateSettings();
         });
       },
     );
@@ -190,6 +193,7 @@ class OrnamentsPageBodyState extends State<OrnamentsPageBody> {
               scaleBarPosition = OrnamentPosition.BOTTOM_LEFT;
               break;
           }
+          _updateSettings();
         });
       },
     );
@@ -214,6 +218,7 @@ class OrnamentsPageBodyState extends State<OrnamentsPageBody> {
               attributionPosition = OrnamentPosition.BOTTOM_LEFT;
               break;
           }
+          _updateSettings();
         });
       },
     );
@@ -238,6 +243,7 @@ class OrnamentsPageBodyState extends State<OrnamentsPageBody> {
               logoPosition = OrnamentPosition.BOTTOM_LEFT;
               break;
           }
+          _updateSettings();
         });
       },
     );
@@ -256,8 +262,8 @@ class OrnamentsPageBodyState extends State<OrnamentsPageBody> {
     listViewChildren.addAll(
       <Widget>[
         _getCompassSettings(),
-        _toggleOrnaments(),
-        _moveOrnaments(),
+        _toggleCompass(),
+        _moveCompass(),
         _toggleScaleBar(),
         _moveScaleBar(),
         _moveAttribution(),


### PR DESCRIPTION
Fixed the OrnamentsPage so that when toggle/move actions are applied instantly to the map.

Previously, the state was updated, e.g `showScaleBar` was changed from true to false, but `mapboxMap.scaleBar.updateSettings` was never called. A couple of other minor changes were made.