### PR TITLE
Configurable android view hosting mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Add an example representing a traffic route with color based on traffic volumes using LineLayer and Expression.
 * [Android] Fix MapOptions incorrect index access at map creation, leading to map not being created(blank view).
+* [Android] Use hybrid composition(HC) as the default platform view hosting mode on Android.
+* [Android] Add experimental `androidHostingMode` contructor parameter to `MapWidget`. Use this to change the way platform MapView is being hosted by Flutter on Android. This changes the way map view is composited with Flutter UI, read more on this in [Android Platform Views](https://github.com/flutter/flutter/wiki/Android-Platform-Views) guide from the Flutter team.
 * [iOS] `MapboxMap`: `isGestureInProgress()`, `isUserAnimationInProgress()`, `setConstrainMode()`, `setNorthOrientation()`, `setViewportMode()` and `reduceMemoryUse()` are now available on iOS.
 * Bump platform Maps SDK dependencies to 11.2.0-beta.1.
 

--- a/example/integration_test/map_interface_test.dart
+++ b/example/integration_test/map_interface_test.dart
@@ -54,8 +54,8 @@ void main() {
       await tester.pumpAndSettle();
       final mapboxMap = await mapFuture;
       var size = await mapboxMap.getSize();
-      expect(size.width, tester.binding.renderView.size.width);
-      expect(size.height, tester.binding.renderView.size.height);
+      expect(size.width, closeTo(tester.binding.renderView.size.width, 1));
+      expect(size.height, closeTo(tester.binding.renderView.size.height, 1));
     });
   }
 

--- a/example/lib/animated_route.dart
+++ b/example/lib/animated_route.dart
@@ -186,7 +186,7 @@ class AnnotationClickListener extends OnPointAnnotationClickListener {
     final end = Point.fromJson((annotation.geometry)!.cast());
 
     final coordinates = await fetchRouteCoordinates(
-        start, end.coordinates, MapsDemo.ACCESS_TOKEN);
+        start, end.coordinates, MapsDemoState.ACCESS_TOKEN);
 
     drawRouteLowLevel(coordinates);
   }

--- a/example/lib/animated_route.dart
+++ b/example/lib/animated_route.dart
@@ -186,7 +186,7 @@ class AnnotationClickListener extends OnPointAnnotationClickListener {
     final end = Point.fromJson((annotation.geometry)!.cast());
 
     final coordinates = await fetchRouteCoordinates(
-        start, end.coordinates, MapsDemoState.ACCESS_TOKEN);
+        start, end.coordinates, MapsDemo.ACCESS_TOKEN);
 
     drawRouteLowLevel(coordinates);
   }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -103,7 +103,7 @@ packages:
     source: sdk
     version: "0.0.0"
   flutter_driver:
-    dependency: "direct dev"
+    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -124,10 +124,10 @@ packages:
     dependency: "direct main"
     description:
       name: font_awesome_flutter
-      sha256: "52671aea66da73b58d42ec6d0912b727a42248dd9a7c76d6c20f275783c48c08"
+      sha256: "275ff26905134bcb59417cf60ad979136f1f8257f2f449914b2c3e05bbb4cd6f"
       url: "https://pub.dev"
     source: hosted
-    version: "10.6.0"
+    version: "10.7.0"
   fuchsia_remote_debug_protocol:
     dependency: transitive
     description: flutter
@@ -314,10 +314,10 @@ packages:
     dependency: transitive
     description:
       name: sweepline_intersections
-      sha256: "924fce1b02b9783fae5ca33ba4f2cc33743b0422b8b829fac60bcd3717a69afb"
+      sha256: a665c707200a4f07140a4029b41a7c4883beb3f04322cd8e08ebf650f69e1176
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.3+2"
+    version: "0.0.4"
   sync_http:
     dependency: transitive
     description:
@@ -346,26 +346,26 @@ packages:
     dependency: "direct dev"
     description:
       name: turf
-      sha256: "2be48cc7ed7e9acccaeee18e06d1ce183f3f7eee7abc0622371880951d41a0d6"
+      sha256: e5774828b5a21b789946041bd3b0066fb6dc880449264eaeab605e3c5358c350
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.8"
+    version: "0.0.9"
   turf_equality:
     dependency: transitive
     description:
       name: turf_equality
-      sha256: "2ae3b117afd5fb134412a245a883589cae80d9d9472c587f754a0c34f82fa1b9"
+      sha256: "61deee4a915a2c3d249be4ee6d6180b2d744e5a6298e1d668213d529766c6a21"
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.2"
+    version: "0.0.3"
   turf_pip:
     dependency: transitive
     description:
       name: turf_pip
-      sha256: "2b33d14ad979e4c33a4f01949b62510356d28037062bd45b60752e4dec9e7dd1"
+      sha256: ba4fd414baffd5d7b30880658ad6db82461c49ec023f8ffd0c23d398ad8b14be
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.1+1"
+    version: "0.0.2"
   typed_data:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -29,8 +29,6 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  flutter_driver:
