### PR TITLE
Deprecate old camera api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ CameraOptions(
 
 * Bump Pigeon to 17.1.2
 * [iOS] Fix crash in `onStyleImageMissingListener`.
+* Deprecate `cameraForCoordinates`, please use `cameraForCoordinatesPadding` instead.
 
 ### 1.0.0
 

--- a/example/integration_test/camera_test.dart
+++ b/example/integration_test/camera_test.dart
@@ -76,33 +76,6 @@ void main() {
     expect(camera.anchor, isNull);
   });
 
-  testWidgets('cameraForCoordinates', (WidgetTester tester) async {
-    final mapFuture = app.main();
-    await tester.pumpAndSettle();
-    final mapboxMap = await mapFuture;
-
-    var camera = await mapboxMap.cameraForCoordinates([
-      Point(
-          coordinates: Position(
-        1.0,
-        2.0,
-      )),
-      Point(
-          coordinates: Position(
-        3.0,
-        4.0,
-      ))
-    ], MbxEdgeInsets(top: 1, left: 2, bottom: 3, right: 4), 10, 20);
-    expect(camera.bearing, 10);
-    expect(camera.pitch, 20);
-    // TODO zoom might be different depending whether surface has changed the size
-    // expect(camera.zoom!.round(), 7);
-    final position = camera.center;
-    expect((position?.coordinates.lng as double).round(), 2);
-    expect((position?.coordinates.lat as double).round(), 3);
-    expect(camera.anchor, isNull);
-  });
-
   testWidgets('cameraForCoordinatesCameraOptions', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();

--- a/example/lib/camera.dart
+++ b/example/lib/camera.dart
@@ -71,32 +71,6 @@ class CameraPageBodyState extends State<CameraPageBody> {
     );
   }
 
-  Widget _cameraForCoordinates() {
-    return TextButton(
-      child: Text('cameraForCoordinates'),
-      onPressed: () {
-        mapboxMap?.cameraForCoordinates([
-          Point(
-              coordinates: Position(
-            1.0,
-            2.0,
-          )),
-          Point(
-              coordinates: Position(
-            3.0,
-            4.0,
-          ))
-        ], MbxEdgeInsets(top: 1, left: 2, bottom: 3, right: 4), 10, 20).then(
-            (value) => ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-                  content: Text(
-                      "Camera zoom: ${value.zoom}, pitch: ${value.pitch}, bearing: ${value.bearing},padding: ${value.padding},center: ${value.center}"),
-                  backgroundColor: Theme.of(context).primaryColor,
-                  duration: Duration(seconds: 2),
-                )));
-      },
-    );
-  }
-
   Widget _cameraForCoordinatesCameraOptions() {
     return TextButton(
       child: Text('cameraForCoordinatesCameraOptions'),
@@ -434,7 +408,6 @@ class CameraPageBodyState extends State<CameraPageBody> {
     listViewChildren.addAll(
       <Widget>[
         _cameraForCoordinateBounds(),
-        _cameraForCoordinates(),
         _cameraForCoordinatesCameraOptions(),
         _cameraForGeometry(),
         _coordinateBoundsForCamera(),

--- a/lib/src/mapbox_map.dart
+++ b/lib/src/mapbox_map.dart
@@ -233,6 +233,7 @@ class MapboxMap extends ChangeNotifier {
           bounds, padding, bearing, pitch, maxZoom, offset);
 
   /// Convenience method that returns the `camera options` object for given parameters.
+  @Deprecated('Use [cameraForCoordinatesPadding] instead')
   Future<CameraOptions> cameraForCoordinates(List<Point> coordinates,
           MbxEdgeInsets padding, double? bearing, double? pitch) =>
       _cameraManager.cameraForCoordinates(coordinates, padding, bearing, pitch);


### PR DESCRIPTION
### What does this pull request do?

This PR deprecates `cameraForCoordinates` API, which has been deprecated in GL-Native, iOS and maybe Android (?!)


### What is the motivation and context behind this change?



### Pull request checklist:
 - [x] Add a changelog entry.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
