### PR TITLE
Reuse FlutterError in Kotlin

### DIFF
--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/CircleAnnotationMessager.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/CircleAnnotationMessager.kt
@@ -16,7 +16,7 @@ private fun wrapResult(result: Any?): List<Any?> {
 }
 
 private fun wrapError(exception: Throwable): List<Any?> {
-  if (exception is CircleAnnotationMessagerFlutterError) {
+  if (exception is FlutterError) {
     return listOf(
       exception.code,
       exception.message,
@@ -31,21 +31,9 @@ private fun wrapError(exception: Throwable): List<Any?> {
   }
 }
 
-private fun createConnectionError(channelName: String): CircleAnnotationMessagerFlutterError {
-  return CircleAnnotationMessagerFlutterError("channel-error", "Unable to establish connection on channel: '$channelName'.", "")
+private fun createConnectionError(channelName: String): FlutterError {
+  return FlutterError("channel-error", "Unable to establish connection on channel: '$channelName'.", "")
 }
-
-/**
- * Error class for passing custom error details to Flutter via a thrown PlatformException.
- * @property code The error code.
- * @property message The error message.
- * @property details The error details. Must be a datatype supported by the api codec.
- */
-class CircleAnnotationMessagerFlutterError(
-  val code: String,
-  override val message: String? = null,
-  val details: Any? = null
-) : Throwable()
 
 /** Orientation of circle when map is pitched. */
 enum class CirclePitchAlignment(val raw: Int) {
@@ -234,7 +222,7 @@ class OnCircleAnnotationClickListener(private val binaryMessenger: BinaryMesseng
     channel.send(listOf(annotationArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(CircleAnnotationMessagerFlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/GestureListeners.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/GestureListeners.kt
@@ -10,21 +10,9 @@ import io.flutter.plugin.common.StandardMessageCodec
 import java.io.ByteArrayOutputStream
 import java.nio.ByteBuffer
 
-private fun createConnectionError(channelName: String): GestureListenersFlutterError {
-  return GestureListenersFlutterError("channel-error", "Unable to establish connection on channel: '$channelName'.", "")
+private fun createConnectionError(channelName: String): FlutterError {
+  return FlutterError("channel-error", "Unable to establish connection on channel: '$channelName'.", "")
 }
-
-/**
- * Error class for passing custom error details to Flutter via a thrown PlatformException.
- * @property code The error code.
- * @property message The error message.
- * @property details The error details. Must be a datatype supported by the api codec.
- */
-class GestureListenersFlutterError(
-  val code: String,
-  override val message: String? = null,
-  val details: Any? = null
-) : Throwable()
 @Suppress("UNCHECKED_CAST")
 private object GestureListenerCodec : StandardMessageCodec() {
   override fun readValueOfType(type: Byte, buffer: ByteBuffer): Any? {
@@ -63,7 +51,7 @@ class GestureListener(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(coordinateArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(GestureListenersFlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
@@ -78,7 +66,7 @@ class GestureListener(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(coordinateArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(GestureListenersFlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
@@ -93,7 +81,7 @@ class GestureListener(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(coordinateArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(GestureListenersFlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/LogBackend.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/LogBackend.kt
@@ -8,21 +8,9 @@ import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.MessageCodec
 import io.flutter.plugin.common.StandardMessageCodec
 
-private fun createConnectionError(channelName: String): LogBackendFlutterError {
-  return LogBackendFlutterError("channel-error", "Unable to establish connection on channel: '$channelName'.", "")
+private fun createConnectionError(channelName: String): FlutterError {
+  return FlutterError("channel-error", "Unable to establish connection on channel: '$channelName'.", "")
 }
-
-/**
- * Error class for passing custom error details to Flutter via a thrown PlatformException.
- * @property code The error code.
- * @property message The error message.
- * @property details The error details. Must be a datatype supported by the api codec.
- */
-class LogBackendFlutterError(
-  val code: String,
-  override val message: String? = null,
-  val details: Any? = null
-) : Throwable()
 
 enum class LoggingLevel(val raw: Int) {
   /** Verbose log data to understand how the code executes. */
@@ -60,7 +48,7 @@ class LogWriterBackend(private val binaryMessenger: BinaryMessenger) {
     channel.send(listOf(levelArg.raw, messageArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(LogBackendFlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/MapInterfaces.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/MapInterfaces.kt
@@ -18,7 +18,7 @@ private fun wrapResult(result: Any?): List<Any?> {
 }
 
 private fun wrapError(exception: Throwable): List<Any?> {
-  if (exception is MapInterfacesFlutterError) {
+  if (exception is FlutterError) {
     return listOf(
       exception.code,
       exception.message,
@@ -39,7 +39,7 @@ private fun wrapError(exception: Throwable): List<Any?> {
  * @property message The error message.
  * @property details The error details. Must be a datatype supported by the api codec.
  */
-class MapInterfacesFlutterError(
+class FlutterError(
   val code: String,
   override val message: String? = null,
   val details: Any? = null

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/PointAnnotationMessager.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/PointAnnotationMessager.kt
@@ -16,7 +16,7 @@ private fun wrapResult(result: Any?): List<Any?> {
 }
 
 private fun wrapError(exception: Throwable): List<Any?> {
-  if (exception is PointAnnotationMessagerFlutterError) {
+  if (exception is FlutterError) {
     return listOf(
       exception.code,
       exception.message,
@@ -31,21 +31,9 @@ private fun wrapError(exception: Throwable): List<Any?> {
   }
 }
 
-private fun createConnectionError(channelName: String): PointAnnotationMessagerFlutterError {
-  return PointAnnotationMessagerFlutterError("channel-error", "Unable to establish connection on channel: '$channelName'.", "")
+private fun createConnectionError(channelName: String): FlutterError {
+  return FlutterError("channel-error", "Unable to establish connection on channel: '$channelName'.", "")
 }
-
-/**
- * Error class for passing custom error details to Flutter via a thrown PlatformException.
- * @property code The error code.
- * @property message The error message.
- * @property details The error details. Must be a datatype supported by the api codec.
- */
-class PointAnnotationMessagerFlutterError(
-  val code: String,
-  override val message: String? = null,
-  val details: Any? = null
-) : Throwable()
 
 /** Part of the icon placed closest to the anchor. */
 enum class IconAnchor(val raw: Int) {
@@ -692,7 +680,7 @@ class OnPointAnnotationClickListener(private val binaryMessenger: BinaryMessenge
     channel.send(listOf(annotationArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(PointAnnotationMessagerFlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/PolygonAnnotationMessager.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/PolygonAnnotationMessager.kt
@@ -16,7 +16,7 @@ private fun wrapResult(result: Any?): List<Any?> {
 }
 
 private fun wrapError(exception: Throwable): List<Any?> {
-  if (exception is PolygonAnnotationMessagerFlutterError) {
+  if (exception is FlutterError) {
     return listOf(
       exception.code,
       exception.message,
@@ -31,21 +31,9 @@ private fun wrapError(exception: Throwable): List<Any?> {
   }
 }
 
-private fun createConnectionError(channelName: String): PolygonAnnotationMessagerFlutterError {
-  return PolygonAnnotationMessagerFlutterError("channel-error", "Unable to establish connection on channel: '$channelName'.", "")
+private fun createConnectionError(channelName: String): FlutterError {
+  return FlutterError("channel-error", "Unable to establish connection on channel: '$channelName'.", "")
 }
-
-/**
- * Error class for passing custom error details to Flutter via a thrown PlatformException.
- * @property code The error code.
- * @property message The error message.
- * @property details The error details. Must be a datatype supported by the api codec.
- */
-class PolygonAnnotationMessagerFlutterError(
-  val code: String,
-  override val message: String? = null,
-  val details: Any? = null
-) : Throwable()
 
 /** Controls the frame of reference for `fill-translate`. */
 enum class FillTranslateAnchor(val raw: Int) {
@@ -182,7 +170,7 @@ class OnPolygonAnnotationClickListener(private val binaryMessenger: BinaryMessen
     channel.send(listOf(annotationArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(PolygonAnnotationMessagerFlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/PolylineAnnotationMessager.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/PolylineAnnotationMessager.kt
@@ -16,7 +16,7 @@ private fun wrapResult(result: Any?): List<Any?> {
 }
 
 private fun wrapError(exception: Throwable): List<Any?> {
-  if (exception is PolylineAnnotationMessagerFlutterError) {
+  if (exception is FlutterError) {
     return listOf(
       exception.code,
       exception.message,
@@ -31,21 +31,9 @@ private fun wrapError(exception: Throwable): List<Any?> {
   }
 }
 
-private fun createConnectionError(channelName: String): PolylineAnnotationMessagerFlutterError {
-  return PolylineAnnotationMessagerFlutterError("channel-error", "Unable to establish connection on channel: '$channelName'.", "")
+private fun createConnectionError(channelName: String): FlutterError {
+  return FlutterError("channel-error", "Unable to establish connection on channel: '$channelName'.", "")
 }
-
-/**
- * Error class for passing custom error details to Flutter via a thrown PlatformException.
- * @property code The error code.
- * @property message The error message.
- * @property details The error details. Must be a datatype supported by the api codec.
- */
-class PolylineAnnotationMessagerFlutterError(
-  val code: String,
-  override val message: String? = null,
-  val details: Any? = null
-) : Throwable()
 
 /** The display of line endings. */
 enum class LineCap(val raw: Int) {
@@ -266,7 +254,7 @@ class OnPolylineAnnotationClickListener(private val binaryMessenger: BinaryMesse
     channel.send(listOf(annotationArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(PolylineAnnotationMessagerFlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/Settings.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/Settings.kt
@@ -16,7 +16,7 @@ private fun wrapResult(result: Any?): List<Any?> {
 }
 
 private fun wrapError(exception: Throwable): List<Any?> {
-  if (exception is SettingsFlutterError) {
+  if (exception is FlutterError) {
     return listOf(
       exception.code,
       exception.message,
@@ -30,18 +30,6 @@ private fun wrapError(exception: Throwable): List<Any?> {
     )
   }
 }
-
-/**
- * Error class for passing custom error details to Flutter via a thrown PlatformException.
- * @property code The error code.
- * @property message The error message.
- * @property details The error details. Must be a datatype supported by the api codec.
- */
-class SettingsFlutterError(
-  val code: String,
-  override val message: String? = null,
-  val details: Any? = null
-) : Throwable()
 
 enum class OrnamentPosition(val raw: Int) {
   TOP_LEFT(0),

--- a/example/integration_test/style/source/image_source_test.dart
+++ b/example/integration_test/style/source/image_source_test.dart
@@ -8,7 +8,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
 import 'package:mapbox_maps_example/empty_map_widget.dart' as app;
-import 'package:turf/helpers.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();

--- a/example/integration_test/style/source/raster_source_test.dart
+++ b/example/integration_test/style/source/raster_source_test.dart
@@ -8,7 +8,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
 import 'package:mapbox_maps_example/empty_map_widget.dart' as app;
-import 'package:turf/helpers.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();

--- a/example/integration_test/style/source/rasterdem_source_test.dart
+++ b/example/integration_test/style/source/rasterdem_source_test.dart
@@ -8,7 +8,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
 import 'package:mapbox_maps_example/empty_map_widget.dart' as app;
-import 'package:turf/helpers.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();

--- a/example/integration_test/style/source/vector_source_test.dart
+++ b/example/integration_test/style/source/vector_source_test.dart
@@ -8,7 +8,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
 import 'package:mapbox_maps_example/empty_map_widget.dart' as app;
-import 'package:turf/helpers.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();

--- a/example/lib/circle_annotations.dart
+++ b/example/lib/circle_annotations.dart
@@ -37,13 +37,7 @@ class CircleAnnotationPageBodyState extends State<CircleAnnotationPageBody> {
   _onMapCreated(MapboxMap mapboxMap) {
     this.mapboxMap = mapboxMap;
     mapboxMap.setCamera(CameraOptions(
-      center:
-        Point(coordinates: Position(
-          0, 0
-        )),
-      zoom: 1,
-      pitch: 0)
-    );
+        center: Point(coordinates: Position(0, 0)), zoom: 1, pitch: 0));
     mapboxMap.annotations.createCircleAnnotationManager().then((value) {
       circleAnnotationManager = value;
       createOneAnnotation();

--- a/example/lib/cluster.dart
+++ b/example/lib/cluster.dart
@@ -29,14 +29,13 @@ class StyleClustersPageBodyState extends State<StyleClustersPageBody> {
   _onMapCreated(MapboxMap mapboxMap) {
     this.mapboxMap = mapboxMap;
     mapboxMap.setCamera(CameraOptions(
-      center:
-        Point(coordinates: Position(
+        center: Point(
+            coordinates: Position(
           -103.94925008414447,
           10.867890040082585,
         )),
-      zoom: 1,
-      pitch: 0)
-    );
+        zoom: 1,
+        pitch: 0));
     _addLayerAndSource();
   }
 

--- a/example/lib/point_annotations.dart
+++ b/example/lib/point_annotations.dart
@@ -37,14 +37,8 @@ class PointAnnotationPageBodyState extends State<PointAnnotationPageBody> {
   int styleIndex = 1;
   _onMapCreated(MapboxMap mapboxMap) {
     this.mapboxMap = mapboxMap;
-      mapboxMap.setCamera(CameraOptions(
-      center:
-        Point(coordinates: Position(
-          0, 0
-        )),
-      zoom: 1,
-      pitch: 0)
-    );
+    mapboxMap.setCamera(CameraOptions(
+        center: Point(coordinates: Position(0, 0)), zoom: 1, pitch: 0));
     mapboxMap.annotations.createPointAnnotationManager().then((value) async {
       pointAnnotationManager = value;
       final ByteData bytes =

--- a/example/lib/polygon_annotations.dart
+++ b/example/lib/polygon_annotations.dart
@@ -38,13 +38,9 @@ class PolygonAnnotationPageBodyState extends State<PolygonAnnotationPageBody> {
   _onMapCreated(MapboxMap mapboxMap) {
     this.mapboxMap = mapboxMap;
     mapboxMap.setCamera(CameraOptions(
-      center:
-        Point(coordinates: Position(
-          -3.363937, -10.733102
-        )),
-      zoom: 1,
-      pitch: 0)
-    );
+        center: Point(coordinates: Position(-3.363937, -10.733102)),
+        zoom: 1,
+        pitch: 0));
     mapboxMap.annotations.createPolygonAnnotationManager().then((value) {
       polygonAnnotationManager = value;
       createOneAnnotation();

--- a/example/lib/polyline_annotations.dart
+++ b/example/lib/polyline_annotations.dart
@@ -40,13 +40,7 @@ class PolylineAnnotationPageBodyState
   _onMapCreated(MapboxMap mapboxMap) {
     this.mapboxMap = mapboxMap;
     mapboxMap.setCamera(CameraOptions(
-      center:
-        Point(coordinates: Position(
-          0, 0
-        )),
-      zoom: 1,
-      pitch: 0)
-    );
+        center: Point(coordinates: Position(0, 0)), zoom: 1, pitch: 0));
     mapboxMap.annotations.createPolylineAnnotationManager().then((value) {
       polylineAnnotationManager = value;
       createOneAnnotation();


### PR DESCRIPTION
### What does this pull request do?

This PR utilizes `includeErrorClass` option released in Pigeon 17.1.0 to reuse `FlutterError` type instead of generating unique error type for each template.


### What is the motivation and context behind this change?

Cleaner codegen on our side.
