### PR TITLE
Update dart sdk requirement

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.5.0
 homepage: https://github.com/mapbox/mapbox-maps-flutter
 
 environment:
-  sdk: ">=2.19.0 <3.0.0"
+  sdk: ">=2.19.0 <4.0.0"
   flutter: ">=2.0.0"
 
 dependencies:


### PR DESCRIPTION
As per https://dart.dev/resources/dart-3-migration#dart-3-backwards-compatibility - if the lower bound is > 2.12.0 then the upper bound is interpreted to be <4.0.0.