### PR TITLE
[iOS] Fix onScroll being triggered only once at the end of pan gesture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Add `LogConfiguration` allowing to intercept logs produced by the plugin. Pass your custom `LogWriterBackend` to `LogConfiguration.registerLogWriterBackend()` to redirect logs produced by the mapping engine to your desired destination.
 * Add `MapWidget.onResourceRequestListener` that can be used to subscribe to resource requests made by the map.
+* [iOS] Re-wire `MapWidget`'s `onScroll` event to be triggered whenever map is being panned instead of triggering it only after pan ends.
 
 ### 1.0.0-beta.3
 


### PR DESCRIPTION
### What does this pull request do?

Re-wires `MapWidget`'s `onScroll` event to be triggered whenever pan gesture is began/moved/ended instead of triggering it only after pan ends(as it was before).

### What is the motivation and context behind this change?

Alignment with the behavior on Android, addressing https://mapbox.atlassian.net/browse/MAPSFLT-170

### Pull request checklist:
 - [x] Add a changelog entry.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
       This behavior is not covered by tests
