### PR TITLE
Use forked Pigeon

### DIFF
--- a/lib/src/pigeons/map_interfaces.dart
+++ b/lib/src/pigeons/map_interfaces.dart
@@ -1049,8 +1049,10 @@ class FeatureExtensionValue {
     result as List<Object?>;
     return FeatureExtensionValue(
       value: result[0] as String?,
-      featureCollection:
-          (result[1] as List<Object?>?)?.cast<Map<String?, Object?>?>(),
+      featureCollection: (result[1] as List<Object?>?)?.map((e) {
+        return Map<Object?, Object?>.from(e as Map<dynamic, dynamic>)
+            .cast<String?, Object?>();
+      }).toList(),
     );
   }
 }
@@ -2529,7 +2531,10 @@ class _CameraManager {
         message: 'Host platform returned null value for non-null return value.',
       );
     } else {
-      return (replyList[0] as List<Object?>?)!.cast<Map<String?, Object?>?>();
+      return (replyList[0] as List<Object?>?)!.map((e) {
+        return Map<Object?, Object?>.from(e as Map<dynamic, dynamic>)
+            .cast<String?, Object?>();
+      }).toList();
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,12 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   test: ^1.19.0
-  pigeon: ^11.0.1
+  pigeon:
+    git:
+      url: https://github.com/evil159/packages.git
+      ref: 53718b121f385905a7baa1531f771d24bbb25a1d
+      path: packages/pigeon
+
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
This PR fixes typecasting crashes for nested collections in generated decoding code by adopting a forked version of Pigeon - https://github.com/evil159/packages

The plan is to use the fork for the time being while proposing this change to be adopted by the mainstream Pigeon.