-    sdk: flutter
   turf: ^0.0.7
 
 # For information on the generic Dart part of this file, see the

--- a/lib/mapbox_maps_flutter.dart
+++ b/lib/mapbox_maps_flutter.dart
@@ -8,7 +8,9 @@ import 'package:enum_to_string/enum_to_string.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
+import 'package:meta/meta.dart';
 
 import 'src/proxy_binary_messenger.dart' show ProxyBinaryMessenger;
 

--- a/lib/src/map_widget.dart
+++ b/lib/src/map_widget.dart
@@ -220,8 +220,8 @@ class _MapWidgetState extends State<MapWidget> {
       'mapboxPluginVersion': '1.0.0-beta.2'
     };
 
-    return (_mapboxMapsPlatform.buildView(widget.androidHostingMode,
-        creationParams, onPlatformViewCreated, widget.gestureRecognizers) as PlatformViewLink).createState().;
+    return _mapboxMapsPlatform.buildView(widget.androidHostingMode,
+        creationParams, onPlatformViewCreated, widget.gestureRecognizers);
   }
 
   @override

--- a/lib/src/map_widget.dart
+++ b/lib/src/map_widget.dart
@@ -1,5 +1,33 @@
 part of mapbox_maps_flutter;
 
+/// A mode for platform MapView to be hosted in Flutter on Android platform.
+///
+/// As per https://github.com/flutter/flutter/wiki/Android-Platform-Views#selecting-a-mode
+@experimental
+enum AndroidPlatformViewHostingMode {
+  /// Texture Layer Hybrid Composition with fallback to Virtual Display,
+  /// when the current SDK version is <23 or [MapWidget.textureView] is `false`.
+  ///
+  /// https://github.com/flutter/flutter/wiki/Texture-Layer-Hybrid-Composition
+  TLHC_VD,
+
+  /// Use Texture Layer Hybrid Composition hosting mode with fallback to Hybrid Composition,
+  /// when the current SDK version is <23 or [MapWidget.textureView] is `false`.
+  ///
+  /// https://github.com/flutter/flutter/wiki/Texture-Layer-Hybrid-Composition
+  TLHC_HC,
+
+  /// Always use Hybrid Composition hosting mode.
+  ///
+  /// https://github.com/flutter/flutter/wiki/Hybrid-Composition
+  HC,
+
+  /// Always use Virtual Display hosting mode.
+  ///
+  /// https://github.com/flutter/flutter/wiki/Virtual-Display
+  VD,
+}
+
 /// A MapWidget provides an embeddable map interface.
 /// You use this class to display map information and to manipulate the map contents from your application.
 /// You can center the map on a given coordinate, specify the size of the area you want to display,
