### PR TITLE
Use iPhone 13 Pro for iOS device tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ jobs:
           command: |
             gcloud firebase test ios run \
               --test << parameters.workspace-path >>/build_products.zip \
-              --device model=iphone8,version=15.7 \
+              --device model=iphone13pro,version=15.8 \
               --timeout 5m \
               --num-flaky-test-attempts 3
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ jobs:
           command: |
             gcloud firebase test ios run \
               --test << parameters.workspace-path >>/build_products.zip \
-              --device model=iphone13pro,version=15.8 \
+              --device model=iphone13pro,version=15.7 \
               --timeout 5m \
               --num-flaky-test-attempts 3
 


### PR DESCRIPTION
### What does this pull request do?

Switches iOS device tests to use iPhone 13 Pro.

### What is the motivation and context behind this change?

Firebase recommendation.
