### PR TITLE
[Android] Fix MapOptions incorrect index access at map creation

### DIFF
--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/MapboxMapFactory.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/MapboxMapFactory.kt
@@ -37,7 +37,7 @@ class MapboxMapFactory(
       mapOptions[4]?.let {
         mapOptionsBuilder.crossSourceCollisions(it as Boolean)
       }
-      mapOptions[6]?.let {
+      mapOptions[5]?.let {
         (it as ArrayList<Double>).let { size ->
           mapOptionsBuilder.size(
             Size(
@@ -47,10 +47,10 @@ class MapboxMapFactory(
           )
         }
       }
-      mapOptions[7]?.let {
+      mapOptions[6]?.let {
         mapOptionsBuilder.pixelRatio((it as Double).toFloat())
       }
-      mapOptions[8]?.let {
+      mapOptions[7]?.let {
         (it as ArrayList<Any?>).let { glyphs ->
           val builder = GlyphsRasterizationOptions.Builder()
           glyphs[1]?.let { fontFamily ->


### PR DESCRIPTION
### Fixes map not beeing created (blank map) issues.

As pointed out in the https://github.com/mapbox/mapbox-maps-flutter/issues/377#issuecomment-1904311347, incorrect index access to mapOptions in `MapboxMapFactory` create method could be causing blank map issues.

The following exception would be thrown:

`Unhandled Exception: PlatformException(error, java.lang.Double cannot be cast to java.util.ArrayList, null, java.lang.ClassCastException: java.lang.Double cannot be cast to java.util.ArrayList`

because it tried to access `pixelRatio` option at index 6 which is `Double` instead of `size` at index 5 which is `ArrayList<Double>` causing MapboxMapFactory to fail creating the map.
