### PR TITLE
feature: Physical position on a map is available by pixel in the callbacks of onTap/onLongTap/onScroll

### DIFF
--- a/android/src/main/java/com/mapbox/maps/pigeons/FLTGestureListeners.java
+++ b/android/src/main/java/com/mapbox/maps/pigeons/FLTGestureListeners.java
@@ -180,28 +180,28 @@ public class FLTGestureListeners {
     static @NonNull MessageCodec<Object> getCodec() {
       return GestureListenerCodec.INSTANCE;
     }
-    public void onTap(@NonNull ScreenCoordinate coordinateArg, @NonNull Reply<Void> callback) {
+    public void onTap(@NonNull ScreenCoordinate coordinateArg, @NonNull Map<String, Object> pointArg, @NonNull Reply<Void> callback) {
       BasicMessageChannel<Object> channel =
           new BasicMessageChannel<>(
               binaryMessenger, "dev.flutter.pigeon.mapbox_maps_flutter.GestureListener.onTap", getCodec());
       channel.send(
-          new ArrayList<Object>(Collections.singletonList(coordinateArg)),
+          new ArrayList<Object>(Arrays.asList(coordinateArg, pointArg)),
           channelReply -> callback.reply(null));
     }
-    public void onLongTap(@NonNull ScreenCoordinate coordinateArg, @NonNull Reply<Void> callback) {
+    public void onLongTap(@NonNull ScreenCoordinate coordinateArg, @NonNull Map<String, Object> pointArg, @NonNull Reply<Void> callback) {
       BasicMessageChannel<Object> channel =
           new BasicMessageChannel<>(
               binaryMessenger, "dev.flutter.pigeon.mapbox_maps_flutter.GestureListener.onLongTap", getCodec());
       channel.send(
-          new ArrayList<Object>(Collections.singletonList(coordinateArg)),
+          new ArrayList<Object>(Arrays.asList(coordinateArg, pointArg))
           channelReply -> callback.reply(null));
     }
-    public void onScroll(@NonNull ScreenCoordinate coordinateArg, @NonNull Reply<Void> callback) {
+    public void onScroll(@NonNull ScreenCoordinate coordinateArg, @NonNull Map<String, Object> pointArg, @NonNull Reply<Void> callback) {
       BasicMessageChannel<Object> channel =
           new BasicMessageChannel<>(
               binaryMessenger, "dev.flutter.pigeon.mapbox_maps_flutter.GestureListener.onScroll", getCodec());
       channel.send(
-          new ArrayList<Object>(Collections.singletonList(coordinateArg)),
+          new ArrayList<Object>(Arrays.asList(coordinateArg, pointArg)),
           channelReply -> callback.reply(null));
     }
   }

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/GestureController.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/GestureController.kt
@@ -33,22 +33,29 @@ class GestureController(private val mapView: MapView) :
 
     removeListeners()
 
-    onClickListener = OnMapClickListener { point ->
-      fltGestureListener.onTap(point.toFLTScreenCoordinate()) {}
+    onClickListener = OnMapClickListener { 
+      fltGestureListener.onTap(
+        it.toFLTScreenCoordinate(),
+        it.toMap()
+      ) {}
       false
     }.also { mapView.gestures.addOnMapClickListener(it) }
 
     onLongClickListener = OnMapLongClickListener {
-      fltGestureListener.onLongTap(it.toFLTScreenCoordinate()) {}
+      fltGestureListener.onLongTap(
+        it.toFLTScreenCoordinate(),
+        it.toMap()
+      ) {}
       false
     }.also { mapView.gestures.addOnMapLongClickListener(it) }
 
     onMoveListener = object : OnMoveListener {
       override fun onMove(detector: MoveGestureDetector): Boolean {
+        var screenCoordinate = 
+          ScreenCoordinate(detector.currentEvent.x.toDouble(), detector.currentEvent.y.toDouble());
         fltGestureListener.onScroll(
-          mapView.getMapboxMap().coordinateForPixel(
-            ScreenCoordinate(detector.currentEvent.x.toDouble(), detector.currentEvent.y.toDouble())
-          ).toFLTScreenCoordinate()
+          screenCoordinate.toFLTScreenCoordinate(),
+          screenCoordinate.toPointMap()
         ) {}
         return false
       }
@@ -64,11 +71,19 @@ class GestureController(private val mapView: MapView) :
     onLongClickListener?.let { mapView.gestures.removeOnMapLongClickListener(it) }
     onMoveListener?.let { mapView.gestures.removeOnMoveListener(it) }
   }
-}
 
-private fun Point.toFLTScreenCoordinate(): FLTGestureListeners.ScreenCoordinate {
-  return FLTGestureListeners.ScreenCoordinate.Builder()
-    .setX(this.latitude())
-    .setY(this.longitude())
-    .build()
+  private fun Point.toFLTScreenCoordinate(): FLTGestureListeners.ScreenCoordinate {
+    return mapView.getMapboxMap().pixelForCoordinate(this).toFLTScreenCoordinate();
+  }
+
+  private fun ScreenCoordinate.toFLTScreenCoordinate(): FLTGestureListeners.ScreenCoordinate {
+    return FLTGestureListeners.ScreenCoordinate.Builder()
+      .setX(this.x)
+      .setY(this.y)
+      .build()
+  }
+
+  private fun ScreenCoordinate.toPointMap(): Map<String, Any> {
+    return  mapView.getMapboxMap().coordinateForPixel(this).toMap();
+  }
 }

--- a/example/lib/gestures.dart
+++ b/example/lib/gestures.dart
@@ -27,16 +27,16 @@ class GesturesPageBodyState extends State<GesturesPageBody> {
 
   MapboxMap? mapboxMap;
 
-  _onTap(ScreenCoordinate coordinate) {
-    print("OnTap ${coordinate.x} - ${coordinate.y}");
+  _onTap(ScreenCoordinate coordinate, Map<String?, Object?> point) {
+    print("OnTap ${coordinate.x} - ${coordinate.y}, $point");
   }
 
-  _onLongTap(ScreenCoordinate coordinate) {
-    print("OnLongTap ${coordinate.x} - ${coordinate.y}");
+  _onLongTap(ScreenCoordinate coordinate, Map<String?, Object?> point) {
+    print("OnLongTap ${coordinate.x} - ${coordinate.y}, $point");
   }
 
-  _onMove(ScreenCoordinate coordinate) {
-    print("OnMove ${coordinate.x} - ${coordinate.y}");
+  _onMove(ScreenCoordinate coordinate, Map<String?, Object?> point) {
+    print("OnMove ${coordinate.x} - ${coordinate.y}, $point");
   }
 
   _onMapCreated(MapboxMap mapboxMap) {

--- a/ios/Classes/GestureListeners.h
+++ b/ios/Classes/GestureListeners.h
@@ -30,9 +30,9 @@ NSObject<FlutterMessageCodec> *FLT_GESTURESGestureListenerGetCodec(void);
 
 @interface FLT_GESTURESGestureListener : NSObject
 - (instancetype)initWithBinaryMessenger:(id<FlutterBinaryMessenger>)binaryMessenger;
-- (void)onTapCoordinate:(FLT_GESTURESScreenCoordinate *)coordinate completion:(void (^)(FlutterError *_Nullable))completion;
-- (void)onLongTapCoordinate:(FLT_GESTURESScreenCoordinate *)coordinate completion:(void (^)(FlutterError *_Nullable))completion;
-- (void)onScrollCoordinate:(FLT_GESTURESScreenCoordinate *)coordinate completion:(void (^)(FlutterError *_Nullable))completion;
+- (void)onTapCoordinate:(FLT_GESTURESScreenCoordinate *)coordinate point:(NSDictionary<NSString *, id> *)point completion:(void (^)(FlutterError *_Nullable))completion;
+- (void)onLongTapCoordinate:(FLT_GESTURESScreenCoordinate *)coordinate point:(NSDictionary<NSString *, id> *)point completion:(void (^)(FlutterError *_Nullable))completion;
+- (void)onScrollCoordinate:(FLT_GESTURESScreenCoordinate *)coordinate point:(NSDictionary<NSString *, id> *)point completion:(void (^)(FlutterError *_Nullable))completion;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/Classes/GestureListeners.m
+++ b/ios/Classes/GestureListeners.m
@@ -111,33 +111,33 @@ NSObject<FlutterMessageCodec> *FLT_GESTURESGestureListenerGetCodec(void) {
   }
   return self;
 }
-- (void)onTapCoordinate:(FLT_GESTURESScreenCoordinate *)arg_coordinate completion:(void (^)(FlutterError *_Nullable))completion {
+- (void)onTapCoordinate:(FLT_GESTURESScreenCoordinate *)arg_coordinate point:(NSDictionary<NSString *, id> *)point completion:(void (^)(FlutterError *_Nullable))completion {
   FlutterBasicMessageChannel *channel =
     [FlutterBasicMessageChannel
       messageChannelWithName:@"dev.flutter.pigeon.mapbox_maps_flutter.GestureListener.onTap"
       binaryMessenger:self.binaryMessenger
       codec:FLT_GESTURESGestureListenerGetCodec()];
-  [channel sendMessage:@[arg_coordinate ?: [NSNull null]] reply:^(id reply) {
+  [channel sendMessage:@[arg_coordinate ?: [NSNull null], point] reply:^(id reply) {
     completion(nil);
   }];
 }
-- (void)onLongTapCoordinate:(FLT_GESTURESScreenCoordinate *)arg_coordinate completion:(void (^)(FlutterError *_Nullable))completion {
+- (void)onLongTapCoordinate:(FLT_GESTURESScreenCoordinate *)arg_coordinate point:(NSDictionary<NSString *, id> *)point completion:(void (^)(FlutterError *_Nullable))completion {
   FlutterBasicMessageChannel *channel =
     [FlutterBasicMessageChannel
       messageChannelWithName:@"dev.flutter.pigeon.mapbox_maps_flutter.GestureListener.onLongTap"
       binaryMessenger:self.binaryMessenger
       codec:FLT_GESTURESGestureListenerGetCodec()];
-  [channel sendMessage:@[arg_coordinate ?: [NSNull null]] reply:^(id reply) {
+  [channel sendMessage:@[arg_coordinate ?: [NSNull null], point] reply:^(id reply) {
     completion(nil);
   }];
 }
-- (void)onScrollCoordinate:(FLT_GESTURESScreenCoordinate *)arg_coordinate completion:(void (^)(FlutterError *_Nullable))completion {
+- (void)onScrollCoordinate:(FLT_GESTURESScreenCoordinate *)arg_coordinate point:(NSDictionary<NSString *, id> *)point completion:(void (^)(FlutterError *_Nullable))completion {
   FlutterBasicMessageChannel *channel =
     [FlutterBasicMessageChannel
       messageChannelWithName:@"dev.flutter.pigeon.mapbox_maps_flutter.GestureListener.onScroll"
       binaryMessenger:self.binaryMessenger
       codec:FLT_GESTURESGestureListenerGetCodec()];
-  [channel sendMessage:@[arg_coordinate ?: [NSNull null]] reply:^(id reply) {
+  [channel sendMessage:@[arg_coordinate ?: [NSNull null], point] reply:^(id reply) {
     completion(nil);
   }];
 }

--- a/ios/Classes/GesturesController.swift
+++ b/ios/Classes/GesturesController.swift
@@ -11,11 +11,13 @@ class GesturesController: NSObject, FLT_SETTINGSGesturesSettingsInterface, UIGes
     func gestureManager(_ gestureManager: MapboxMaps.GestureManager, didEnd gestureType: MapboxMaps.GestureType, willAnimate: Bool) {
         switch gestureType {
         case .pan:
-            let point = Point(mapView.mapboxMap.coordinate(for: gestureManager.panGestureRecognizer.location(in: mapView)))
-            self.onGestureListener?.onScroll(FLT_GESTURESScreenCoordinate.makeWith(x: NSNumber(value: point.coordinates.latitude), y: NSNumber(value: point.coordinates.longitude)), completion: {_ in })
+            let cgpoint = gestureManager.panGestureRecognizer.location(in: mapView)
+            let point = Point(mapView.mapboxMap.coordinate(for: cgpoint))
+            self.onGestureListener?.onScroll(FLT_GESTURESScreenCoordinate.makeWith(x: NSNumber(value: point.coordinates.latitude), y: NSNumber(value: point.coordinates.longitude)), point: [ "x": cgpoint.x, "y": cgpoint.y ], completion: {_ in })
         case .singleTap:
-            let point = Point(mapView.mapboxMap.coordinate(for: gestureManager.singleTapGestureRecognizer.location(in: mapView)))
-            self.onGestureListener?.onTap(FLT_GESTURESScreenCoordinate.makeWith(x: NSNumber(value: point.coordinates.latitude), y: NSNumber(value: point.coordinates.longitude)), completion: {_ in })
+            let cgpoint = gestureManager.singleTapGestureRecognizer.location(in: mapView)
+            let point = Point(mapView.mapboxMap.coordinate(for: cgpoint))
+            self.onGestureListener?.onTap(FLT_GESTURESScreenCoordinate.makeWith(x: NSNumber(value: point.coordinates.latitude), y: NSNumber(value: point.coordinates.longitude)), point: [ "x": cgpoint.x, "y": cgpoint.y ], completion: {_ in })
         default: break
         }
     }
@@ -24,8 +26,9 @@ class GesturesController: NSObject, FLT_SETTINGSGesturesSettingsInterface, UIGes
 
     @objc private func onMapLongTap(_ sender: UITapGestureRecognizer) {
         guard sender.state == .ended else { return }
-        let point = Point(mapView.mapboxMap.coordinate(for: sender.location(in: mapView)))
-        self.onGestureListener?.onLongTap(FLT_GESTURESScreenCoordinate.makeWith(x: NSNumber(value: point.coordinates.latitude), y: NSNumber(value: point.coordinates.longitude)), completion: {_ in })
+        let cgpoint = sender.location(in: mapView)
+        let point = Point(mapView.mapboxMap.coordinate(for: cgpoint))
+        self.onGestureListener?.onLongTap(FLT_GESTURESScreenCoordinate.makeWith(x: NSNumber(value: point.coordinates.latitude), y: NSNumber(value: point.coordinates.longitude)), point: [ "x": cgpoint.x, "y": cgpoint.y ], completion: {_ in })
     }
 
     func updateSettingsSettings(_ settings: FLT_SETTINGSGesturesSettings, error: AutoreleasingUnsafeMutablePointer<FlutterError?>) {

--- a/lib/src/callbacks.dart
+++ b/lib/src/callbacks.dart
@@ -101,10 +101,13 @@ typedef void OnStyleImageUnusedListener(
     StyleImageUnusedEventData styleImageUnusedEventData);
 
 /// Gesture listener called on map tap.
-typedef void OnMapTapListener(ScreenCoordinate coordinate);
+typedef void OnMapTapListener(
+    ScreenCoordinate coordinate, Map<String?, Object?> point);
 
 /// Gesture listener called on map double tap.
-typedef void OnMapLongTapListener(ScreenCoordinate coordinate);
+typedef void OnMapLongTapListener(
+    ScreenCoordinate coordinate, Map<String?, Object?> point);
 
 /// Gesture listener called on map scroll.
-typedef void OnMapScrollListener(ScreenCoordinate coordinate);
+typedef void OnMapScrollListener(
+    ScreenCoordinate coordinate, Map<String?, Object?> point);

--- a/lib/src/mapbox_map.dart
+++ b/lib/src/mapbox_map.dart
@@ -634,17 +634,17 @@ class _GestureListener extends GestureListener {
   final OnMapScrollListener? onMapScrollListener;
 
   @override
-  void onTap(ScreenCoordinate coordinate) {
-    onMapTapListener?.call(coordinate);
+  void onTap(ScreenCoordinate coordinate, Map<String?, Object?> point) {
+    onMapTapListener?.call(coordinate, point);
   }
 
   @override
-  void onLongTap(ScreenCoordinate coordinate) {
-    onMapLongTapListener?.call(coordinate);
+  void onLongTap(ScreenCoordinate coordinate, Map<String?, Object?> point) {
+    onMapLongTapListener?.call(coordinate, point);
   }
 
   @override
-  void onScroll(ScreenCoordinate coordinate) {
-    onMapScrollListener?.call(coordinate);
+  void onScroll(ScreenCoordinate coordinate, Map<String?, Object?> point) {
+    onMapScrollListener?.call(coordinate, point);
   }
 }

--- a/lib/src/pigeons/gesture_listeners.dart
+++ b/lib/src/pigeons/gesture_listeners.dart
@@ -26,11 +26,9 @@ class _GestureListenerCodec extends StandardMessageCodec {
 abstract class GestureListener {
   static const MessageCodec<Object?> codec = _GestureListenerCodec();
 
-  void onTap(ScreenCoordinate coordinate);
-
-  void onLongTap(ScreenCoordinate coordinate);
-
-  void onScroll(ScreenCoordinate coordinate);
+  void onTap(ScreenCoordinate coordinate, Map<String?, Object?> point);
+  void onLongTap(ScreenCoordinate coordinate, Map<String?, Object?> point);
+  void onScroll(ScreenCoordinate coordinate, Map<String?, Object?> point);
 
   static void setup(GestureListener? api, {BinaryMessenger? binaryMessenger}) {
     {
@@ -46,9 +44,11 @@ abstract class GestureListener {
           final List<Object?> args = (message as List<Object?>?)!;
           final ScreenCoordinate? arg_coordinate =
               (args[0] as ScreenCoordinate?);
-          assert(arg_coordinate != null,
+          final Map<String?, Object?>? arg_point =
+              (args[1] as Map<Object?, Object?>?)?.cast<String?, Object?>();
+          assert(arg_coordinate != null || arg_point != null,
               'Argument for dev.flutter.pigeon.mapbox_maps_flutter.GestureListener.onTap was null, expected non-null ScreenCoordinate.');
-          api.onTap(arg_coordinate!);
+          api.onTap(arg_coordinate!, arg_point!);
           return;
         });
       }
@@ -67,9 +67,11 @@ abstract class GestureListener {
           final List<Object?> args = (message as List<Object?>?)!;
           final ScreenCoordinate? arg_coordinate =
               (args[0] as ScreenCoordinate?);
-          assert(arg_coordinate != null,
+          final Map<String?, Object?>? arg_point =
+              (args[1] as Map<Object?, Object?>?)?.cast<String?, Object?>();
+          assert(arg_coordinate != null || arg_point != null,
               'Argument for dev.flutter.pigeon.mapbox_maps_flutter.GestureListener.onLongTap was null, expected non-null ScreenCoordinate.');
-          api.onLongTap(arg_coordinate!);
+          api.onLongTap(arg_coordinate!, arg_point!);
           return;
         });
       }
@@ -88,9 +90,11 @@ abstract class GestureListener {
           final List<Object?> args = (message as List<Object?>?)!;
           final ScreenCoordinate? arg_coordinate =
               (args[0] as ScreenCoordinate?);
-          assert(arg_coordinate != null,
+          final Map<String?, Object?>? arg_point =
+              (args[1] as Map<Object?, Object?>?)?.cast<String?, Object?>();
+          assert(arg_coordinate != null || arg_point != null,
               'Argument for dev.flutter.pigeon.mapbox_maps_flutter.GestureListener.onScroll was null, expected non-null ScreenCoordinate.');
-          api.onScroll(arg_coordinate!);
+          api.onScroll(arg_coordinate!, arg_point!);
           return;
         });
       }


### PR DESCRIPTION
It is inspired, although I reused it, by https://github.com/mapbox/mapbox-maps-flutter/pull/194 .

I was struggling that it was impossible to obtain a position which point of device is tapped physically. The positions, however, are needed to use the `queryRenderedFeatures` method.

Therefore, I added the implementation of iOS that is counterpart of android, which is already there.

Indeed, it already enabled to get geo location by lat/lng though, it looks wired that the values derive from coordinate `x/y` that should have been `lat/lng` or something like it to avoid misreading. Notwithstanding, I do not want to change these interface, so I endorse current style to add `position` parameter to the callbacks.

In addition, https://github.com/mapbox/mapbox-maps-flutter/pull/194 is conflicted to main branch, hence I also resolved it.