### PR TITLE
[iOS] Fix swift 5.8 build error

### DIFF
--- a/ios/Classes/CompassController.swift
+++ b/ios/Classes/CompassController.swift
@@ -27,10 +27,11 @@ class CompassController: NSObject, FLT_SETTINGSCompassSettingsInterface {
         if let visible = settings.enabled?.boolValue {
             let fadeWhenFacingNorth = settings.fadeWhenFacingNorth?.boolValue ?? true
 
-            let visibility: OrnamentVisibility = switch (visible, fadeWhenFacingNorth) {
-            case (true, true): .adaptive
-            case (true, false): .visible
-            case (false, _): .hidden
+            let visibility: OrnamentVisibility
+            switch (visible, fadeWhenFacingNorth) {
+            case (true, true): visibility = .adaptive
+            case (true, false): visibility = .visible
+            case (false, _): visibility = .hidden
             }
 
             compass.visibility = visibility


### PR DESCRIPTION
This PR removes one instance of >swift 5.9 -only syntax that makes iOS builds fail with Xcode 14.

Addresses https://github.com/mapbox/mapbox-maps-flutter/issues/264