### PR TITLE
Fix point annotation image disappearing after update on iOS

### DIFF
--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/annotation/PointAnnotationController.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/annotation/PointAnnotationController.kt
@@ -1,6 +1,7 @@
 // This file is generated.
 package com.mapbox.maps.mapbox_maps.annotation
 
+import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import com.mapbox.maps.extension.style.layers.properties.generated.*
 import com.mapbox.maps.mapbox_maps.toMap
@@ -35,6 +36,7 @@ import toTextPitchAlignment
 import toTextRotationAlignment
 import toTextTransform
 import toTextTranslateAnchor
+import java.io.ByteArrayOutputStream
 import java.util.*
 
 class PointAnnotationController(private val delegate: ControllerDelegate) :
@@ -811,6 +813,13 @@ fun PointAnnotation.toFLTPointAnnotation(): FLTPointAnnotationMessager.PointAnno
 
   this.geometry.let {
     builder.setGeometry(it.toMap())
+  }
+  this.iconImageBitmap?.let {
+    builder.setImage(
+      ByteArrayOutputStream().also { stream ->
+        it.compress(Bitmap.CompressFormat.PNG, 100, stream)
+      }.toByteArray()
+    )
   }
   this.iconAnchor?.let {
     builder.setIconAnchor(it.toFLTIconAnchor())

--- a/example/integration_test/annotations/point_annotation_test.dart
+++ b/example/integration_test/annotations/point_annotation_test.dart
@@ -1,5 +1,6 @@
 // This file is generated.
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
@@ -18,9 +19,13 @@ void main() {
     final mapboxMap = await mapFuture;
     final manager = await mapboxMap.annotations.createPointAnnotationManager();
     var geometry = Point(coordinates: Position(1.0, 2.0));
+    final ByteData bytes =
+        await rootBundle.load('assets/symbols/custom-icon.png');
+    final Uint8List imageData = bytes.buffer.asUint8List();
 
     var pointAnnotationOptions = PointAnnotationOptions(
       geometry: geometry.toJson(),
+      image: imageData,
       iconAnchor: IconAnchor.CENTER,
       iconImage: "abc",
       iconOffset: [0.0, 1.0],
@@ -58,6 +63,7 @@ void main() {
     var point = Point.fromJson((annotation.geometry)!.cast());
     expect(1.0, point.coordinates.lng);
     expect(2.0, point.coordinates.lat);
+    expect(annotation.image, isNotNull);
     expect(IconAnchor.CENTER, annotation.iconAnchor);
     expect("abc", annotation.iconImage);
     expect([0.0, 1.0], annotation.iconOffset);

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - Flutter (1.0.0)
   - integration_test (0.0.1):
     - Flutter
-  - mapbox_maps_flutter (0.5.0):
+  - mapbox_maps_flutter (1.0.0-beta.1):
     - Flutter
     - MapboxMaps (~> 11.0.0)
   - MapboxCommon (24.0.0)
@@ -42,7 +42,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   integration_test: 13825b8a9334a850581300559b8839134b124670
-  mapbox_maps_flutter: dc15c467501aef64bd70e341e6f6570fca7f7ca3
+  mapbox_maps_flutter: 826a6fda4a08984e997af720bf9d8310cde1e00f
   MapboxCommon: 0cca816960ad2d21c86e1d32435fcb412cfdcf4f
   MapboxCoreMaps: 633f5ecd7580a6d1342ff20cc8732170b2cd7ba3
   MapboxMaps: 1c219108691a2000cb842b02e64d82158d74e6cd

--- a/ios/Classes/PointAnnotationController.swift
+++ b/ios/Classes/PointAnnotationController.swift
@@ -842,7 +842,7 @@ extension FLTPointAnnotation {
     func toPointAnnotation() -> PointAnnotation {
                 var annotation = PointAnnotation(id: self.id, coordinate: convertDictionaryToCLLocationCoordinate2D(dict: self.geometry)!)
         if let image = self.image {
-            annotation.image = .init(image: UIImage(data: image.data, scale: UIScreen.main.scale)!, name: UUID().uuidString)
+            annotation.image = .init(image: UIImage(data: image.data, scale: UIScreen.main.scale)!, name: iconImage ?? UUID().uuidString)
         }
                 annotation.iconAnchor = iconAnchor.flatMap(IconAnchor.init)
         if let iconImage {
@@ -971,7 +971,7 @@ extension PointAnnotation {
         return FLTPointAnnotation.make(
             withId: id,
             geometry: geometry.toMap(),
-            image: nil,
+            image: image?.image.pngData().map(FlutterStandardTypedData.init(bytes:)),
             iconAnchor: iconAnchor,
             iconImage: iconImage,
             iconOffset: iconOffset,


### PR DESCRIPTION
There was an error in conversion from FLT annotation to the native one - image would always get assigned a new, random name. I fixed that, as well as added image bitmap to annotations created by annotation manager.

Addresses: https://github.com/mapbox/mapbox-maps-flutter/issues/241, https://github.com/mapbox/mapbox-maps-flutter/issues/166