### PR TITLE
Remove hardcoded delays from integration tests

### DIFF
--- a/example/integration_test/animation_test.dart
+++ b/example/integration_test/animation_test.dart
@@ -8,7 +8,6 @@ import 'package:mapbox_maps_example/empty_map_widget.dart' as app;
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-
   testWidgets('easeTo', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();

--- a/example/integration_test/animation_test.dart
+++ b/example/integration_test/animation_test.dart
@@ -8,9 +8,6 @@ import 'package:mapbox_maps_example/empty_map_widget.dart' as app;
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  Future<void> addDelay(int ms) async {
-    await Future<void>.delayed(Duration(milliseconds: ms));
-  }
 
   testWidgets('easeTo', (WidgetTester tester) async {
     final mapFuture = app.main();
@@ -29,7 +26,6 @@ void main() {
             bearing: 0,
             pitch: 3),
         MapAnimationOptions(duration: 2000, startDelay: 0));
-    await addDelay(1000);
   });
 
   testWidgets('flyTo', (WidgetTester tester) async {
@@ -49,7 +45,6 @@ void main() {
             bearing: 0,
             pitch: 3),
         MapAnimationOptions(duration: 2000, startDelay: 0));
-    await addDelay(1000);
   });
 
   if (Platform.isAndroid) {
@@ -104,6 +99,5 @@ void main() {
             pitch: 3),
         MapAnimationOptions(duration: 2000, startDelay: 0));
     mapboxMap.cancelCameraAnimation();
-    await addDelay(1000);
   });
 }

--- a/example/integration_test/annotations/circle_annotation_manager_test.dart
+++ b/example/integration_test/annotations/circle_annotation_manager_test.dart
@@ -8,16 +8,11 @@ import 'package:mapbox_maps_example/empty_map_widget.dart' as app;
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  Future<void> addDelay(int ms) async {
-    await Future<void>.delayed(Duration(milliseconds: ms));
-  }
-
   testWidgets('create CircleAnnotation_manager ', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();
     final mapboxMap = await mapFuture;
     final manager = await mapboxMap.annotations.createCircleAnnotationManager();
-    await addDelay(1000);
 
     await manager.setCircleEmissiveStrength(1.0);
     var circleEmissiveStrength = await manager.getCircleEmissiveStrength();
@@ -38,7 +33,6 @@ void main() {
     await manager.setCircleTranslateAnchor(CircleTranslateAnchor.MAP);
     var circleTranslateAnchor = await manager.getCircleTranslateAnchor();
     expect(CircleTranslateAnchor.MAP, circleTranslateAnchor);
-    await addDelay(1000);
   });
 }
 // End of generated file.

--- a/example/integration_test/annotations/circle_annotation_test.dart
+++ b/example/integration_test/annotations/circle_annotation_test.dart
@@ -8,10 +8,6 @@ import 'package:mapbox_maps_example/empty_map_widget.dart' as app;
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  Future<void> addDelay(int ms) async {
-    await Future<void>.delayed(Duration(milliseconds: ms));
-  }
-
   testWidgets('create CircleAnnotation', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();
@@ -69,7 +65,6 @@ void main() {
     }
 
     await manager.deleteAll();
-    await addDelay(1000);
   });
 }
 // End of generated file.

--- a/example/integration_test/annotations/point_annotation_manager_test.dart
+++ b/example/integration_test/annotations/point_annotation_manager_test.dart
@@ -8,16 +8,11 @@ import 'package:mapbox_maps_example/empty_map_widget.dart' as app;
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  Future<void> addDelay(int ms) async {
-    await Future<void>.delayed(Duration(milliseconds: ms));
-  }
-
   testWidgets('create PointAnnotation_manager ', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();
     final mapboxMap = await mapFuture;
     final manager = await mapboxMap.annotations.createPointAnnotationManager();
-    await addDelay(1000);
 
     await manager.setIconAllowOverlap(true);
     var iconAllowOverlap = await manager.getIconAllowOverlap();
@@ -118,7 +113,6 @@ void main() {
     await manager.setTextTranslateAnchor(TextTranslateAnchor.MAP);
     var textTranslateAnchor = await manager.getTextTranslateAnchor();
     expect(TextTranslateAnchor.MAP, textTranslateAnchor);
-    await addDelay(1000);
   });
 }
 // End of generated file.

--- a/example/integration_test/annotations/point_annotation_test.dart
+++ b/example/integration_test/annotations/point_annotation_test.dart
@@ -9,10 +9,6 @@ import 'package:mapbox_maps_example/empty_map_widget.dart' as app;
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  Future<void> addDelay(int ms) async {
-    await Future<void>.delayed(Duration(milliseconds: ms));
-  }
-
   testWidgets('create PointAnnotation', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();
@@ -122,7 +118,6 @@ void main() {
     }
 
     await manager.deleteAll();
-    await addDelay(1000);
   });
 }
 // End of generated file.