@@ -18,6 +46,7 @@ class MapWidget extends StatefulWidget {
     // FIXME Flutter 3.x has memory leak on Android using in SurfaceView mode, see https://github.com/flutter/flutter/issues/118384
     // As a workaround default is true.
     this.textureView = true,
+    this.androidHostingMode = AndroidPlatformViewHostingMode.HC,
     this.styleUri = MapboxStyles.STANDARD,
     this.gestureRecognizers,
     this.onMapCreated,
@@ -90,6 +119,11 @@ class MapWidget extends StatefulWidget {
   /// FIXME Flutter 3.x has memory leak on Android using in SurfaceView mode, see https://github.com/flutter/flutter/issues/118384
   /// As a workaround default is true.
   final bool? textureView;
+
+  /// Controls the way the underlaying MapView is being hosted by Flutter on Android.
+  /// This setting has no effect on iOS.
+  @experimental
+  final AndroidPlatformViewHostingMode androidHostingMode;
 
   /// The styleUri will applied for the MapWidget in the onStart lifecycle event if no style is set. Default is [Style.MAPBOX_STREETS].
   final String styleUri;
@@ -186,8 +220,8 @@ class _MapWidgetState extends State<MapWidget> {
       'mapboxPluginVersion': '1.0.0-beta.2'
     };
 
-    return _mapboxMapsPlatform.buildView(
-        creationParams, onPlatformViewCreated, widget.gestureRecognizers);
+    return (_mapboxMapsPlatform.buildView(widget.androidHostingMode,
+        creationParams, onPlatformViewCreated, widget.gestureRecognizers) as PlatformViewLink).createState().;
   }
 
   @override

--- a/lib/src/mapbox_maps_platform.dart
+++ b/lib/src/mapbox_maps_platform.dart
@@ -111,19 +111,56 @@ class _MapboxMapsPlatform {
   }
 
   Widget buildView(
+      AndroidPlatformViewHostingMode androidHostingMode,
       Map<String, dynamic> creationParams,
       OnPlatformViewCreatedCallback onPlatformViewCreated,
       Set<Factory<OneSequenceGestureRecognizer>>? gestureRecognizers) {
     creationParams['channelSuffix'] = _channelSuffix;
 
     if (defaultTargetPlatform == TargetPlatform.android) {
-      return AndroidView(
-        viewType: 'plugins.flutter.io/mapbox_maps',
-        onPlatformViewCreated: onPlatformViewCreated,
-        gestureRecognizers: gestureRecognizers,
-        creationParams: creationParams,
-        creationParamsCodec: const StandardMessageCodec(),
-      );
+
+      switch (androidHostingMode) {
+        case AndroidPlatformViewHostingMode.TLHC_VD:
+        case AndroidPlatformViewHostingMode.TLHC_HC:
+        case AndroidPlatformViewHostingMode.HC:
+          return PlatformViewLink(
+            viewType: "plugins.flutter.io/mapbox_maps",
+            surfaceFactory: (context, controller) {
+              return AndroidViewSurface(
+                  controller: controller as AndroidViewController,
+                  hitTestBehavior: PlatformViewHitTestBehavior.opaque,
+                  gestureRecognizers: gestureRecognizers ?? Set());
+            },
+            onCreatePlatformView: (params) {
+              final AndroidViewController controller =
+                  _androidViewControllerFactoryForMode(androidHostingMode)(
+                id: params.id,
+                viewType: 'plugins.flutter.io/mapbox_maps',
+                layoutDirection: TextDirection.ltr,
+                creationParams: creationParams,
+                creationParamsCodec: const StandardMessageCodec(),
+                onFocus: () => params.onFocusChanged(true),
+              );
+              controller.addOnPlatformViewCreatedListener(
+                params.onPlatformViewCreated,
+              );
+              controller.addOnPlatformViewCreatedListener(
+                onPlatformViewCreated,
+              );
+
+              controller.create();
+              return controller;
+            },
+          );
+        case AndroidPlatformViewHostingMode.VD:
+          return AndroidView(
+            viewType: 'plugins.flutter.io/mapbox_maps',
+            onPlatformViewCreated: onPlatformViewCreated,
+            gestureRecognizers: gestureRecognizers,
+            creationParams: creationParams,
+            creationParamsCodec: const StandardMessageCodec(),
+          );
+      }
     } else if (defaultTargetPlatform == TargetPlatform.iOS) {
       return UiKitView(
         viewType: 'plugins.flutter.io/mapbox_maps',
@@ -135,6 +172,27 @@ class _MapboxMapsPlatform {
     }
     return Text(
         '$defaultTargetPlatform is not yet supported by the maps plugin');
+  }
+
+  AndroidViewController Function(
+          {required int id,
+          required String viewType,
+          required TextDirection layoutDirection,
+          dynamic creationParams,
+          MessageCodec<dynamic>? creationParamsCodec,
+          VoidCallback? onFocus})
+      _androidViewControllerFactoryForMode(
+          AndroidPlatformViewHostingMode hostingMode) {
+    switch (hostingMode) {
+      case AndroidPlatformViewHostingMode.TLHC_VD:
+        return PlatformViewsService.initAndroidView;
+      case AndroidPlatformViewHostingMode.TLHC_HC:
+        return PlatformViewsService.initSurfaceAndroidView;
+      case AndroidPlatformViewHostingMode.HC:
+        return PlatformViewsService.initExpensiveAndroidView;
+      case AndroidPlatformViewHostingMode.VD:
+        throw "Unexpected hostring mode(VD) when selecting an android view controller";
+    }
   }
 
   void dispose() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   flutter_plugin_android_lifecycle: ^2.0.5
   turf: ^0.0.8
   typed_data: ^1.3.0
-  meta: ^1.10.0
+  meta: ^1.9.1
 
 dev_dependencies:
   integration_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,12 +14,10 @@ dependencies:
   flutter_plugin_android_lifecycle: ^2.0.5
   turf: ^0.0.8
   typed_data: ^1.3.0
-  meta: ^1.11.0
+  meta: ^1.10.0
 
 dev_dependencies:
   integration_test:
-    sdk: flutter
-  flutter_driver:
     sdk: flutter
   flutter_test:
     sdk: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   flutter_plugin_android_lifecycle: ^2.0.5
   turf: ^0.0.8
   typed_data: ^1.3.0
+  meta: ^1.11.0
 
 dev_dependencies:
   integration_test:


### PR DESCRIPTION
### What does this pull request do?

* Adds a `androidHostingMode` construction parameter to `MapWidget`, allowing to configure the way map view is being hosted in Flutter.
* Changes the default hosting mode from Virtual Display to Hybrid Composition.

### What is the motivation and context behind this change?

Latest Android 14 QPR beta 3 makes the map view to stop rendering on resume from background in Virtual Display mode, switching to Hybrid Composition helps[TODO: Link Android flutter ticket]. Similar issue with the latest update of Android 14 on Samsung Galaxy phones. https://github.com/flutter/flutter/issues/139039 https://github.com/flutter/flutter/issues/139630

Addresses: https://github.com/mapbox/mapbox-maps-flutter/issues/323 https://github.com/mapbox/mapbox-maps-flutter/issues/205
### Pull request checklist:
 - [x] Add a changelog entry.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
     Not testable. 
 - [x] Add documentation comments for any added or updated public APIs.
