### PR TITLE
Update fastlane gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "fastlane"
+gem "fastlane", "~> 2.216.0"
 
 plugins_path = File.join(File.dirname(__FILE__), '.fastlane', 'Pluginfile')
 eval_gemfile(plugins_path) if File.exist?(plugins_path)


### PR DESCRIPTION
In 2.215.0 faslane addressed a WWDR certificate issue https://github.com/fastlane/fastlane/releases/tag/2.215.0, fingers crossed it helps with this error: https://app.circleci.com/pipelines/github/mapbox/mapbox-maps-flutter/168/workflows/c7eee086-ccf1-4afc-8b20-d8e9594d97a1/jobs/517