--- a/example/integration_test/annotations/polygon_annotation_manager_test.dart
+++ b/example/integration_test/annotations/polygon_annotation_manager_test.dart
@@ -8,17 +8,12 @@ import 'package:mapbox_maps_example/empty_map_widget.dart' as app;
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  Future<void> addDelay(int ms) async {
-    await Future<void>.delayed(Duration(milliseconds: ms));
-  }
-
   testWidgets('create PolygonAnnotation_manager ', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();
     final mapboxMap = await mapFuture;
     final manager =
         await mapboxMap.annotations.createPolygonAnnotationManager();
-    await addDelay(1000);
 
     await manager.setFillAntialias(true);
     var fillAntialias = await manager.getFillAntialias();
@@ -35,7 +30,6 @@ void main() {
     await manager.setFillTranslateAnchor(FillTranslateAnchor.MAP);
     var fillTranslateAnchor = await manager.getFillTranslateAnchor();
     expect(FillTranslateAnchor.MAP, fillTranslateAnchor);
-    await addDelay(1000);
   });
 }
 // End of generated file.

--- a/example/integration_test/annotations/polygon_annotation_test.dart
+++ b/example/integration_test/annotations/polygon_annotation_test.dart
@@ -8,10 +8,6 @@ import 'package:mapbox_maps_example/empty_map_widget.dart' as app;
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  Future<void> addDelay(int ms) async {
-    await Future<void>.delayed(Duration(milliseconds: ms));
-  }
-
   testWidgets('create PolygonAnnotation', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();
@@ -86,7 +82,6 @@ void main() {
     }
 
     await manager.deleteAll();
-    await addDelay(1000);
   });
 }
 // End of generated file.

--- a/example/integration_test/annotations/polyline_annotation_manager_test.dart
+++ b/example/integration_test/annotations/polyline_annotation_manager_test.dart
@@ -8,10 +8,6 @@ import 'package:mapbox_maps_example/empty_map_widget.dart' as app;
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  Future<void> addDelay(int ms) async {
-    await Future<void>.delayed(Duration(milliseconds: ms));
-  }
-
   testWidgets('create PolylineAnnotation_manager ',
       (WidgetTester tester) async {
     final mapFuture = app.main();
@@ -19,7 +15,6 @@ void main() {
     final mapboxMap = await mapFuture;
     final manager =
         await mapboxMap.annotations.createPolylineAnnotationManager();
-    await addDelay(1000);
 
     await manager.setLineCap(LineCap.BUTT);
     var lineCap = await manager.getLineCap();
@@ -56,7 +51,6 @@ void main() {
     await manager.setLineTrimOffset([0.0, 1.0]);
     var lineTrimOffset = await manager.getLineTrimOffset();
     expect([0.0, 1.0], lineTrimOffset);
-    await addDelay(1000);
   });
 }
 // End of generated file.

--- a/example/integration_test/annotations/polyline_annotation_test.dart
+++ b/example/integration_test/annotations/polyline_annotation_test.dart
@@ -8,10 +8,6 @@ import 'package:mapbox_maps_example/empty_map_widget.dart' as app;
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  Future<void> addDelay(int ms) async {
-    await Future<void>.delayed(Duration(milliseconds: ms));
-  }
-
   testWidgets('create PolylineAnnotation', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();
@@ -84,7 +80,6 @@ void main() {
     }
 
     await manager.deleteAll();
-    await addDelay(1000);
   });
 }
 // End of generated file.

