### PR TITLE
[v11] resolve build errors iOS

### DIFF
--- a/android/src/main/java/com/mapbox/maps/pigeons/FLTMapInterfaces.java
+++ b/android/src/main/java/com/mapbox/maps/pigeons/FLTMapInterfaces.java
@@ -5435,16 +5435,6 @@ public class FLTMapInterfaces {
      */
     @NonNull 
     CameraBounds getBounds();
-    /**
-     * Calculates target point where camera should move after drag. The method should be called after `dragStart` and before `dragEnd`.
-     *
-     * @param fromPoint The `screen coordinate` to drag the map from, measured in `logical pixels` from top to bottom and from left to right.
-     * @param toPoint The `screen coordinate` to drag the map to, measured in `logical pixels` from top to bottom and from left to right.
-     *
-     * @return The `camera options` object showing the end point.
-     */
-    @NonNull 
-    CameraOptions cameraForDrag(@NonNull ScreenCoordinate fromPoint, @NonNull ScreenCoordinate toPoint);
 
     /** The codec used by _CameraManager. */
     static @NonNull MessageCodec<Object> getCodec() {
@@ -5833,31 +5823,6 @@ public class FLTMapInterfaces {
                 ArrayList<Object> wrapped = new ArrayList<Object>();
                 try {
                   CameraBounds output = api.getBounds();
-                  wrapped.add(0, output);
-                }
- catch (Throwable exception) {
-                  ArrayList<Object> wrappedError = wrapError(exception);
-                  wrapped = wrappedError;
-                }
-                reply.reply(wrapped);
-              });
-        } else {
-          channel.setMessageHandler(null);
-        }
-      }
-      {
-        BasicMessageChannel<Object> channel =
-            new BasicMessageChannel<>(
-                binaryMessenger, "dev.flutter.pigeon.mapbox_maps_flutter._CameraManager.cameraForDrag", getCodec());
-        if (api != null) {
-          channel.setMessageHandler(
-              (message, reply) -> {
-                ArrayList<Object> wrapped = new ArrayList<Object>();
-                ArrayList<Object> args = (ArrayList<Object>) message;
-                ScreenCoordinate fromPointArg = (ScreenCoordinate) args.get(0);
-                ScreenCoordinate toPointArg = (ScreenCoordinate) args.get(1);
-                try {
-                  CameraOptions output = api.cameraForDrag(fromPointArg, toPointArg);
                   wrapped.add(0, output);
                 }
  catch (Throwable exception) {

--- a/android/src/main/java/com/mapbox/maps/pigeons/FLTMapInterfaces.java
+++ b/android/src/main/java/com/mapbox/maps/pigeons/FLTMapInterfaces.java
@@ -9425,14 +9425,6 @@ public class FLTMapInterfaces {
      */
     void setLights(@NonNull AmbientLight ambientLight, @NonNull DirectionalLight directionalLight);
     /**
-     * Sets the style global [light](https://docs.mapbox.com/mapbox-gl-js/style-spec/#light) properties.
-     *
-     * @param properties A map of style light properties values, with their names as a key.
-     *
-     * @return A string describing an error if the operation was not successful, empty otherwise.
-     */
-    void setStyleLight(@NonNull String properties, @NonNull Result<Void> result);
-    /**
      * Gets the value of a style light property.
      *
      * @param property The style light property name.
@@ -10602,35 +10594,6 @@ public class FLTMapInterfaces {
                   wrapped = wrappedError;
                 }
                 reply.reply(wrapped);
-              });
-        } else {
-          channel.setMessageHandler(null);
-        }
-      }
-      {
-        BasicMessageChannel<Object> channel =
-            new BasicMessageChannel<>(
-                binaryMessenger, "dev.flutter.pigeon.mapbox_maps_flutter.StyleManager.setStyleLight", getCodec());
-        if (api != null) {
-          channel.setMessageHandler(
-              (message, reply) -> {
-                ArrayList<Object> wrapped = new ArrayList<Object>();
-                ArrayList<Object> args = (ArrayList<Object>) message;
-                String propertiesArg = (String) args.get(0);
-                Result<Void> resultCallback =
-                    new Result<Void>() {
-                      public void success(Void result) {
-                        wrapped.add(0, null);
-                        reply.reply(wrapped);
-                      }
-
-                      public void error(Throwable error) {
-                        ArrayList<Object> wrappedError = wrapError(error);
-                        reply.reply(wrappedError);
-                      }
-                    };
-
-                api.setStyleLight(propertiesArg, resultCallback);
               });
         } else {
           channel.setMessageHandler(null);

--- a/example/integration_test/camera_test.dart
+++ b/example/integration_test/camera_test.dart
@@ -416,27 +416,4 @@ void main() {
 
     await addDelay(1000);
   });
-
-  testWidgets('drag', (WidgetTester tester) async {
-    final mapFuture = app.main();
-    await tester.pumpAndSettle();
-    final mapboxMap = await mapFuture;
-    await mapboxMap.dragStart(ScreenCoordinate(x: 1, y: 1));
-    await addDelay(1000);
-    mapboxMap.dragEnd();
-  });
-  testWidgets('getDragCameraOptions', (WidgetTester tester) async {
-    final mapFuture = app.runFixedSizeMap();
-    await tester.pumpAndSettle();
-    final mapboxMap = await mapFuture;
-
-    final destination = ScreenCoordinate(x: 100, y: 100);
-    final options = await mapboxMap.getDragCameraOptions(
-        ScreenCoordinate(x: 0, y: 0), destination);
-    final coordinates = options.center!["coordinates"] as List;
-    expect((coordinates.first as double).round(), -97);
-    expect((coordinates.last as double).round(), 69);
-
-    await addDelay(1000);
-  });
 }

--- a/example/integration_test/camera_test.dart
+++ b/example/integration_test/camera_test.dart
@@ -35,7 +35,8 @@ void main() {
             infiniteBounds: true),
         MbxEdgeInsets(top: 1, left: 2, bottom: 3, right: 4),
         10,
-        20);
+        20, 
+        null, null);
     expect(camera.bearing, 10);
     expect(camera.pitch, 20);
     expect(camera.padding!.top, 1);

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -42,7 +42,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   integration_test: 13825b8a9334a850581300559b8839134b124670
-  mapbox_maps_flutter: 3fe52061c7ca3655c21def2c48ee8270dea519e7
+  mapbox_maps_flutter: dc15c467501aef64bd70e341e6f6570fca7f7ca3
   MapboxCommon: 0cca816960ad2d21c86e1d32435fcb412cfdcf4f
   MapboxCoreMaps: 633f5ecd7580a6d1342ff20cc8732170b2cd7ba3
   MapboxMaps: 1c219108691a2000cb842b02e64d82158d74e6cd

--- a/example/lib/camera.dart
+++ b/example/lib/camera.dart
@@ -57,7 +57,9 @@ class CameraPageBodyState extends State<CameraPageBody> {
                     infiniteBounds: true),
                 MbxEdgeInsets(top: 1, left: 2, bottom: 3, right: 4),
                 10,
-                20)
+                20, 
+                null, 
+                null)
             .then(
                 (value) => ScaffoldMessenger.of(context).showSnackBar(SnackBar(
                       content: Text(
@@ -423,24 +425,6 @@ class CameraPageBodyState extends State<CameraPageBody> {
     );
   }
 
-  Widget _getDragCameraOptions() {
-    return TextButton(
-      child: Text('getDragCameraOptions'),
-      onPressed: () {
-        mapboxMap
-            ?.cameraForDrag(
-                ScreenCoordinate(x: 1, y: 1), ScreenCoordinate(x: 100, y: 100))
-            .then(
-                (value) => ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-                      content: Text(
-                          "Camera state zoom: ${value.zoom}, pitch: ${value.pitch}, bearing: ${value.bearing},padding: ${value.padding},center: ${value.center}"),
-                      backgroundColor: Theme.of(context).primaryColor,
-                      duration: Duration(seconds: 2),
-                    )));
-      },
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     final MapWidget mapWidget =
@@ -466,7 +450,6 @@ class CameraPageBodyState extends State<CameraPageBody> {
         _getCameraState(),
         _setBounds(),
         _getBounds(),
-        _getDragCameraOptions(),
       ],
     );
 

--- a/ios/Classes/CameraController.swift
+++ b/ios/Classes/CameraController.swift
@@ -1,28 +1,67 @@
-import Foundation
 import MapboxMaps
 import UIKit
+
 class CameraController: NSObject, FLT_CameraManager {
-    func cameraForDrag(fromPoint: FLTScreenCoordinate, toPoint: FLTScreenCoordinate, error: AutoreleasingUnsafeMutablePointer<FlutterError?>) -> FLTCameraOptions? {
-        return self.mapboxMap.dragCameraOptions(from: fromPoint.toCGPoint(), to: toPoint.toCGPoint()).toFLTCameraOptions()
+    func camera(
+        forCoordinateBoundsBounds bounds: FLTCoordinateBounds,
+        padding: FLTMbxEdgeInsets,
+        bearing: NSNumber?,
+        pitch: NSNumber?,
+        maxZoom: NSNumber?,
+        offset: FLTScreenCoordinate?,
+        error: AutoreleasingUnsafeMutablePointer<FlutterError?>
+    ) -> FLTCameraOptions? {
+
+        let coordinateBounds = bounds.toCoordinateBounds()
+        let camera = mapboxMap.camera(
+            for: [coordinateBounds.northeast, coordinateBounds.southwest],
+            camera: CameraOptions(),
+            coordinatesPadding: padding.toUIEdgeInsets(),
+            maxZoom: maxZoom?.doubleValue,
+            offset: offset?.toCGPoint())
+        return camera.toFLTCameraOptions()
     }
 
-    func camera(forCoordinateBoundsBounds bounds: FLTCoordinateBounds, padding: FLTMbxEdgeInsets, bearing: NSNumber?, pitch: NSNumber?, maxZoom: NSNumber?, offset: FLTScreenCoordinate?, error: AutoreleasingUnsafeMutablePointer<FlutterError?>) -> FLTCameraOptions? {
-        let cameraOptions = self.mapboxMap.camera(for: bounds.toCoordinateBounds(), padding: padding.toUIEdgeInsets(), bearing: bearing?.doubleValue, pitch: pitch?.doubleValue, maxZoom: maxZoom?.doubleValue, offset: offset?.toCGPoint())
+    func camera(
+        forCoordinatesCoordinates coordinates: [[String: Any]],
+        padding: FLTMbxEdgeInsets,
+        bearing: NSNumber?,
+        pitch: NSNumber?,
+        error: AutoreleasingUnsafeMutablePointer<FlutterError?>
+    ) -> FLTCameraOptions? {
+        let cameraOptions = mapboxMap.camera(
+            for: coordinates.map({convertDictionaryToCLLocationCoordinate2D(dict: $0)!}),
+            padding: padding.toUIEdgeInsets(),
+            bearing: bearing?.doubleValue,
+            pitch: pitch?.doubleValue)
         return cameraOptions.toFLTCameraOptions()
     }
 
-    func camera(forCoordinatesCoordinates coordinates: [[String: Any]], padding: FLTMbxEdgeInsets, bearing: NSNumber?, pitch: NSNumber?, error: AutoreleasingUnsafeMutablePointer<FlutterError?>) -> FLTCameraOptions? {
-        let cameraOptions = self.mapboxMap.camera(for: coordinates.map({convertDictionaryToCLLocationCoordinate2D(dict: $0)!}), padding: padding.toUIEdgeInsets(), bearing: bearing?.doubleValue, pitch: pitch?.doubleValue)
+    func camera(
+        forCoordinatesCameraOptionsCoordinates coordinates: [[String: Any]],
+        camera: FLTCameraOptions, 
+        box: FLTScreenBox,
+        error: AutoreleasingUnsafeMutablePointer<FlutterError?>
+    ) -> FLTCameraOptions? {
+        let cameraOptions = mapboxMap.camera(
+            for: coordinates.map({convertDictionaryToCLLocationCoordinate2D(dict: $0)!}), 
+            camera: camera.toCameraOptions(),
+            rect: box.toCGRect())
         return cameraOptions.toFLTCameraOptions()
     }
 
-    func camera(forCoordinatesCameraOptionsCoordinates coordinates: [[String: Any]], camera: FLTCameraOptions, box: FLTScreenBox, error: AutoreleasingUnsafeMutablePointer<FlutterError?>) -> FLTCameraOptions? {
-        let cameraOptions = self.mapboxMap.camera(for: coordinates.map({convertDictionaryToCLLocationCoordinate2D(dict: $0)!}), camera: camera.toCameraOptions(), rect: box.toCGRect())
-        return cameraOptions.toFLTCameraOptions()
-    }
-
-    func camera(forGeometryGeometry geometry: [String: Any], padding: FLTMbxEdgeInsets, bearing: NSNumber?, pitch: NSNumber?, error: AutoreleasingUnsafeMutablePointer<FlutterError?>) -> FLTCameraOptions? {
-        let cameraOptions = self.mapboxMap.camera(for: convertDictionaryToGeometry(dict: geometry)!, padding: padding.toUIEdgeInsets(), bearing: bearing?.CGFloat, pitch: pitch?.CGFloat)
+    func camera(
+        forGeometryGeometry geometry: [String: Any],
+        padding: FLTMbxEdgeInsets, 
+        bearing: NSNumber?,
+        pitch: NSNumber?,
+        error: AutoreleasingUnsafeMutablePointer<FlutterError?>
+    ) -> FLTCameraOptions? {
+        let cameraOptions = mapboxMap.camera(
+            for: convertDictionaryToGeometry(dict: geometry)!,
+            padding: padding.toUIEdgeInsets(),
+            bearing: bearing?.cgFloatValue,
+            pitch: pitch?.cgFloatValue)
         return cameraOptions.toFLTCameraOptions()
     }
 
@@ -87,7 +126,7 @@ class CameraController: NSObject, FLT_CameraManager {
     func getBoundsWithError(_ error: AutoreleasingUnsafeMutablePointer<FlutterError?>) -> FLTCameraBounds? {
         return self.mapboxMap.cameraBounds.toFLTCameraBounds()
     }
-
+    
     private var mapboxMap: MapboxMap
     init(withMapboxMap mapboxMap: MapboxMap) {
         self.mapboxMap = mapboxMap

--- a/ios/Classes/CameraController.swift
+++ b/ios/Classes/CameraController.swift
@@ -47,12 +47,12 @@ class CameraController: NSObject, FLT_CameraManager {
 
     func camera(
         forCoordinatesCameraOptionsCoordinates coordinates: [[String: Any]],
-        camera: FLTCameraOptions, 
+        camera: FLTCameraOptions,
         box: FLTScreenBox,
         error: AutoreleasingUnsafeMutablePointer<FlutterError?>
     ) -> FLTCameraOptions? {
         let cameraOptions = mapboxMap.camera(
-            for: coordinates.map({convertDictionaryToCLLocationCoordinate2D(dict: $0)!}), 
+            for: coordinates.map({convertDictionaryToCLLocationCoordinate2D(dict: $0)!}),
             camera: camera.toCameraOptions(),
             rect: box.toCGRect())
         return cameraOptions.toFLTCameraOptions()
@@ -60,7 +60,7 @@ class CameraController: NSObject, FLT_CameraManager {
 
     func camera(
         forGeometryGeometry geometry: [String: Any],
-        padding: FLTMbxEdgeInsets, 
+        padding: FLTMbxEdgeInsets,
         bearing: NSNumber?,
         pitch: NSNumber?,
         error: AutoreleasingUnsafeMutablePointer<FlutterError?>

--- a/ios/Classes/Extensions.swift
+++ b/ios/Classes/Extensions.swift
@@ -533,3 +533,31 @@ struct SupportedStyleColor: Encodable {
         (a << 24) + (r << 16) + << (g << 8) + b
     }
 }
+
+// MARK: Style Projection
+
+extension StyleProjectionName {
+
+    init(_ fltValue: FLTStyleProjectionName) {
+        switch fltValue {
+        case .mercator: self = .mercator
+        case .globe: self = .globe
+        @unknown default: self.init(rawValue: "undefined")
+        }
+    }
+
+    func toFLTStyleProjectionName() -> FLTStyleProjectionName? {
+        switch self {
+        case .globe: return .globe
+        case .mercator: return .mercator
+        default: return nil
+        }
+    }
+}
+
+extension StyleProjection {
+
+    func toFLTStyleProjection() -> FLTStyleProjection? {
+        name.toFLTStyleProjectionName().map(FLTStyleProjection.make(with:))
+    }
+}

--- a/ios/Classes/Extensions.swift
+++ b/ios/Classes/Extensions.swift
@@ -442,7 +442,7 @@ extension StyleColor {
 
     var nsNumberValue: NSNumber? {
         do {
-            let color = SupportedStyleColor(styleColor: self)
+            let color = try SupportedStyleColor(styleColor: self)
             return NSNumber(value: color.intValue)
         } catch {
             return nil
@@ -474,7 +474,14 @@ struct SupportedStyleColor: Encodable {
             throw StyleColorConversionError.invalidStyleColor
         }
 
-        try self.init(tag: tag, values: valueString.components(separatedBy: ",").compactMap(Double.init(_:)))
+        try self.init(
+            tag: tag,
+            values: valueString.components(separatedBy: ",").compactMap {
+                let scanner = Scanner(string: $0)
+                var doubleValue: Double = 0
+                scanner.scanDouble(&doubleValue)
+                return doubleValue
+            })
     }
 
     private init(tag: String, values: [Double]) throws {
@@ -529,8 +536,12 @@ struct SupportedStyleColor: Encodable {
     }
 
     var intValue: Int {
+        let red = Int(r * 255.0)
+        let green = Int(g * 255.0)
+        let blue = Int(b * 255.0)
+        let alpha = Int(a * 255.0)
         // Bits 24-31 are alpha, 16-23 are red, 8-15 are green, 0-7 are blue
-        (a << 24) + (r << 16) + << (g << 8) + b
+        return (alpha << 24) + (red << 16) + (green << 8) + blue
     }
 }
 

--- a/ios/Classes/MapEvents+JSON.swift
+++ b/ios/Classes/MapEvents+JSON.swift
@@ -9,8 +9,8 @@ protocol MapEventEncodable {
 extension EventTimeInterval {
     var toJSON: [String: Any] {
         [
-            "begin": begin.milisecondsSince1970,
-            "end": end.milisecondsSince1970
+            "begin": begin.microsecondsSince1970,
+            "end": end.microsecondsSince1970
         ]
     }
 }
@@ -40,7 +40,7 @@ extension MapLoadingError: MapEventEncodable {
             "message": message,
             "sourceId": sourceId,
             "tileId": tileId?.toJSON,
-            "timestamp": timestamp.milisecondsSince1970
+            "timestamp": timestamp.microsecondsSince1970
         ]
     }
 }
@@ -65,7 +65,7 @@ extension StyleDataLoaded: MapEventEncodable {
 extension CameraChanged: MapEventEncodable {
     var toJSON: [String: Any?] {
         [
-            "timestamp": timestamp.milisecondsSince1970
+            "timestamp": timestamp.microsecondsSince1970
         ]
     }
 }
@@ -73,7 +73,7 @@ extension CameraChanged: MapEventEncodable {
 extension MapIdle: MapEventEncodable {
     var toJSON: [String: Any?] {
         [
-            "timestamp": timestamp.milisecondsSince1970
+            "timestamp": timestamp.microsecondsSince1970
         ]
     }
 }
@@ -82,7 +82,7 @@ extension SourceAdded: MapEventEncodable {
     var toJSON: [String: Any?] {
         [
             "sourceId": sourceId,
-            "timestamp": timestamp.milisecondsSince1970
+            "timestamp": timestamp.microsecondsSince1970
         ]
     }
 }
@@ -91,7 +91,7 @@ extension SourceRemoved: MapEventEncodable {
     var toJSON: [String: Any?] {
         [
             "sourceId": sourceId,
-            "timestamp": timestamp.milisecondsSince1970
+            "timestamp": timestamp.microsecondsSince1970
         ]
     }
 }
@@ -122,7 +122,7 @@ extension StyleImageRemoveUnused: MapEventEncodable {
     var toJSON: [String: Any?] {
         [
             "imageId": imageId,
-            "timestamp": timestamp.milisecondsSince1970
+            "timestamp": timestamp.microsecondsSince1970
         ]
     }
 }
@@ -130,7 +130,7 @@ extension StyleImageRemoveUnused: MapEventEncodable {
 extension RenderFrameStarted: MapEventEncodable {
     var toJSON: [String: Any?] {
         [
-            "timestamp": timestamp.milisecondsSince1970
+            "timestamp": timestamp.microsecondsSince1970
         ]
     }
 }
@@ -209,7 +209,7 @@ extension MapEventEncodable {
 
 private extension Date {
 
-    var milisecondsSince1970: Int64 {
+    var microsecondsSince1970: Int64 {
         Int64((timeIntervalSince1970 * 1_000_000).rounded())
     }
 }

--- a/ios/Classes/MapEvents+JSON.swift
+++ b/ios/Classes/MapEvents+JSON.swift
@@ -9,8 +9,8 @@ protocol MapEventEncodable {
 extension EventTimeInterval {
     var toJSON: [String: Any] {
         [
-            "begin": begin.timeIntervalSince1970,
-            "end": end.timeIntervalSince1970
+            "begin": begin.milisecondsSince1970,
+            "end": end.milisecondsSince1970
         ]
     }
 }
@@ -40,7 +40,7 @@ extension MapLoadingError: MapEventEncodable {
             "message": message,
             "sourceId": sourceId,
             "tileId": tileId?.toJSON,
-            "timestamp": timestamp.timeIntervalSince1970
+            "timestamp": timestamp.milisecondsSince1970
         ]
     }
 }
@@ -65,7 +65,7 @@ extension StyleDataLoaded: MapEventEncodable {
 extension CameraChanged: MapEventEncodable {
     var toJSON: [String: Any?] {
         [
-            "timestamp": timestamp.timeIntervalSince1970
+            "timestamp": timestamp.milisecondsSince1970
         ]
     }
 }
@@ -73,7 +73,7 @@ extension CameraChanged: MapEventEncodable {
 extension MapIdle: MapEventEncodable {
     var toJSON: [String: Any?] {
         [
-            "timestamp": timestamp.timeIntervalSince1970
+            "timestamp": timestamp.milisecondsSince1970
         ]
     }
 }
@@ -82,7 +82,7 @@ extension SourceAdded: MapEventEncodable {
     var toJSON: [String: Any?] {
         [
             "sourceId": sourceId,
-            "timestamp": timestamp.timeIntervalSince1970
+            "timestamp": timestamp.milisecondsSince1970
         ]
     }
 }
@@ -91,7 +91,7 @@ extension SourceRemoved: MapEventEncodable {
     var toJSON: [String: Any?] {
         [
             "sourceId": sourceId,
-            "timestamp": timestamp.timeIntervalSince1970
+            "timestamp": timestamp.milisecondsSince1970
         ]
     }
 }
@@ -122,7 +122,7 @@ extension StyleImageRemoveUnused: MapEventEncodable {
     var toJSON: [String: Any?] {
         [
             "imageId": imageId,
-            "timestamp": timestamp.timeIntervalSince1970
+            "timestamp": timestamp.milisecondsSince1970
         ]
     }
 }
@@ -130,7 +130,7 @@ extension StyleImageRemoveUnused: MapEventEncodable {
 extension RenderFrameStarted: MapEventEncodable {
     var toJSON: [String: Any?] {
         [
-            "timestamp": timestamp.timeIntervalSince1970
+            "timestamp": timestamp.milisecondsSince1970
         ]
     }
 }
@@ -202,5 +202,14 @@ extension MapEventEncodable {
         } catch {
             return ""
         }
+    }
+}
+
+// MARK: Date
+
+private extension Date {
+
+    var milisecondsSince1970: Int64 {
+        Int64((timeIntervalSince1970 * 1000).rounded())
     }
 }

--- a/ios/Classes/MapEvents+JSON.swift
+++ b/ios/Classes/MapEvents+JSON.swift
@@ -46,7 +46,7 @@ extension MapLoadingError: MapEventEncodable {
 }
 
 extension StyleLoaded: MapEventEncodable {
-    var toJSON: [String : Any?] {
+    var toJSON: [String: Any?] {
         [
             "timeInterval": timeInterval.toJSON
         ]
@@ -54,7 +54,7 @@ extension StyleLoaded: MapEventEncodable {
 }
 
 extension StyleDataLoaded: MapEventEncodable {
-    var toJSON: [String : Any?] {
+    var toJSON: [String: Any?] {
         [
             "type": type.rawValue,
             "timeInterval": timeInterval.toJSON
@@ -63,7 +63,7 @@ extension StyleDataLoaded: MapEventEncodable {
 }
 
 extension CameraChanged: MapEventEncodable {
-    var toJSON: [String : Any?] {
+    var toJSON: [String: Any?] {
         [
             "timestamp": timestamp.timeIntervalSince1970
         ]
@@ -71,7 +71,7 @@ extension CameraChanged: MapEventEncodable {
 }
 
 extension MapIdle: MapEventEncodable {
-    var toJSON: [String : Any?] {
+    var toJSON: [String: Any?] {
         [
             "timestamp": timestamp.timeIntervalSince1970
         ]
@@ -79,7 +79,7 @@ extension MapIdle: MapEventEncodable {
 }
 
 extension SourceAdded: MapEventEncodable {
-    var toJSON: [String : Any?] {
+    var toJSON: [String: Any?] {
         [
             "sourceId": sourceId,
             "timestamp": timestamp.timeIntervalSince1970
@@ -88,7 +88,7 @@ extension SourceAdded: MapEventEncodable {
 }
 
 extension SourceRemoved: MapEventEncodable {
-    var toJSON: [String : Any?] {
+    var toJSON: [String: Any?] {
         [
             "sourceId": sourceId,
             "timestamp": timestamp.timeIntervalSince1970
@@ -97,7 +97,7 @@ extension SourceRemoved: MapEventEncodable {
 }
 
 extension SourceDataLoaded: MapEventEncodable {
-    var toJSON: [String : Any?] {
+    var toJSON: [String: Any?] {
         [
             "sourceId": sourceId,
             "type": type.rawValue,
@@ -110,7 +110,7 @@ extension SourceDataLoaded: MapEventEncodable {
 }
 
 extension StyleImageMissing: MapEventEncodable {
-    var toJSON: [String : Any?] {
+    var toJSON: [String: Any?] {
         [
             "imageId": imageId,
             "timestamp": timestamp
@@ -119,7 +119,7 @@ extension StyleImageMissing: MapEventEncodable {
 }
 
 extension StyleImageRemoveUnused: MapEventEncodable {
-    var toJSON: [String : Any?] {
+    var toJSON: [String: Any?] {
         [
             "imageId": imageId,
             "timestamp": timestamp.timeIntervalSince1970
@@ -128,7 +128,7 @@ extension StyleImageRemoveUnused: MapEventEncodable {
 }
 
 extension RenderFrameStarted: MapEventEncodable {
-    var toJSON: [String : Any?] {
+    var toJSON: [String: Any?] {
         [
             "timestamp": timestamp.timeIntervalSince1970
         ]
@@ -136,7 +136,7 @@ extension RenderFrameStarted: MapEventEncodable {
 }
 
 extension RenderFrameFinished: MapEventEncodable {
-    var toJSON: [String : Any?] {
+    var toJSON: [String: Any?] {
         [
             "renderMode": renderMode.rawValue,
             "timeInterval": timeInterval.toJSON,
@@ -147,7 +147,7 @@ extension RenderFrameFinished: MapEventEncodable {
 }
 
 extension RequestInfo {
-    var toJSON: [String : Any] {
+    var toJSON: [String: Any] {
         [
             "url": url,
             "resource": resource.rawValue,
@@ -158,7 +158,7 @@ extension RequestInfo {
 }
 
 extension ResourceRequestError {
-    var toJSON: [String : Any] {
+    var toJSON: [String: Any] {
         [
             "reason": reason.rawValue,
             "message": message
@@ -167,7 +167,7 @@ extension ResourceRequestError {
 }
 
 extension ResponseInfo {
-    var toJSON: [String : Any] {
+    var toJSON: [String: Any] {
         var result = [String: Any]()
         result["noContent"] = noContent
         result["notModified"] = notModified
@@ -183,7 +183,7 @@ extension ResponseInfo {
 }
 
 extension ResourceRequest: MapEventEncodable {
-    var toJSON: [String : Any?] {
+    var toJSON: [String: Any?] {
         [
             "source": source.rawValue,
             "request": request.toJSON,

--- a/ios/Classes/MapEvents+JSON.swift
+++ b/ios/Classes/MapEvents+JSON.swift
@@ -9,8 +9,8 @@ protocol MapEventEncodable {
 extension EventTimeInterval {
     var toJSON: [String: Any] {
         [
-            "begin": begin,
-            "end": end
+            "begin": begin.timeIntervalSince1970,
+            "end": end.timeIntervalSince1970
         ]
     }
 }
@@ -40,7 +40,7 @@ extension MapLoadingError: MapEventEncodable {
             "message": message,
             "sourceId": sourceId,
             "tileId": tileId?.toJSON,
-            "timestamp": timestamp
+            "timestamp": timestamp.timeIntervalSince1970
         ]
     }
 }
@@ -48,7 +48,7 @@ extension MapLoadingError: MapEventEncodable {
 extension StyleLoaded: MapEventEncodable {
     var toJSON: [String : Any?] {
         [
-            "timeInterval": timeInterval
+            "timeInterval": timeInterval.toJSON
         ]
     }
 }
@@ -57,7 +57,7 @@ extension StyleDataLoaded: MapEventEncodable {
     var toJSON: [String : Any?] {
         [
             "type": type.rawValue,
-            "timeInterval": timeInterval
+            "timeInterval": timeInterval.toJSON
         ]
     }
 }
@@ -65,7 +65,7 @@ extension StyleDataLoaded: MapEventEncodable {
 extension CameraChanged: MapEventEncodable {
     var toJSON: [String : Any?] {
         [
-            "timestamp": timestamp
+            "timestamp": timestamp.timeIntervalSince1970
         ]
     }
 }
@@ -73,7 +73,7 @@ extension CameraChanged: MapEventEncodable {
 extension MapIdle: MapEventEncodable {
     var toJSON: [String : Any?] {
         [
-            "timestamp": timestamp
+            "timestamp": timestamp.timeIntervalSince1970
         ]
     }
 }
@@ -82,7 +82,7 @@ extension SourceAdded: MapEventEncodable {
     var toJSON: [String : Any?] {
         [
             "sourceId": sourceId,
-            "timestamp": timestamp
+            "timestamp": timestamp.timeIntervalSince1970
         ]
     }
 }
@@ -91,7 +91,7 @@ extension SourceRemoved: MapEventEncodable {
     var toJSON: [String : Any?] {
         [
             "sourceId": sourceId,
-            "timestamp": timestamp
+            "timestamp": timestamp.timeIntervalSince1970
         ]
     }
 }
@@ -122,7 +122,7 @@ extension StyleImageRemoveUnused: MapEventEncodable {
     var toJSON: [String : Any?] {
         [
             "imageId": imageId,
-            "timestamp": timestamp
+            "timestamp": timestamp.timeIntervalSince1970
         ]
     }
 }
@@ -130,7 +130,7 @@ extension StyleImageRemoveUnused: MapEventEncodable {
 extension RenderFrameStarted: MapEventEncodable {
     var toJSON: [String : Any?] {
         [
-            "timestamp": timestamp
+            "timestamp": timestamp.timeIntervalSince1970
         ]
     }
 }

--- a/ios/Classes/MapEvents+JSON.swift
+++ b/ios/Classes/MapEvents+JSON.swift
@@ -210,6 +210,6 @@ extension MapEventEncodable {
 private extension Date {
 
     var milisecondsSince1970: Int64 {
-        Int64((timeIntervalSince1970 * 1000).rounded())
+        Int64((timeIntervalSince1970 * 1_000_000).rounded())
     }
 }

--- a/ios/Classes/MapInterfaces.h
+++ b/ios/Classes/MapInterfaces.h
@@ -1349,15 +1349,6 @@ NSObject<FlutterMessageCodec> *FLT_CameraManagerGetCodec(void);
 ///
 /// @return `nil` only when `error != nil`.
 - (nullable FLTCameraBounds *)getBoundsWithError:(FlutterError *_Nullable *_Nonnull)error;
-/// Calculates target point where camera should move after drag. The method should be called after `dragStart` and before `dragEnd`.
-///
-/// @param fromPoint The `screen coordinate` to drag the map from, measured in `logical pixels` from top to bottom and from left to right.
-/// @param toPoint The `screen coordinate` to drag the map to, measured in `logical pixels` from top to bottom and from left to right.
-///
-/// @return The `camera options` object showing the end point.
-///
-/// @return `nil` only when `error != nil`.
-- (nullable FLTCameraOptions *)cameraForDragFromPoint:(FLTScreenCoordinate *)fromPoint toPoint:(FLTScreenCoordinate *)toPoint error:(FlutterError *_Nullable *_Nonnull)error;
 @end
 
 extern void FLT_CameraManagerSetup(id<FlutterBinaryMessenger> binaryMessenger, NSObject<FLT_CameraManager> *_Nullable api);

--- a/ios/Classes/MapInterfaces.h
+++ b/ios/Classes/MapInterfaces.h
@@ -2047,12 +2047,6 @@ NSObject<FlutterMessageCodec> *FLTStyleManagerGetCodec(void);
 /// @param ambientLight The ambient light source.
 /// @param directionalLight The directional light source.
 - (void)setLightsAmbientLight:(FLTAmbientLight *)ambientLight directionalLight:(FLTDirectionalLight *)directionalLight error:(FlutterError *_Nullable *_Nonnull)error;
-/// Sets the style global [light](https://docs.mapbox.com/mapbox-gl-js/style-spec/#light) properties.
-///
-/// @param properties A map of style light properties values, with their names as a key.
-///
-/// @return A string describing an error if the operation was not successful, empty otherwise.
-- (void)setStyleLightProperties:(NSString *)properties completion:(void (^)(FlutterError *_Nullable))completion;
 /// Gets the value of a style light property.
 ///
 /// @param property The style light property name.

--- a/ios/Classes/MapInterfaces.m
+++ b/ios/Classes/MapInterfaces.m
@@ -2650,32 +2650,6 @@ void FLT_CameraManagerSetup(id<FlutterBinaryMessenger> binaryMessenger, NSObject
       [channel setMessageHandler:nil];
     }
   }
-  /// Calculates target point where camera should move after drag. The method should be called after `dragStart` and before `dragEnd`.
-  ///
-  /// @param fromPoint The `screen coordinate` to drag the map from, measured in `logical pixels` from top to bottom and from left to right.
-  /// @param toPoint The `screen coordinate` to drag the map to, measured in `logical pixels` from top to bottom and from left to right.
-  ///
-  /// @return The `camera options` object showing the end point.
-  {
-    FlutterBasicMessageChannel *channel =
-      [[FlutterBasicMessageChannel alloc]
-        initWithName:@"dev.flutter.pigeon.mapbox_maps_flutter._CameraManager.cameraForDrag"
-        binaryMessenger:binaryMessenger
-        codec:FLT_CameraManagerGetCodec()];
-    if (api) {
-      NSCAssert([api respondsToSelector:@selector(cameraForDragFromPoint:toPoint:error:)], @"FLT_CameraManager api (%@) doesn't respond to @selector(cameraForDragFromPoint:toPoint:error:)", api);
-      [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
-        NSArray *args = message;
-        FLTScreenCoordinate *arg_fromPoint = GetNullableObjectAtIndex(args, 0);
-        FLTScreenCoordinate *arg_toPoint = GetNullableObjectAtIndex(args, 1);
-        FlutterError *error;
-        FLTCameraOptions *output = [api cameraForDragFromPoint:arg_fromPoint toPoint:arg_toPoint error:&error];
-        callback(wrapResult(output, error));
-      }];
-    } else {
-      [channel setMessageHandler:nil];
-    }
-  }
 }
 @interface FLT_MapInterfaceCodecReader : FlutterStandardReader
 @end

--- a/ios/Classes/MapInterfaces.m
+++ b/ios/Classes/MapInterfaces.m
@@ -6280,30 +6280,6 @@ void FLTStyleManagerSetup(id<FlutterBinaryMessenger> binaryMessenger, NSObject<F
       [channel setMessageHandler:nil];
     }
   }
-  /// Sets the style global [light](https://docs.mapbox.com/mapbox-gl-js/style-spec/#light) properties.
-  ///
-  /// @param properties A map of style light properties values, with their names as a key.
-  ///
-  /// @return A string describing an error if the operation was not successful, empty otherwise.
-  {
-    FlutterBasicMessageChannel *channel =
-      [[FlutterBasicMessageChannel alloc]
-        initWithName:@"dev.flutter.pigeon.mapbox_maps_flutter.StyleManager.setStyleLight"
-        binaryMessenger:binaryMessenger
-        codec:FLTStyleManagerGetCodec()];
-    if (api) {
-      NSCAssert([api respondsToSelector:@selector(setStyleLightProperties:completion:)], @"FLTStyleManager api (%@) doesn't respond to @selector(setStyleLightProperties:completion:)", api);
-      [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
-        NSArray *args = message;
-        NSString *arg_properties = GetNullableObjectAtIndex(args, 0);
-        [api setStyleLightProperties:arg_properties completion:^(FlutterError *_Nullable error) {
-          callback(wrapResult(nil, error));
-        }];
-      }];
-    } else {
-      [channel setMessageHandler:nil];
-    }
-  }
   /// Gets the value of a style light property.
   ///
   /// @param property The style light property name.

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -1,5 +1,5 @@
 import Flutter
-import MapboxMaps
+@_spi(Experimental) import MapboxMaps
 import UIKit
 
 class ProxyBinaryMessenger: NSObject, FlutterBinaryMessenger {
@@ -70,7 +70,7 @@ class MapboxMapController: NSObject, FlutterPlatformView {
 
         channel.setMethodCallHandler { [weak self] in self?.onMethodCall(methodCall: $0, result: $1) }
 
-        let styleController = StyleController(withMapboxMap: mapboxMap)
+        let styleController = StyleController(styleManager: mapboxMap)
         FLTStyleManagerSetup(proxyBinaryMessenger, styleController)
 
         let cameraController = CameraController(withMapboxMap: mapboxMap)

--- a/ios/Classes/MapboxMapFactory.swift
+++ b/ios/Classes/MapboxMapFactory.swift
@@ -119,10 +119,6 @@ class MapboxMapFactory: NSObject, FlutterPlatformViewFactory {
         arguments args: Any?
     ) -> FlutterPlatformView {
 
-        let mapboxOptionsController = MapboxOptionsController()
-        FLT_MapboxOptionsSetup(registrar.messenger(), mapboxOptionsController)
-        FLT_MapboxMapsOptionsSetup(registrar.messenger(), mapboxOptionsController)
-
         var mapInitOptions = MapInitOptions()
         var eventTypes = [Int]()
         var pluginVersion = ""

--- a/ios/Classes/MapboxMapFactory.swift
+++ b/ios/Classes/MapboxMapFactory.swift
@@ -7,6 +7,11 @@ class MapboxMapFactory: NSObject, FlutterPlatformViewFactory {
 
     init(withRegistrar registrar: FlutterPluginRegistrar) {
         self.registrar = registrar
+
+        // Register MapboxMapsOptions and MapboxOptions
+        let mapboxOptionsController = MapboxOptionsController()
+        FLT_MapboxOptionsSetup(registrar.messenger(), mapboxOptionsController)
+        FLT_MapboxMapsOptionsSetup(registrar.messenger(), mapboxOptionsController)
     }
 
     func createArgsCodec() -> FlutterMessageCodec & NSObjectProtocol {
@@ -108,8 +113,16 @@ class MapboxMapFactory: NSObject, FlutterPlatformViewFactory {
         return cameraOptions
     }
 
-    func create(withFrame frame: CGRect, viewIdentifier viewId: Int64,
-                arguments args: Any?) -> FlutterPlatformView {
+    func create(
+        withFrame frame: CGRect,
+        viewIdentifier viewId: Int64,
+        arguments args: Any?
+    ) -> FlutterPlatformView {
+
+        let mapboxOptionsController = MapboxOptionsController()
+        FLT_MapboxOptionsSetup(registrar.messenger(), mapboxOptionsController)
+        FLT_MapboxMapsOptionsSetup(registrar.messenger(), mapboxOptionsController)
+
         var mapInitOptions = MapInitOptions()
         var eventTypes = [Int]()
         var pluginVersion = ""

--- a/ios/Classes/MapboxMapFactory.swift
+++ b/ios/Classes/MapboxMapFactory.swift
@@ -107,6 +107,7 @@ class MapboxMapFactory: NSObject, FlutterPlatformViewFactory {
         }
         return cameraOptions
     }
+
     func create(withFrame frame: CGRect, viewIdentifier viewId: Int64,
                 arguments args: Any?) -> FlutterPlatformView {
         var mapInitOptions = MapInitOptions()
@@ -132,9 +133,11 @@ class MapboxMapFactory: NSObject, FlutterPlatformViewFactory {
         if let types = args["eventTypes"] as? [Int] {
             eventTypes = types
         }
-        mapInitOptions = MapInitOptions(mapOptions: createMapOptions(args: args),
-                                        cameraOptions: createCameraOptions(args: args),
-                                        styleURI: styleURI
+
+        mapInitOptions = MapInitOptions(
+            mapOptions: createMapOptions(args: args),
+            cameraOptions: createCameraOptions(args: args),
+            styleURI: styleURI
         )
 
         if let version = args["mapboxPluginVersion"] as? String {

--- a/ios/Classes/MapboxOptionsController.swift
+++ b/ios/Classes/MapboxOptionsController.swift
@@ -1,0 +1,62 @@
+import MapboxMaps
+import MapboxCommon
+
+final class MapboxOptionsController: NSObject, FLT_MapboxOptions, FLT_MapboxMapsOptions {
+    private static let errorCode = "0"
+
+    func getBaseUrlWithError(_ error: AutoreleasingUnsafeMutablePointer<FlutterError?>) -> String? {
+        MapboxMapsOptions.baseURL.absoluteString
+    }
+
+    func setBaseUrlUrl(_ url: String, error: AutoreleasingUnsafeMutablePointer<FlutterError?>) {
+        guard let url = URL(string: url) else {
+            error.pointee = FlutterError(code: MapboxOptionsController.errorCode, message: "Invalid url", details: nil)
+            return
+        }
+        MapboxMapsOptions.baseURL = url
+    }
+
+    func getDataPathWithError(_ error: AutoreleasingUnsafeMutablePointer<FlutterError?>) -> String? {
+        MapboxMapsOptions.dataPath.absoluteString
+    }
+
+    func setDataPathPath(_ path: String, error: AutoreleasingUnsafeMutablePointer<FlutterError?>) {
+        guard let url = URL(string: path) else {
+            error.pointee = FlutterError(code: MapboxOptionsController.errorCode, message: "Invalid url", details: nil)
+            return
+        }
+        MapboxMapsOptions.dataPath = url
+    }
+
+    func getAssetPathWithError(_ error: AutoreleasingUnsafeMutablePointer<FlutterError?>) -> String? {
+        MapboxMapsOptions.assetPath.absoluteString
+    }
+
+    func setAssetPathPath(_ path: String, error: AutoreleasingUnsafeMutablePointer<FlutterError?>) {
+        guard let url = URL(string: path) else {
+            error.pointee = FlutterError(code: MapboxOptionsController.errorCode, message: "Invalid url", details: nil)
+            return
+        }
+        MapboxMapsOptions.assetPath = url
+    }
+
+    func getTileStoreUsageModeWithError(_ error: AutoreleasingUnsafeMutablePointer<FlutterError?>) -> FLTTileStoreUsageMode {
+        FLTTileStoreUsageMode(rawValue: UInt(MapboxMapsOptions.tileStoreUsageMode.rawValue))!
+    }
+
+    func setTileStoreUsageModeMode(_ mode: FLTTileStoreUsageMode, error: AutoreleasingUnsafeMutablePointer<FlutterError?>) {
+        guard let mode = TileStoreUsageMode(rawValue: Int(mode.rawValue)) else {
+            error.pointee = FlutterError(code: MapboxOptionsController.errorCode, message: "Invalid tile store usage mode", details: nil)
+            return
+        }
+        MapboxMapsOptions.tileStoreUsageMode = mode
+    }
+
+    func getAccessTokenWithError(_ error: AutoreleasingUnsafeMutablePointer<FlutterError?>) -> String? {
+        MapboxOptions.accessToken
+    }
+
+    func setAccessTokenToken(_ token: String, error: AutoreleasingUnsafeMutablePointer<FlutterError?>) {
+        MapboxOptions.accessToken = token
+    }
+}

--- a/ios/Classes/StyleController.swift
+++ b/ios/Classes/StyleController.swift
@@ -2,7 +2,7 @@ import MapboxMaps
 import UIKit
 
 final class StyleController: NSObject, FLTStyleManager {
-    
+
     // MARK: -
     private let styleManager: StyleManager
     init(styleManager: StyleManager) {
@@ -407,7 +407,7 @@ final class StyleController: NSObject, FLTStyleManager {
         }
     }
 
-    func getStyleImportConfigPropertiesImportId(_ importId: String, error: AutoreleasingUnsafeMutablePointer<FlutterError?>) -> [String : FLTStylePropertyValue]? {
+    func getStyleImportConfigPropertiesImportId(_ importId: String, error: AutoreleasingUnsafeMutablePointer<FlutterError?>) -> [String: FLTStylePropertyValue]? {
         do {
             let styleImportsConfig = try styleManager.getStyleImportConfigProperties(for: importId)
             return styleImportsConfig.reduce(into: [:]) { partialResult, pair in
@@ -430,7 +430,7 @@ final class StyleController: NSObject, FLTStyleManager {
         }
     }
 
-    func setStyleImportConfigPropertiesImportId(_ importId: String, configs: [String : Any], error: AutoreleasingUnsafeMutablePointer<FlutterError?>) {
+    func setStyleImportConfigPropertiesImportId(_ importId: String, configs: [String: Any], error: AutoreleasingUnsafeMutablePointer<FlutterError?>) {
         do {
             try styleManager.setStyleImportConfigProperties(for: importId, configs: configs)
         } catch let styleError {

--- a/ios/Classes/StyleController.swift
+++ b/ios/Classes/StyleController.swift
@@ -1,45 +1,45 @@
-import Foundation
 import MapboxMaps
 import UIKit
 
-class StyleController: NSObject, FLTStyleManager {
-
-    private var mapboxMap: MapboxMap
-    init(withMapboxMap mapboxMap: MapboxMap) {
-        self.mapboxMap = mapboxMap
+final class StyleController: NSObject, FLTStyleManager {
+    
+    // MARK: -
+    private let styleManager: StyleManager
+    init(styleManager: StyleManager) {
+        self.styleManager = styleManager
     }
     func getStyleURI(completion: @escaping (String?, FlutterError?) -> Void) {
-        completion(mapboxMap.style.uri?.rawValue, nil)
+        completion(styleManager.uri?.rawValue, nil)
     }
 
     func setStyleURIUri(_ uri: String, completion: @escaping (FlutterError?) -> Void) {
-        mapboxMap.style.uri = StyleURI(rawValue: uri)
+        styleManager.uri = StyleURI(rawValue: uri)
         completion(nil)
     }
 
     func getStyleJSON(completion: @escaping (String?, FlutterError?) -> Void) {
-        completion(mapboxMap.style.JSON, nil)
+        completion(styleManager.JSON, nil)
     }
 
     func setStyleJSONJson(_ json: String, completion: @escaping (FlutterError?) -> Void) {
-        mapboxMap.style.JSON = json
+        styleManager.JSON = json
         completion(nil)
     }
 
     func getStyleDefaultCamera(completion: @escaping (FLTCameraOptions?, FlutterError?) -> Void) {
-        let camera = mapboxMap.style.defaultCamera
+        let camera = styleManager.defaultCamera
         completion(camera.toFLTCameraOptions(), nil)
     }
 
     func getStyleTransition(completion: @escaping (FLTTransitionOptions?, FlutterError?) -> Void) {
-        let transition = mapboxMap.style.transition
+        let transition = styleManager.transition
         completion(transition.toFLTTransitionOptions(), nil)
 
     }
 
     func setStyleTransitionTransitionOptions(_ transitionOptions: FLTTransitionOptions,
                                              completion: @escaping (FlutterError?) -> Void) {
-        mapboxMap.style.transition = transitionOptions.toTransitionOptions()
+        styleManager.transition = transitionOptions.toTransitionOptions()
         completion(nil)
     }
 
@@ -47,7 +47,7 @@ class StyleController: NSObject, FLTStyleManager {
                                  completion: @escaping (FlutterError?) -> Void) {
         do {
             let layerProperties: [String: Any] = convertStringToDictionary(properties: properties)
-            try mapboxMap.style.addLayer(with: layerProperties, layerPosition: layerPosition?.toLayerPosition())
+            try styleManager.addLayer(with: layerProperties, layerPosition: layerPosition?.toLayerPosition())
             completion(nil)
         } catch {
             completion(FlutterError(code: StyleController.errorCode, message: "\(error)", details: nil))
@@ -57,7 +57,7 @@ class StyleController: NSObject, FLTStyleManager {
     func addPersistentStyleLayerProperties(_ properties: String, layerPosition: FLTLayerPosition?,
                                            completion: @escaping (FlutterError?) -> Void) {
         do {
-            try mapboxMap.style
+            try styleManager.style
                 .addPersistentLayer(
                     with: convertStringToDictionary(properties: properties),
                     layerPosition: layerPosition?.toLayerPosition()
@@ -71,7 +71,7 @@ class StyleController: NSObject, FLTStyleManager {
     func isStyleLayerPersistentLayerId(_ layerId: String,
                                        completion: @escaping (NSNumber?, FlutterError?) -> Void) {
         do {
-            let isPersistent = try mapboxMap.style.isPersistentLayer(id: layerId)
+            let isPersistent = try styleManager.isPersistentLayer(id: layerId)
             completion(NSNumber(value: isPersistent), nil)
         } catch {
             completion(nil, FlutterError(code: "\(error)", message: nil, details: nil))
@@ -80,7 +80,7 @@ class StyleController: NSObject, FLTStyleManager {
 
     func removeStyleLayerLayerId(_ layerId: String, completion: @escaping (FlutterError?) -> Void) {
         do {
-            try mapboxMap.style.removeLayer(withId: layerId)
+            try styleManager.removeLayer(withId: layerId)
             completion(nil)
         } catch {
             completion(FlutterError(code: StyleController.errorCode, message: "\(error)", details: nil))
@@ -91,9 +91,9 @@ class StyleController: NSObject, FLTStyleManager {
                                completion: @escaping (FlutterError?) -> Void) {
         do {
             if layerPosition != nil {
-                try mapboxMap.style.moveLayer(withId: layerId, to: layerPosition!.toLayerPosition())
+                try styleManager.moveLayer(withId: layerId, to: layerPosition!.toLayerPosition())
             } else {
-                try mapboxMap.style.moveLayer(withId: layerId, to: LayerPosition.default)
+                try styleManager.moveLayer(withId: layerId, to: LayerPosition.default)
             }
             completion(nil)
         } catch {
@@ -103,12 +103,12 @@ class StyleController: NSObject, FLTStyleManager {
 
     func styleLayerExistsLayerId(_ layerId: String,
                                  completion: @escaping (NSNumber?, FlutterError?) -> Void) {
-        let existes = mapboxMap.style.layerExists(withId: layerId)
+        let existes = styleManager.layerExists(withId: layerId)
         completion(NSNumber(value: existes), nil)
     }
 
     func getStyleLayers(completion: @escaping ([FLTStyleObjectInfo]?, FlutterError?) -> Void) {
-        let layerInfos = mapboxMap.style.allLayerIdentifiers.map {
+        let layerInfos = styleManager.allLayerIdentifiers.map {
             FLTStyleObjectInfo.make(withId: $0.id as String, type: $0.type.rawValue)
         }
         completion(layerInfos, nil)
@@ -118,7 +118,7 @@ class StyleController: NSObject, FLTStyleManager {
                                       property: String,
                                       completion: @escaping (FLTStylePropertyValue?,
                                                              FlutterError?) -> Void) {
-        let layerProperty = mapboxMap.style.layerProperty(for: layerId, property: property)
+        let layerProperty = styleManager.layerProperty(for: layerId, property: property)
         completion(layerProperty.toFLTStylePropertyValue(property: property), nil)
     }
 
@@ -136,7 +136,7 @@ class StyleController: NSObject, FLTStyleManager {
                     }
                 }
             }
-            try mapboxMap.style.setLayerProperty(for: layerId, property: property, value: mappedValue)
+            try styleManager.setLayerProperty(for: layerId, property: property, value: mappedValue)
             completion(nil)
         } catch {
             completion(FlutterError(code: StyleController.errorCode, message: "\(error)", details: nil))
@@ -146,7 +146,7 @@ class StyleController: NSObject, FLTStyleManager {
     func getStyleLayerPropertiesLayerId(_ layerId: String,
                                         completion: @escaping (String?, FlutterError?) -> Void) {
         do {
-            let properties = try mapboxMap.style.layerProperties(for: layerId)
+            let properties = try styleManager.layerProperties(for: layerId)
             completion(convertDictionaryToString(dict: properties), nil)
         } catch {
             completion(nil, FlutterError(code: "\(error)", message: nil, details: nil))
@@ -158,7 +158,7 @@ class StyleController: NSObject, FLTStyleManager {
         let data = properties.data(using: String.Encoding.utf8)!
         let jsonObject = try? JSONSerialization.jsonObject(with: data, options: [])
         do {
-            try mapboxMap.style.setLayerProperties(for: layerId, properties: jsonObject as? [String: Any] ?? [:])
+            try styleManager.setLayerProperties(for: layerId, properties: jsonObject as? [String: Any] ?? [:])
             completion(nil)
         } catch {
             completion(FlutterError(code: StyleController.errorCode, message: "\(error)", details: nil))
@@ -168,7 +168,7 @@ class StyleController: NSObject, FLTStyleManager {
     func addStyleSourceSourceId(_ sourceId: String, properties: String,
                                 completion: @escaping (FlutterError?) -> Void) {
         do {
-            try mapboxMap.style.addSource(withId: sourceId,
+            try styleManager.addSource(withId: sourceId,
                                           properties: convertStringToDictionary(properties: properties))
             completion(nil)
         } catch {
@@ -178,14 +178,14 @@ class StyleController: NSObject, FLTStyleManager {
 
     func getStyleSourcePropertySourceId(_ sourceId: String, property: String,
                                         completion: @escaping (FLTStylePropertyValue?, FlutterError?) -> Void) {
-        let sourceProperty = mapboxMap.style.sourceProperty(for: sourceId, property: property)
+        let sourceProperty = styleManager.sourceProperty(for: sourceId, property: property)
         completion(sourceProperty.toFLTStylePropertyValue(property: property), nil)
     }
 
     func setStyleSourcePropertySourceId(_ sourceId: String, property: String,
                                         value: Any, completion: @escaping (FlutterError?) -> Void) {
         do {
-            try mapboxMap.style.setSourceProperty(for: sourceId, property: property, value: value)
+            try styleManager.setSourceProperty(for: sourceId, property: property, value: value)
             completion(nil)
         } catch {
             completion(FlutterError(code: StyleController.errorCode, message: "\(error)", details: nil))
@@ -195,7 +195,7 @@ class StyleController: NSObject, FLTStyleManager {
     func getStyleSourcePropertiesSourceId(_ sourceId: String,
                                           completion: @escaping (String?, FlutterError?) -> Void) {
         do {
-            let properties = try mapboxMap.style.sourceProperties(for: sourceId)
+            let properties = try styleManager.sourceProperties(for: sourceId)
             completion(convertDictionaryToString(dict: properties), nil)
         } catch {
             completion(nil, FlutterError(code: "\(error)", message: nil, details: nil))
@@ -205,7 +205,7 @@ class StyleController: NSObject, FLTStyleManager {
     func setStyleSourcePropertiesSourceId(_ sourceId: String, properties: String,
                                           completion: @escaping (FlutterError?) -> Void) {
         do {
-            try mapboxMap.style.setSourceProperties(for: sourceId,
+            try styleManager.setSourceProperties(for: sourceId,
                                                        properties: convertStringToDictionary(properties: properties))
             completion(nil)
         } catch {
@@ -217,7 +217,7 @@ class StyleController: NSObject, FLTStyleManager {
                                              completion: @escaping (FlutterError?) -> Void) {
         guard let image = UIImage(data: image.data.data, scale: UIScreen.main.scale) else { return }
         do {
-            try mapboxMap.style.updateImageSource(withId: sourceId, image: image)
+            try styleManager.updateImageSource(withId: sourceId, image: image)
             completion(nil)
         } catch {
             completion(FlutterError(code: StyleController.errorCode, message: "\(error)", details: nil))
@@ -226,7 +226,7 @@ class StyleController: NSObject, FLTStyleManager {
 
     func removeStyleSourceSourceId(_ sourceId: String, completion: @escaping (FlutterError?) -> Void) {
         do {
-            try mapboxMap.style.removeSource(withId: sourceId)
+            try styleManager.removeSource(withId: sourceId)
             completion(nil)
         } catch {
             completion(FlutterError(code: StyleController.errorCode, message: "\(error)", details: nil))
@@ -234,12 +234,12 @@ class StyleController: NSObject, FLTStyleManager {
     }
 
     func styleSourceExistsSourceId(_ sourceId: String, completion: @escaping (NSNumber?, FlutterError?) -> Void) {
-        let existes = mapboxMap.style.sourceExists(withId: sourceId)
+        let existes = styleManager.sourceExists(withId: sourceId)
         completion(NSNumber(value: existes), nil)
     }
 
     func getStyleSources(completion: @escaping ([FLTStyleObjectInfo]?, FlutterError?) -> Void) {
-        let sourcesInfos = mapboxMap.style.allSourceIdentifiers.map {
+        let sourcesInfos = styleManager.allSourceIdentifiers.map {
             FLTStyleObjectInfo.make(withId: $0.id as String, type: $0.type.rawValue)
         }
         completion(sourcesInfos, nil)
@@ -249,7 +249,7 @@ class StyleController: NSObject, FLTStyleManager {
         let data = properties.data(using: String.Encoding.utf8)!
         let jsonObject = try? JSONSerialization.jsonObject(with: data, options: [])
         do {
-            try mapboxMap.style.setLight(properties: jsonObject as? [String: Any] ?? [:])
+            try styleManager.setLight(properties: jsonObject as? [String: Any] ?? [:])
             completion(nil)
         } catch {
             completion(FlutterError(code: StyleController.errorCode, message: "\(error)", details: nil))
@@ -258,14 +258,14 @@ class StyleController: NSObject, FLTStyleManager {
 
     func getStyleLightPropertyProperty(_ property: String,
                                        completion: @escaping (FLTStylePropertyValue?, FlutterError?) -> Void) {
-        let lightProperty: StylePropertyValue = mapboxMap.style.lightProperty(property)
+        let lightProperty: StylePropertyValue = styleManager.lightProperty(property)
         completion(lightProperty.toFLTStylePropertyValue(property: property), nil)
     }
 
     func setStyleLightPropertyProperty(_ property: String, value: Any,
                                        completion: @escaping (FlutterError?) -> Void) {
         do {
-            try mapboxMap.style.setLightProperty(property, value: value)
+            try styleManager.setLightProperty(property, value: value)
             completion(nil)
         } catch {
             completion(FlutterError(code: StyleController.errorCode, message: "\(error)", details: nil))
@@ -276,7 +276,7 @@ class StyleController: NSObject, FLTStyleManager {
         let data = properties.data(using: String.Encoding.utf8)!
         let jsonObject = try? JSONSerialization.jsonObject(with: data, options: [])
         do {
-            try mapboxMap.style.setTerrain(properties: jsonObject as? [String: Any] ?? [:])
+            try styleManager.setTerrain(properties: jsonObject as? [String: Any] ?? [:])
             completion(nil)
         } catch {
             completion(FlutterError(code: StyleController.errorCode, message: "\(error)", details: nil))
@@ -285,14 +285,14 @@ class StyleController: NSObject, FLTStyleManager {
 
     func getStyleTerrainPropertyProperty(_ property: String,
                                          completion: @escaping (FLTStylePropertyValue?, FlutterError?) -> Void) {
-        let terrainProperty: StylePropertyValue = mapboxMap.style.terrainProperty(property)
+        let terrainProperty: StylePropertyValue = styleManager.terrainProperty(property)
         completion(terrainProperty.toFLTStylePropertyValue(property: property), nil)
     }
 
     func setStyleTerrainPropertyProperty(_ property: String, value: Any,
                                          completion: @escaping (FlutterError?) -> Void) {
         do {
-            try mapboxMap.style.setTerrainProperty(property, value: value)
+            try styleManager.setTerrainProperty(property, value: value)
             completion(nil)
         } catch {
             completion(FlutterError(code: StyleController.errorCode, message: "\(error)", details: nil))
@@ -300,7 +300,7 @@ class StyleController: NSObject, FLTStyleManager {
     }
 
     func getStyleImageImageId(_ imageId: String, completion: @escaping (FLTMbxImage?, FlutterError?) -> Void) {
-        guard let image = mapboxMap.style.image(withId: imageId) else {
+        guard let image = styleManager.image(withId: imageId) else {
             completion(nil, nil)
             return
         }
@@ -328,7 +328,7 @@ class StyleController: NSObject, FLTStyleManager {
                                         bottom: Float(truncating: content!.bottom))
         }
         do {
-            try mapboxMap.style.addImage(image,
+            try styleManager.addImage(image,
                                          id: imageId,
                                          sdf: sdf as? Bool ?? false,
                                          stretchX: stretchX.map {
@@ -345,7 +345,7 @@ class StyleController: NSObject, FLTStyleManager {
 
     func removeStyleImageImageId(_ imageId: String, completion: @escaping (FlutterError?) -> Void) {
         do {
-            try mapboxMap.style.removeImage(withId: imageId)
+            try styleManager.removeImage(withId: imageId)
             completion(nil)
         } catch {
             completion(FlutterError(code: StyleController.errorCode, message: "\(error)", details: nil))
@@ -353,7 +353,7 @@ class StyleController: NSObject, FLTStyleManager {
     }
 
     func hasStyleImageImageId(_ imageId: String, completion: @escaping (NSNumber?, FlutterError?) -> Void) {
-        let image = mapboxMap.style.image(withId: imageId)
+        let image = styleManager.image(withId: imageId)
         completion(NSNumber(value: image != nil), nil)
     }
 //
@@ -381,7 +381,7 @@ class StyleController: NSObject, FLTStyleManager {
                                                          tileId: FLTCanonicalTileID,
                                                          completion: @escaping (FlutterError?) -> Void) {
         do {
-            try mapboxMap.style.invalidateCustomGeometrySourceTile(forSourceId: sourceId,
+            try styleManager.invalidateCustomGeometrySourceTile(forSourceId: sourceId,
                                                                    tileId: tileId.toCanonicalTileID())
             completion(nil)
         } catch {
@@ -393,7 +393,7 @@ class StyleController: NSObject, FLTStyleManager {
                                                            bounds: FLTCoordinateBounds,
                                                            completion: @escaping (FlutterError?) -> Void) {
         do {
-            try mapboxMap.style.invalidateCustomGeometrySourceRegion(forSourceId: sourceId,
+            try styleManager.invalidateCustomGeometrySourceRegion(forSourceId: sourceId,
                                                                      bounds: bounds.toCoordinateBounds())
             completion(nil)
         } catch {
@@ -402,22 +402,118 @@ class StyleController: NSObject, FLTStyleManager {
     }
 
     func isStyleLoaded(completion: @escaping (NSNumber?, FlutterError?) -> Void) {
-        completion(NSNumber(value: (mapboxMap.style.isLoaded)), nil)
+        completion(NSNumber(value: (styleManager.isLoaded)), nil)
     }
 
     func getProjectionWithCompletion(_ completion: @escaping (String?, FlutterError?) -> Void) {
-        completion(mapboxMap.style.projection.name.rawValue, nil)
+        completion(styleManager.projection.name.rawValue, nil)
     }
 
     func setProjectionProjection(_ projection: String, completion: @escaping (FlutterError?) -> Void) {
-        try! mapboxMap.style.setProjection(projection == "globe" ? StyleProjection(name: StyleProjectionName.globe) : StyleProjection(name: StyleProjectionName.mercator))
+        try! styleManager.setProjection(projection == "globe" ? StyleProjection(name: StyleProjectionName.globe) : StyleProjection(name: StyleProjectionName.mercator))
         completion(nil)
     }
 
     func localizeLabelsLocale(_ locale: String, layerIds: [String]?, completion: @escaping (FlutterError?) -> Void) {
-        try! mapboxMap.style.localizeLabels(into: Locale(identifier: locale), forLayerIds: layerIds)
+        try! styleManager.localizeLabels(into: Locale(identifier: locale), forLayerIds: layerIds)
         completion(nil)
     }
 
     private static let errorCode = "0"
+
+    // MARK: Style Imports
+
+    func getStyleImportsWithError(_ error: AutoreleasingUnsafeMutablePointer<FlutterError?>) -> [FLTStyleObjectInfo]? {
+        styleManager.styleImports.map { FLTStyleObjectInfo.make(withId: $0.id, type: $0.type) }
+    }
+
+    func removeStyleImportImportId(_ importId: String, error: AutoreleasingUnsafeMutablePointer<FlutterError?>) {
+        do {
+            try styleManager.removeStyleImport(for: importId)
+        } catch let styleError {
+            error.pointee = FlutterError(code: StyleController.errorCode, message: styleError.localizedDescription, details: nil)
+        }
+    }
+
+    func getStyleImportSchemaImportId(_ importId: String, error: AutoreleasingUnsafeMutablePointer<FlutterError?>) -> Any? {
+        do {
+            return try styleManager.getStyleImportSchema(for: importId)
+        } catch let styleError {
+            error.pointee = FlutterError(code: StyleController.errorCode, message: styleError.localizedDescription, details: nil)
+            return nil
+        }
+    }
+
+    func getStyleImportConfigPropertiesImportId(_ importId: String, error: AutoreleasingUnsafeMutablePointer<FlutterError?>) -> [String : FLTStylePropertyValue]? {
+        do {
+            let styleImportsConfig = try styleManager.getStyleImportConfigProperties(for: importId)
+            return styleImportsConfig.map { ($0, $1.toFLTStylePropertyValue(property: $0)) }
+        } catch let styleError {
+            error.pointee = FlutterError(code: StyleController.errorCode, message: styleError.localizedDescription, details: nil)
+            return nil
+        }
+    }
+
+    func getStyleImportConfigPropertyImportId(_ importId: String, config: String, error: AutoreleasingUnsafeMutablePointer<FlutterError?>) -> FLTStylePropertyValue? {
+        do {
+            let value = try styleManager.getStyleImportConfigProperty(for: importId, config: config)
+            return value.toFLTStylePropertyValue(property: config)
+        } catch let styleError {
+            error.pointee = FlutterError(code: StyleController.errorCode, message: styleError.localizedDescription, details: nil)
+            return nil
+        }
+    }
+
+    func setStyleImportConfigPropertiesImportId(_ importId: String, configs: [String : Any], error: AutoreleasingUnsafeMutablePointer<FlutterError?>) {
+        do {
+            try styleManager.setStyleImportConfigProperties(for: importId, configs: configs)
+        } catch let styleError {
+            error.pointee = FlutterError(code: StyleController.errorCode, message: styleError.localizedDescription, details: nil)
+        }
+    }
+
+    func setStyleImportConfigPropertyImportId(_ importId: String, config: String, value: Any, error: AutoreleasingUnsafeMutablePointer<FlutterError?>) {
+        do {
+            try styleManager.setStyleImportConfigProperty(for: importId, config: config, value: value)
+        } catch let styleError {
+            error.pointee = FlutterError(code: StyleController.errorCode, message: styleError.localizedDescription, details: nil)
+        }
+    }
+
+    // MARK: Style Lights
+
+    func getStyleLightsWithError(_ error: AutoreleasingUnsafeMutablePointer<FlutterError?>) -> [FLTStyleObjectInfo]? {
+        fatalError()
+    }
+
+    func setLightFlatLight(_ flatLight: FLTFlatLight, error: AutoreleasingUnsafeMutablePointer<FlutterError?>) {
+        fatalError()
+    }
+
+    func setLightsAmbientLight(_ ambientLight: FLTAmbientLight, directionalLight: FLTDirectionalLight, error: AutoreleasingUnsafeMutablePointer<FlutterError?>) {
+        fatalError()
+    }
+
+    func getStyleLightPropertyId(_ id: String, property: String, completion: @escaping (FLTStylePropertyValue?, FlutterError?) -> Void) {
+        fatalError()
+    }
+
+    func setStyleLightPropertyId(_ id: String, property: String, value: Any, completion: @escaping (FlutterError?) -> Void) {
+        fatalError()
+    }
+
+    // MARK: Style Projection
+
+    func getProjectionWithError(_ error: AutoreleasingUnsafeMutablePointer<FlutterError?>) -> FLTStyleProjection? {
+        guard let projection = styleManager.projection else { return nil }
+        return projection.toFLTStyleProjection()
+    }
+
+    func setProjectionProjection(_ projection: FLTStyleProjection, error: AutoreleasingUnsafeMutablePointer<FlutterError?>) {
+        do {
+            try styleManager.setProjection(StyleProjection(name: StyleProjectionName(projection.name)))
+        } catch let styleError {
+            error.pointee = FlutterError(code: StyleController.errorCode, message: styleError.localizedDescription, details: nil)
+        }
+    }
 }

--- a/ios/mapbox_maps_flutter.podspec
+++ b/ios/mapbox_maps_flutter.podspec
@@ -20,5 +20,5 @@ Pod::Spec.new do |s|
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
-  s.swift_version = '5.3'
+  s.swift_version = '5.7'
 end

--- a/lib/src/events.dart
+++ b/lib/src/events.dart
@@ -111,7 +111,7 @@ class MapLoadedEventData {
   final EventTimeInterval timeInterval;
 
   MapLoadedEventData.fromJson(Map<String, dynamic> json)
-      : timeInterval = EventTimeInterval.fromJson(json['timeInteval']);
+      : timeInterval = EventTimeInterval.fromJson(json['timeInterval']);
 }
 
 /// The class for map-loading-error event in Observer
@@ -134,7 +134,7 @@ class MapLoadingErrorEventData {
   MapLoadingErrorEventData.fromJson(Map<String, dynamic> json)
       : type = MapLoadErrorType.values[json['type']],
         message = json['message'],
-        sourceId = json['source-id'],
+        sourceId = json['sourceId'],
         tileId =
             json['tileId'] != null ? TileID.fromJson(json['tileId']) : null,
         timestamp = json['timestamp'];
@@ -156,7 +156,7 @@ class RenderFrameFinishedEventData {
   final bool placementChanged;
 
   RenderFrameFinishedEventData.fromJson(Map<String, dynamic> json)
-      : timeInterval = json['timeInterval'],
+      : timeInterval = EventTimeInterval.fromJson(json['timeInterval']),
         renderMode = RenderMode.values[json['renderMode']],
         placementChanged = json['placementChanged'],
         needsRepaint = json['needsRepaint'];
@@ -203,7 +203,7 @@ class ResourceEventData {
 
   ResourceEventData.fromJson(Map<String, dynamic> json)
       : timeInterval = EventTimeInterval.fromJson(json['timeInterval']),
-        dataSource = DataSourceType.values[json['dataSource']],
+        dataSource = DataSourceType.values[json['source']],
         request = Request.fromJson(json['request']),
         response = json['response'] != null
             ? Response.fromJson(json['response'])

--- a/lib/src/events.dart
+++ b/lib/src/events.dart
@@ -75,15 +75,15 @@ part of mapbox_maps_flutter;
 /// the time required to dispatch an event.
 class EventTimeInterval {
   /// Representing timestamp taken at the time of an event creation; in microseconds; since the epoch.
-  final int begin;
+  final DateTime begin;
 
   /// For an interfinal events; an optional `end` property will be present that represents timestamp taken at the time
   /// of an event completion.
-  final int end;
+  final DateTime end;
 
   EventTimeInterval.fromJson(Map<String, dynamic> json)
-      : begin = json['begin'],
-        end = json['end'];
+      : begin = DateTime.fromMicrosecondsSinceEpoch(json['begin']),
+        end = DateTime.fromMicrosecondsSinceEpoch(json['end']);
 }
 
 /// The class for camera-changed event in Observer

--- a/lib/src/mapbox_map.dart
+++ b/lib/src/mapbox_map.dart
@@ -198,8 +198,8 @@ class MapboxMap extends ChangeNotifier {
 
   /// Convenience method that returns the `camera options` object for given parameters.
   Future<CameraOptions> cameraForCoordinateBounds(CoordinateBounds bounds,
-          MbxEdgeInsets padding, double? bearing, double? pitch) =>
-      _cameraManager.cameraForCoordinateBounds(bounds, padding, bearing, pitch);
+          MbxEdgeInsets padding, double? bearing, double? pitch, double? maxZoom, ScreenCoordinate? offset) =>
+      _cameraManager.cameraForCoordinateBounds(bounds, padding, bearing, pitch, maxZoom, offset);
 
   /// Convenience method that returns the `camera options` object for given parameters.
   Future<CameraOptions> cameraForCoordinates(
@@ -307,11 +307,6 @@ class MapboxMap extends ChangeNotifier {
 
   /// Returns the `camera bounds` of the map.
   Future<CameraBounds> getBounds() => _cameraManager.getBounds();
-
-  /// Calculates target point where camera should move after drag. The method should be called after `dragStart` and before `dragEnd`.
-  Future<CameraOptions> cameraForDrag(
-          ScreenCoordinate fromPoint, ScreenCoordinate toPoint) =>
-      _cameraManager.cameraForDrag(fromPoint, toPoint);
 
   /// Gets the size of the map.
   /// Note : not supported for iOS.

--- a/lib/src/pigeons/gesture_listeners.dart
+++ b/lib/src/pigeons/gesture_listeners.dart
@@ -1,5 +1,6 @@
 part of mapbox_maps_flutter;
 
+
 class _GestureListenerCodec extends StandardMessageCodec {
   const _GestureListenerCodec();
   @override

--- a/lib/src/pigeons/map_interfaces.dart
+++ b/lib/src/pigeons/map_interfaces.dart
@@ -2949,41 +2949,6 @@ class _CameraManager {
       return (replyList[0] as CameraBounds?)!;
     }
   }
-
-  /// Calculates target point where camera should move after drag. The method should be called after `dragStart` and before `dragEnd`.
-  ///
-  /// @param fromPoint The `screen coordinate` to drag the map from, measured in `logical pixels` from top to bottom and from left to right.
-  /// @param toPoint The `screen coordinate` to drag the map to, measured in `logical pixels` from top to bottom and from left to right.
-  ///
-  /// @return The `camera options` object showing the end point.
-  Future<CameraOptions> cameraForDrag(
-      ScreenCoordinate arg_fromPoint, ScreenCoordinate arg_toPoint) async {
-    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.mapbox_maps_flutter._CameraManager.cameraForDrag',
-        codec,
-        binaryMessenger: _binaryMessenger);
-    final List<Object?>? replyList = await channel
-        .send(<Object?>[arg_fromPoint, arg_toPoint]) as List<Object?>?;
-    if (replyList == null) {
-      throw PlatformException(
-        code: 'channel-error',
-        message: 'Unable to establish connection on channel.',
-      );
-    } else if (replyList.length > 1) {
-      throw PlatformException(
-        code: replyList[0]! as String,
-        message: replyList[1] as String?,
-        details: replyList[2],
-      );
-    } else if (replyList[0] == null) {
-      throw PlatformException(
-        code: 'null-error',
-        message: 'Host platform returned null value for non-null return value.',
-      );
-    } else {
-      return (replyList[0] as CameraOptions?)!;
-    }
-  }
 }
 
 class __MapInterfaceCodec extends StandardMessageCodec {

--- a/lib/src/pigeons/map_interfaces.dart
+++ b/lib/src/pigeons/map_interfaces.dart
@@ -7198,34 +7198,6 @@ class StyleManager {
     }
   }
 
-  /// Sets the style global [light](https://docs.mapbox.com/mapbox-gl-js/style-spec/#light) properties.
-  ///
-  /// @param properties A map of style light properties values, with their names as a key.
-  ///
-  /// @return A string describing an error if the operation was not successful, empty otherwise.
-  Future<void> setStyleLight(String arg_properties) async {
-    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.mapbox_maps_flutter.StyleManager.setStyleLight',
-        codec,
-        binaryMessenger: _binaryMessenger);
-    final List<Object?>? replyList =
-        await channel.send(<Object?>[arg_properties]) as List<Object?>?;
-    if (replyList == null) {
-      throw PlatformException(
-        code: 'channel-error',
-        message: 'Unable to establish connection on channel.',
-      );
-    } else if (replyList.length > 1) {
-      throw PlatformException(
-        code: replyList[0]! as String,
-        message: replyList[1] as String?,
-        details: replyList[2],
-      );
-    } else {
-      return;
-    }
-  }
-
   /// Gets the value of a style light property.
   ///
   /// @param property The style light property name.

--- a/test/events_test.dart
+++ b/test/events_test.dart
@@ -82,11 +82,11 @@ void main() {
     var resourceEventData = ResourceEventData.fromJson(<String, dynamic>{
       'timeInterval': <String, dynamic>{'begin': 1, 'end': 2},
       'cancelled': false,
-      'data-source': 3,
+      'source': 3,
       'request': <String, dynamic>{
         'loading-method': [0],
         'url': 'https://api.mapbox.com',
-        'kind': 'tile',
+        'resource': 3,
         'priority': 0
       },
       'response': <String, dynamic>{
@@ -140,7 +140,7 @@ void main() {
       'sourceId': 'id',
       'type': 1,
       'loaded': false,
-      'tile-id': <String, dynamic>{'x': 1, 'y': 2, 'z': 3}
+      'tileId': <String, dynamic>{'x': 1, 'y': 2, 'z': 3}
     });
     expect(sourceDataLoadedEventData.timeInterval.begin, 1);
     expect(sourceDataLoadedEventData.timeInterval.end, 2);

--- a/test/events_test.dart
+++ b/test/events_test.dart
@@ -19,8 +19,8 @@ void main() {
         MapLoadedEventData.fromJson(<String, dynamic>{
           'timeInterval': <String, dynamic>{'begin': 1, 'end': 2}
           });
-    expect(mapLoadedEventData.timeInterval.begin, 1);
-    expect(mapLoadedEventData.timeInterval.end, 2);
+    expect(mapLoadedEventData.timeInterval.begin.microsecondsSinceEpoch, 1);
+    expect(mapLoadedEventData.timeInterval.end.microsecondsSinceEpoch, 2);
   });
 
   test('MapLoadingErrorEventData fromJson', () {
@@ -65,8 +65,8 @@ void main() {
       'placementChanged': true,
       'needsRepaint': false
     });
-    expect(renderFrameFinishedEventData.timeInterval.begin, 1);
-    expect(renderFrameFinishedEventData.timeInterval.end, 2);
+    expect(renderFrameFinishedEventData.timeInterval.begin.microsecondsSinceEpoch, 1);
+    expect(renderFrameFinishedEventData.timeInterval.end.microsecondsSinceEpoch, 2);
     expect(renderFrameFinishedEventData.renderMode, RenderMode.FULL);
     expect(renderFrameFinishedEventData.placementChanged, true);
     expect(renderFrameFinishedEventData.needsRepaint, false);
@@ -104,8 +104,8 @@ void main() {
         }
       }
     });
-    expect(resourceEventData.timeInterval.begin, 1);
-    expect(resourceEventData.timeInterval.end, 2);
+    expect(resourceEventData.timeInterval.begin.microsecondsSinceEpoch, 1);
+    expect(resourceEventData.timeInterval.end.microsecondsSinceEpoch, 2);
     expect(resourceEventData.cancelled, false);
     expect(resourceEventData.dataSource, DataSourceType.NETWORK);
     expect(resourceEventData.request.kind, RequestType.TILE);
@@ -142,8 +142,8 @@ void main() {
       'loaded': false,
       'tileId': <String, dynamic>{'x': 1, 'y': 2, 'z': 3}
     });
-    expect(sourceDataLoadedEventData.timeInterval.begin, 1);
-    expect(sourceDataLoadedEventData.timeInterval.end, 2);
+    expect(sourceDataLoadedEventData.timeInterval.begin.microsecondsSinceEpoch, 1);
+    expect(sourceDataLoadedEventData.timeInterval.end.microsecondsSinceEpoch, 2);
     expect(sourceDataLoadedEventData.id, 'id');
     expect(sourceDataLoadedEventData.type, SourceDataType.TILE);
     expect(sourceDataLoadedEventData.loaded, false);
@@ -164,7 +164,7 @@ void main() {
       'timeInterval': <String, dynamic>{'begin': 1, 'end': 2},
       'type': 0
     });
-    expect(styleDataLoadedEventData.timeInterval.begin, 1);
+    expect(styleDataLoadedEventData.timeInterval.begin.microsecondsSinceEpoch, 1);
     expect(styleDataLoadedEventData.type, StyleDataType.STYLE);
   });
 
@@ -187,7 +187,7 @@ void main() {
         <String, dynamic>{
           'timeInterval': <String, dynamic>{'begin': 1, 'end': 2}
         });
-    expect(styleLoadedEventData.timeInterval.begin, 1);
-    expect(styleLoadedEventData.timeInterval.end, 2);
+    expect(styleLoadedEventData.timeInterval.begin.microsecondsSinceEpoch, 1);
+    expect(styleLoadedEventData.timeInterval.end.microsecondsSinceEpoch, 2);
   });
 }


### PR DESCRIPTION
1fdd691652e9020c7bbaac946eacd6c1231072dd Convert `StyleColor` to integer representation. In v11, `StyleColor` supports RGB(A), HSL(A), hex, and a raw string as shown [here](https://docs.mapbox.com/style-spec/reference/types/#color) for a moment, we support HSL(A) and RGB(A) only.
49605d6f306f89569951871ec16653e47cf2943c Add conformers for `_MapboxOptions` and `_MapboxMapsOptions` that is responsible for managing access token and map's configuration (previously known as ResourceOptionsManager).

Upstream https://github.com/mapbox/mapbox-maps-flutter-internal/pull/126