--- a/example/integration_test/camera_test.dart
+++ b/example/integration_test/camera_test.dart
@@ -10,15 +10,10 @@ import 'package:turf/helpers.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  Future<void> addDelay(int ms) async {
-    await Future<void>.delayed(Duration(milliseconds: ms));
-  }
-
   testWidgets('cameraForCoordinatesPadding', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();
     final mapboxMap = await mapFuture;
-    await addDelay(1000);
 
     var reference = CameraOptions(
         center: Point(coordinates: Position(1.0, 2.0)).toJson(),
@@ -54,7 +49,6 @@ void main() {
     final mapFuture = app.main();
     await tester.pumpAndSettle();
     final mapboxMap = await mapFuture;
-    await addDelay(1000);
 
     var camera = await mapboxMap.cameraForCoordinateBounds(
         CoordinateBounds(
@@ -81,14 +75,12 @@ void main() {
     expect((coordinates.first as double).round(), 2);
     expect((coordinates.last as double).round(), 3);
     expect(camera.anchor, isNull);
-    await addDelay(1000);
   });
 
   testWidgets('cameraForCoordinates', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();
     final mapboxMap = await mapFuture;
-    await addDelay(1000);
 
     var camera = await mapboxMap.cameraForCoordinates([
       Point(
@@ -110,14 +102,14 @@ void main() {
     expect((coordinates.first as double).round(), 2);
     expect((coordinates.last as double).round(), 3);
     expect(camera.anchor, isNull);
-    await addDelay(1000);
   });
 
   testWidgets('cameraForCoordinatesCameraOptions', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();
     final mapboxMap = await mapFuture;
-    await addDelay(3000);
+
+    await app.events.onMapLoaded.future;
 
     var option = CameraOptions(
         center: Point(
@@ -159,7 +151,6 @@ void main() {
     expect(camera.padding!.bottom, option.padding!.bottom);
     expect(camera.padding!.right, option.padding!.right);
     expect(camera.zoom!.round(), 10);
-    await addDelay(1000);
   });
 
   testWidgets('cameraForGeometry', (WidgetTester tester) async {
@@ -178,7 +169,6 @@ void main() {
     expect((coordinates.first as double).round(), 1);
     expect((coordinates.last as double).round(), 2);
     expect(camera.anchor, isNull);
-    await addDelay(1000);
   });
 
   testWidgets('coordinateBoundsForCamera', (WidgetTester tester) async {
@@ -206,7 +196,6 @@ void main() {
     expect((northeast.last as double).round(), 2);
     expect((southwest.first as double).round(), 1);
     expect((southwest.last as double).round(), 2);
-    await addDelay(1000);
   });
 
   testWidgets('coordinateBoundsForCameraUnwrapped',
@@ -235,7 +224,6 @@ void main() {
     expect((northeast.last as double).round(), 2);
     expect((southwest.first as double).round(), 1);
     expect((southwest.last as double).round(), 2);
-    await addDelay(1000);
   });
 
   testWidgets('coordinateBoundsZoomForCamera', (WidgetTester tester) async {
@@ -262,7 +250,6 @@ void main() {
     expect((northeast.last as double).round(), 2);
     expect((southwest.first as double).round(), 1);
     expect((southwest.last as double).round(), 2);
-    await addDelay(1000);
   });
   testWidgets('coordinateBoundsZoomForCameraUnwrapped',
       (WidgetTester tester) async {
@@ -290,7 +277,6 @@ void main() {
     expect((northeast.last as double).round(), 2);
     expect((southwest.first as double).round(), 1);
     expect((southwest.last as double).round(), 2);
-    await addDelay(1000);
   });
   testWidgets('pixelForCoordinate', (WidgetTester tester) async {
     final mapFuture = app.main();
@@ -304,7 +290,6 @@ void main() {
     )).toJson());
     expect(pixel.x, isNotNull);
     expect(pixel.y, isNotNull);
-    await addDelay(1000);
   });
   testWidgets('pixelsForCoordinates', (WidgetTester tester) async {
     final mapFuture = app.main();
@@ -328,7 +313,6 @@ void main() {
     expect(pixels.first!.y, isNotNull);
     expect(pixels.last!.x, isNotNull);
     expect(pixels.last!.y, isNotNull);
-    await addDelay(1000);
   });
 
   testWidgets('coordinateForPixel', (WidgetTester tester) async {
@@ -340,7 +324,6 @@ void main() {
         await mapboxMap.coordinateForPixel(ScreenCoordinate(x: 100, y: 100));
     var coordinates = point['coordinates'] as List;
     expect(coordinates.length, 2);
-    await addDelay(1000);
   });
   testWidgets('coordinatesForPixels', (WidgetTester tester) async {
     final mapFuture = app.main();
@@ -353,13 +336,11 @@ void main() {
       ScreenCoordinate(x: 200, y: 300)
     ]);
     expect(coordinates.length, 2);
-    await addDelay(1000);
   });
 
   testWidgets('setCamera', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();
-    await addDelay(1000);
     final mapboxMap = await mapFuture;
     var option = CameraOptions(
         center: Point(
@@ -373,13 +354,12 @@ void main() {
         bearing: 20,
         pitch: 30);
     await mapboxMap.setCamera(option);
-    await addDelay(1000);
   });
 
   testWidgets('getCameraState', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();
-    await addDelay(5000);
+
     final mapboxMap = await mapFuture;
     var cameraState = await mapboxMap.getCameraState();
     expect(cameraState.zoom.floor(), 15);
@@ -393,7 +373,6 @@ void main() {
     expect(cameraState.padding.bottom, 0);
     expect(cameraState.padding.left, 0);
 
-    await addDelay(1000);
   });
   testWidgets('setBounds', (WidgetTester tester) async {
     final mapFuture = app.main();
@@ -417,12 +396,10 @@ void main() {
         maxPitch: 10,
         minPitch: 0));
 
-    await addDelay(1000);
   });
   testWidgets('getBounds', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();
-    await addDelay(1000);
     final mapboxMap = await mapFuture;
     var bounds = await mapboxMap.getBounds();
     expect(bounds.maxPitch, 85);
@@ -438,6 +415,5 @@ void main() {
     expect(northeast.last, 90);
     expect(bounds.bounds.infiniteBounds, true);
 
-    await addDelay(1000);
   });
 }

--- a/example/integration_test/camera_test.dart
+++ b/example/integration_test/camera_test.dart
@@ -372,7 +372,6 @@ void main() {
     expect(cameraState.padding.right, 0);
     expect(cameraState.padding.bottom, 0);
     expect(cameraState.padding.left, 0);
-
   });
   testWidgets('setBounds', (WidgetTester tester) async {
     final mapFuture = app.main();
@@ -395,7 +394,6 @@ void main() {
         minZoom: 0,
         maxPitch: 10,
         minPitch: 0));
-
   });
   testWidgets('getBounds', (WidgetTester tester) async {
     final mapFuture = app.main();
@@ -414,6 +412,5 @@ void main() {
     expect(northeast.first, 180);
     expect(northeast.last, 90);
     expect(bounds.bounds.infiniteBounds, true);
-
   });
 }

--- a/example/integration_test/map_interface_test.dart
+++ b/example/integration_test/map_interface_test.dart
@@ -56,7 +56,7 @@ void main() {
       var size = await mapboxMap.getSize();
       expect(size.width, tester.binding.renderView.size.width);
       expect(size.height, tester.binding.renderView.size.height);
-      });
+    });
 
     testWidgets('reduceMemoryUse', (WidgetTester tester) async {
       final mapFuture = app.main();
@@ -64,7 +64,7 @@ void main() {
       final mapboxMap = await mapFuture;
 
       await mapboxMap.reduceMemoryUse();
-      });
+    });
   }
 
   testWidgets('triggerRepaint', (WidgetTester tester) async {
@@ -275,7 +275,7 @@ void main() {
     style.addStyleLayer(layer, null);
     await app.events.onSourceDataLoaded.future;
     await app.events.onMapIdle.future;
-    
+
     var query = await mapboxMap.querySourceFeatures(
         'source', SourceQueryOptions(filter: ''));
     expect(query.length, greaterThan(0));

--- a/example/integration_test/map_interface_test.dart
+++ b/example/integration_test/map_interface_test.dart
@@ -10,10 +10,6 @@ import 'package:mapbox_maps_example/empty_map_widget.dart' as app;
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  Future<void> addDelay(int ms) async {
-    await Future<void>.delayed(Duration(milliseconds: ms));
-  }
-
   testWidgets('loadStyleURI', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();
@@ -21,7 +17,6 @@ void main() {
     await mapboxMap.loadStyleURI(MapboxStyles.DARK);
     var style = await mapboxMap.style.getStyleURI();
     expect(MapboxStyles.DARK, style);
-    await addDelay(1000);
   });
 
   testWidgets('loadStyleJson', (WidgetTester tester) async {
@@ -29,13 +24,13 @@ void main() {
     await tester.pumpAndSettle();
     final mapboxMap = await mapFuture;
     var styleJson = await rootBundle.loadString('assets/style.json');
+    app.events.resetOnStyleLoaded();
     mapboxMap.loadStyleJson(styleJson);
 
-    await app.events.onMapLoaded.future;
+    await app.events.onStyleLoaded.future;
 
     var getStyleJson = await mapboxMap.style.getStyleJSON();
     expect(styleJson, getStyleJson);
-    await addDelay(1000);
   });
 
   testWidgets('clearData', (WidgetTester tester) async {
@@ -43,7 +38,6 @@ void main() {
     await tester.pumpAndSettle();
     final mapboxMap = await mapFuture;
     mapboxMap.clearData();
-    await addDelay(1000);
   });
 
   testWidgets('setTileCacheBudget', (WidgetTester tester) async {
@@ -52,7 +46,6 @@ void main() {
     final mapboxMap = await mapFuture;
     mapboxMap.setTileCacheBudget(TileCacheBudgetInMegabytes(size: 100), null);
     mapboxMap.setTileCacheBudget(null, TileCacheBudgetInTiles(size: 100));
-    await addDelay(1000);
   });
 
   if (Platform.isAndroid) {
@@ -63,8 +56,7 @@ void main() {
       var size = await mapboxMap.getSize();
       expect(size.width, tester.binding.renderView.size.width);
       expect(size.height, tester.binding.renderView.size.height);
-      await addDelay(1000);
-    });
+      });
 
     testWidgets('reduceMemoryUse', (WidgetTester tester) async {
       final mapFuture = app.main();
@@ -72,8 +64,7 @@ void main() {
       final mapboxMap = await mapFuture;
 
       await mapboxMap.reduceMemoryUse();
-      await addDelay(1000);
-    });
+      });
   }
 
   testWidgets('triggerRepaint', (WidgetTester tester) async {
@@ -81,7 +72,6 @@ void main() {
     await tester.pumpAndSettle();
     final mapboxMap = await mapFuture;
     await mapboxMap.triggerRepaint();
-    await addDelay(1000);
   });
 
   testWidgets('PrefetchZoomDelta', (WidgetTester tester) async {
@@ -91,7 +81,6 @@ void main() {
     await mapboxMap.setPrefetchZoomDelta(10);
     var prefetchZoomDelta = await mapboxMap.getPrefetchZoomDelta();
     expect(prefetchZoomDelta, 10);
-    await addDelay(1000);
   });
 
   testWidgets('MapOptions', (WidgetTester tester) async {
@@ -120,7 +109,6 @@ void main() {
       expect(options.constrainMode, ConstrainMode.WIDTH_AND_HEIGHT);
       expect(options.viewportMode, ViewportMode.FLIPPED_Y);
     }
-    await addDelay(1000);
   });
 
   testWidgets('isGestureInProgress', (WidgetTester tester) async {
@@ -136,7 +124,6 @@ void main() {
       var isGestureInProgress = await mapboxMap.isGestureInProgress();
       expect(isGestureInProgress, true);
     }
-    await addDelay(1000);
   });
 
   testWidgets('isUserAnimationInProgress', (WidgetTester tester) async {
@@ -154,7 +141,6 @@ void main() {
           await mapboxMap.isUserAnimationInProgress();
       expect(isUserAnimationInProgress, true);
     }
-    await addDelay(1000);
   });
 
   testWidgets('debugOptions', (WidgetTester tester) async {
@@ -166,7 +152,6 @@ void main() {
     var debugOptions = await mapboxMap.getDebug();
     expect(debugOptions.length, 1);
     expect(debugOptions.first!.data, MapDebugOptionsData.TILE_BORDERS);
-    await addDelay(1000);
   });
 
   testWidgets('featureState', (WidgetTester tester) async {
@@ -177,11 +162,13 @@ void main() {
     var source = await rootBundle.loadString('assets/source.json');
     var layer = await rootBundle.loadString('assets/point_layer.json');
 
-    await app.events.onMapLoaded.future;
-
+    app.events.resetOnStyleDataLoaded();
+    app.events.resetOnMapIdle();
     style.addStyleSource('source', source);
     style.addStyleLayer(layer, null);
-    await addDelay(1000);
+
+    await app.events.onSourceDataLoaded.future;
+    await app.events.onMapIdle.future;
 
     await mapboxMap.setFeatureState(
         'source', 'custom', 'point', json.encode({'choose': true}));
@@ -195,10 +182,9 @@ void main() {
     featureState = await mapboxMap.getFeatureState('source', 'custom', 'point');
     stateMap = json.decode(featureState);
     expect(stateMap.length, 0);
-    await addDelay(1000);
   });
 
-  testWidgets('getResourceOptions', (WidgetTester tester) async {
+  testWidgets('MapboxMapsOptions', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();
 
@@ -206,7 +192,6 @@ void main() {
     expect(baseUrl, 'https://api.mapbox.com');
     var accessToken = await MapboxOptions.getAccessToken();
     expect(accessToken, isNotNull);
-    await addDelay(1000);
   });
 
   testWidgets('queryRenderedFeatures', (WidgetTester tester) async {
@@ -217,7 +202,11 @@ void main() {
     var options = CameraOptions(
         center: Point(coordinates: Position(-77.032667, 38.913175)).toJson(),
         zoom: 10);
+
+    app.events.resetOnCameraChanged();
     mapboxMap.setCamera(options);
+    await app.events.onCameraChanged.future;
+
     var source = await rootBundle.loadString('assets/source.json');
     var layer = await rootBundle.loadString('assets/point_layer.json');
     final ByteData bytes =
@@ -225,9 +214,13 @@ void main() {
     final Uint8List list = bytes.buffer.asUint8List();
     await style.addStyleImage('icon', 1.0,
         MbxImage(width: 40, height: 40, data: list), true, [], [], null);
+
+    app.events.resetOnSourceDataLoaded();
+    app.events.resetOnMapIdle();
     style.addStyleSource('source', source);
     style.addStyleLayer(layer, null);
-    await addDelay(1000);
+    await app.events.onSourceDataLoaded.future;
+    await app.events.onMapIdle.future;
 
     var screenBox = ScreenBox(
         min: ScreenCoordinate(x: 0.0, y: 0.0),
@@ -255,7 +248,6 @@ void main() {
             type: Type.LIST),
         RenderedQueryOptions(layerIds: ['points'], filter: null));
     expect(query.length, 0);
-    await addDelay(1000);
   });
 
   testWidgets('querySourceFeatures', (WidgetTester tester) async {
@@ -267,12 +259,23 @@ void main() {
         center: Point(coordinates: Position(-77.032667, 38.913175)).toJson(),
         zoom: 10,
         pitch: 0);
+
+    await app.events.onMapLoaded.future;
+
+    app.events.resetOnCameraChanged();
     mapboxMap.setCamera(options);
+    await app.events.onCameraChanged.future;
+
     var source = await rootBundle.loadString('assets/source.json');
     var layer = await rootBundle.loadString('assets/point_layer.json');
+
+    app.events.resetOnSourceDataLoaded();
+    app.events.resetOnMapIdle();
     style.addStyleSource('source', source);
     style.addStyleLayer(layer, null);
-    await addDelay(1000);
+    await app.events.onSourceDataLoaded.future;
+    await app.events.onMapIdle.future;
+    
     var query = await mapboxMap.querySourceFeatures(
         'source', SourceQueryOptions(filter: ''));
     expect(query.length, greaterThan(0));
@@ -287,19 +290,22 @@ void main() {
     var style = mapboxMap.style;
     var source =
         await rootBundle.loadString('assets/cluster/cluster_source.json');
-    style.addStyleSource("earthquakes", source);
     var layer =
         await rootBundle.loadString('assets/cluster/cluster_layer.json');
-    style.addStyleLayer(layer, null);
-
     var clusterCountLayer =
         await rootBundle.loadString('assets/cluster/cluster_count_layer.json');
-    style.addStyleLayer(clusterCountLayer, null);
-
     var unclusteredLayer = await rootBundle
         .loadString('assets/cluster/unclustered_point_layer.json');
+
+    app.events.resetOnSourceDataLoaded();
+    app.events.resetOnMapIdle();
+    style.addStyleSource("earthquakes", source);
+    style.addStyleLayer(layer, null);
+    style.addStyleLayer(clusterCountLayer, null);
     style.addStyleLayer(unclusteredLayer, null);
-    await addDelay(5000);
+    await app.events.onSourceDataLoaded.future;
+    await app.events.onMapIdle.future;
+
     var feature = {
       "id": 1249,
       "properties": {

--- a/example/integration_test/style/layer/background_layer_test.dart
+++ b/example/integration_test/style/layer/background_layer_test.dart
@@ -11,15 +11,10 @@ import 'package:turf/helpers.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  Future<void> addDelay(int ms) async {
-    await Future<void>.delayed(Duration(milliseconds: ms));
-  }
-
   testWidgets('Add BackgroundLayer', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();
     final mapboxMap = await mapFuture;
-    await addDelay(1000);
 
     await mapboxMap.style.addLayer(BackgroundLayer(
       id: 'layer',

--- a/example/integration_test/style/layer/circle_layer_test.dart
+++ b/example/integration_test/style/layer/circle_layer_test.dart
@@ -11,15 +11,10 @@ import 'package:turf/helpers.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  Future<void> addDelay(int ms) async {
-    await Future<void>.delayed(Duration(milliseconds: ms));
-  }
-
   testWidgets('Add CircleLayer', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();
     final mapboxMap = await mapFuture;
-    await addDelay(1000);
 
     final point = Point(coordinates: Position(-77.032667, 38.913175));
     await mapboxMap.style

--- a/example/integration_test/style/layer/fill_extrusion_layer_test.dart
+++ b/example/integration_test/style/layer/fill_extrusion_layer_test.dart
@@ -11,15 +11,10 @@ import 'package:turf/helpers.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  Future<void> addDelay(int ms) async {
-    await Future<void>.delayed(Duration(milliseconds: ms));
-  }
-
   testWidgets('Add FillExtrusionLayer', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();
     final mapboxMap = await mapFuture;
-    await addDelay(1000);
 
     await mapboxMap.style.addLayer(FillExtrusionLayer(
       id: 'layer',

--- a/example/integration_test/style/layer/fill_layer_test.dart
+++ b/example/integration_test/style/layer/fill_layer_test.dart
@@ -11,15 +11,10 @@ import 'package:turf/helpers.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  Future<void> addDelay(int ms) async {
-    await Future<void>.delayed(Duration(milliseconds: ms));
-  }
-
   testWidgets('Add FillLayer', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();
     final mapboxMap = await mapFuture;
-    await addDelay(1000);
 
     var polygon = Polygon(coordinates: [
       [

--- a/example/integration_test/style/layer/heatmap_layer_test.dart
+++ b/example/integration_test/style/layer/heatmap_layer_test.dart
@@ -11,15 +11,10 @@ import 'package:turf/helpers.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  Future<void> addDelay(int ms) async {
-    await Future<void>.delayed(Duration(milliseconds: ms));
-  }
-
   testWidgets('Add HeatmapLayer', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();
     final mapboxMap = await mapFuture;
-    await addDelay(1000);
 
     await mapboxMap.style.addSource(GeoJsonSource(
         id: "source",

--- a/example/integration_test/style/layer/hillshade_layer_test.dart
+++ b/example/integration_test/style/layer/hillshade_layer_test.dart
@@ -11,15 +11,10 @@ import 'package:turf/helpers.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  Future<void> addDelay(int ms) async {
-    await Future<void>.delayed(Duration(milliseconds: ms));
-  }
-
   testWidgets('Add HillshadeLayer', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();
     final mapboxMap = await mapFuture;
-    await addDelay(1000);
 
     await mapboxMap.style.addSource(RasterDemSource(
         id: "source", url: "mapbox://mapbox.mapbox-terrain-dem-v1"));

--- a/example/integration_test/style/layer/line_layer_test.dart
+++ b/example/integration_test/style/layer/line_layer_test.dart
@@ -11,15 +11,10 @@ import 'package:turf/helpers.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  Future<void> addDelay(int ms) async {
-    await Future<void>.delayed(Duration(milliseconds: ms));
-  }
-
   testWidgets('Add LineLayer', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();
     final mapboxMap = await mapFuture;
-    await addDelay(1000);
 
     var line =
         LineString(coordinates: [Position(1.0, 2.0), Position(10.0, 20.0)]);

--- a/example/integration_test/style/layer/location_indicator_layer_test.dart
+++ b/example/integration_test/style/layer/location_indicator_layer_test.dart
@@ -11,15 +11,10 @@ import 'package:turf/helpers.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  Future<void> addDelay(int ms) async {
-    await Future<void>.delayed(Duration(milliseconds: ms));
-  }
-
   testWidgets('Add LocationIndicatorLayer', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();
     final mapboxMap = await mapFuture;
-    await addDelay(1000);
 
     await mapboxMap.style.addLayer(LocationIndicatorLayer(
       id: 'layer',

--- a/example/integration_test/style/layer/raster_layer_test.dart
+++ b/example/integration_test/style/layer/raster_layer_test.dart
@@ -11,15 +11,10 @@ import 'package:turf/helpers.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  Future<void> addDelay(int ms) async {
-    await Future<void>.delayed(Duration(milliseconds: ms));
-  }
-
   testWidgets('Add RasterLayer', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();
     final mapboxMap = await mapFuture;
-    await addDelay(1000);
 
     await mapboxMap.style
         .addSource(RasterSource(id: "source", tileSize: 256, tiles: [

--- a/example/integration_test/style/layer/sky_layer_test.dart
+++ b/example/integration_test/style/layer/sky_layer_test.dart
@@ -11,15 +11,10 @@ import 'package:turf/helpers.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  Future<void> addDelay(int ms) async {
-    await Future<void>.delayed(Duration(milliseconds: ms));
-  }
-
   testWidgets('Add SkyLayer', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();
     final mapboxMap = await mapFuture;
-    await addDelay(1000);
 
     await mapboxMap.style.addLayer(SkyLayer(
       id: 'layer',

--- a/example/integration_test/style/layer/symbol_layer_test.dart
+++ b/example/integration_test/style/layer/symbol_layer_test.dart
@@ -11,15 +11,10 @@ import 'package:turf/helpers.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  Future<void> addDelay(int ms) async {
-    await Future<void>.delayed(Duration(milliseconds: ms));
-  }
-
   testWidgets('Add SymbolLayer', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();
     final mapboxMap = await mapFuture;
-    await addDelay(1000);
 
     final point = Point(coordinates: Position(-77.032667, 38.913175));
     await mapboxMap.style

--- a/example/integration_test/style/source/geojson_source_test.dart
+++ b/example/integration_test/style/source/geojson_source_test.dart
@@ -13,10 +13,6 @@ import 'package:turf/helpers.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  Future<void> addDelay(int ms) async {
-    await Future<void>.delayed(Duration(milliseconds: ms));
-  }
-
   testWidgets('Add GeoJsonSource', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();

--- a/example/integration_test/style/source/image_source_test.dart
+++ b/example/integration_test/style/source/image_source_test.dart
@@ -13,10 +13,6 @@ import 'package:turf/helpers.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  Future<void> addDelay(int ms) async {
-    await Future<void>.delayed(Duration(milliseconds: ms));
-  }
-
   testWidgets('Add ImageSource', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();

--- a/example/integration_test/style/source/raster_source_test.dart
+++ b/example/integration_test/style/source/raster_source_test.dart
@@ -13,10 +13,6 @@ import 'package:turf/helpers.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  Future<void> addDelay(int ms) async {
-    await Future<void>.delayed(Duration(milliseconds: ms));
-  }
-
   testWidgets('Add RasterSource', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();

--- a/example/integration_test/style/source/rasterdem_source_test.dart
+++ b/example/integration_test/style/source/rasterdem_source_test.dart
@@ -13,10 +13,6 @@ import 'package:turf/helpers.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  Future<void> addDelay(int ms) async {
-    await Future<void>.delayed(Duration(milliseconds: ms));
-  }
-
   testWidgets('Add RasterDemSource', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();

--- a/example/integration_test/style/source/vector_source_test.dart
+++ b/example/integration_test/style/source/vector_source_test.dart
@@ -13,10 +13,6 @@ import 'package:turf/helpers.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  Future<void> addDelay(int ms) async {
-    await Future<void>.delayed(Duration(milliseconds: ms));
-  }
-
   testWidgets('Add VectorSource', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();

--- a/example/integration_test/style/style_test.dart
+++ b/example/integration_test/style/style_test.dart
@@ -15,10 +15,6 @@ import '../utils/list_close_to_matcher.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  Future<void> addDelay(int ms) async {
-    await Future<void>.delayed(Duration(milliseconds: ms));
-  }
-
   testWidgets('Style uri', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();
@@ -50,7 +46,6 @@ void main() {
     await tester.pumpAndSettle();
     final mapboxMap = await mapFuture;
     var style = mapboxMap.style;
-    await addDelay(1000);
     var styleLoaded = await style.isStyleLoaded();
     expect(styleLoaded, true);
   });
@@ -419,7 +414,6 @@ void main() {
     style.addStyleSource('source', source);
     await style.invalidateStyleCustomGeometrySourceTile(
         'source', CanonicalTileID(z: 0, x: 1, y: 2));
-    await addDelay(1000);
   });
 
   testWidgets('invalidateStyleCustomGeometrySourceRegion',
@@ -444,7 +438,6 @@ void main() {
               4.0,
             )).toJson(),
             infiniteBounds: true));
-    await addDelay(1000);
   });
 
   testWidgets('handleImage', (WidgetTester tester) async {
@@ -484,7 +477,6 @@ void main() {
     );
     var projection = await mapboxMap.style.getProjection();
     expect(projection?.name, StyleProjectionName.mercator);
-    await addDelay(1000);
   });
 }
 

--- a/example/lib/empty_map_widget.dart
+++ b/example/lib/empty_map_widget.dart
@@ -4,11 +4,19 @@ import 'package:flutter/material.dart';
 import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
 
 class Events {
+  var onMapIdle = Completer();
   var onMapLoaded = Completer();
+  var onStyleLoaded = Completer();
+  var onStyleDataLoaded = Completer();
+  var onSourceDataLoaded = Completer();
+  var onCameraChanged = Completer();
 
-  void resetOnMapLoaded() {
-    onMapLoaded = Completer();
-  }
+  void resetOnMapLoaded() => onMapLoaded = Completer();
+  void resetOnStyleLoaded() => onStyleLoaded = Completer();
+  void resetOnStyleDataLoaded()  => onStyleDataLoaded = Completer();
+  void resetOnSourceDataLoaded()  => onSourceDataLoaded = Completer();
+  void resetOnCameraChanged() => onCameraChanged = Completer();
+  void resetOnMapIdle() => onMapIdle = Completer();
 }
 
 var events = Events();
@@ -31,9 +39,37 @@ Future<MapboxMap> main() {
         events.onMapLoaded.complete();
       }
     },
+    onStyleLoadedListener: (StyleLoadedEventData data) {
+      if (!events.onStyleLoaded.isCompleted) {
+        events.onStyleLoaded.complete();
+      }
+    },
+  onStyleDataLoadedListener: (StyleDataLoadedEventData data) {
+      if (!events.onStyleDataLoaded.isCompleted) {
+        events.onStyleDataLoaded.complete();
+      }
+    },
+    onSourceDataLoadedListener: (SourceDataLoadedEventData data) {
+      if (!events.onSourceDataLoaded.isCompleted) {
+        events.onSourceDataLoaded.complete();
+      }
+    },
+    onCameraChangeListener: (CameraChangedEventData data) {
+      if (!events.onCameraChanged.isCompleted) {
+        events.onCameraChanged.complete();
+      }
+    },
+    onMapIdleListener: (MapIdleEventData data) {
+      if (!events.onMapIdle.isCompleted) {
+        events.onMapIdle.complete();
+      }
+    },
   )));
 
-  return completer.future;
+  return Future.wait([
+    completer.future,
+    events.onStyleLoaded.future,
+  ]).then((value) => value.first as MapboxMap);
 }
 
 Future<MapboxMap> runFixedSizeMap() {

--- a/example/lib/empty_map_widget.dart
+++ b/example/lib/empty_map_widget.dart
@@ -13,8 +13,8 @@ class Events {
 
   void resetOnMapLoaded() => onMapLoaded = Completer();
   void resetOnStyleLoaded() => onStyleLoaded = Completer();
-  void resetOnStyleDataLoaded()  => onStyleDataLoaded = Completer();
-  void resetOnSourceDataLoaded()  => onSourceDataLoaded = Completer();
+  void resetOnStyleDataLoaded() => onStyleDataLoaded = Completer();
+  void resetOnSourceDataLoaded() => onSourceDataLoaded = Completer();
   void resetOnCameraChanged() => onCameraChanged = Completer();
   void resetOnMapIdle() => onMapIdle = Completer();
 }
@@ -44,7 +44,7 @@ Future<MapboxMap> main() {
         events.onStyleLoaded.complete();
       }
     },
-  onStyleDataLoadedListener: (StyleDataLoadedEventData data) {
+    onStyleDataLoadedListener: (StyleDataLoadedEventData data) {
       if (!events.onStyleDataLoaded.isCompleted) {
         events.onStyleDataLoaded.complete();
       }


### PR DESCRIPTION
Replace `addDelay(1000)` with waiting for relevant events in the integration tests to speed them up.