### PR TITLE
Allows setting empty byte array to remove puck's images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 ### main
 
 * Mark `MapboxMapsOptions.get/setWorldview()` and `MapboxMapsOptions.get/setLanguage()` as experimental.
+* Bump Pigeon to 17.1.2
+* [iOS] Fix crash in `onStyleImageMissingListener`.
+* Deprecate `cameraForCoordinates`, please use `cameraForCoordinatesPadding` instead.
+* Add a way to disable default puck' image(s) when using `DefaultLocationPuck2D` by passing an empty byte array, for example, the following code shows a puck 2D with custom top image, default bearing image and no shadow image.
+```
+mapboxMap?.location.updateSettings(LocationComponentSettings(
+    enabled: true,
+    puckBearingEnabled: true,
+    locationPuck:
+        LocationPuck(locationPuck2D: DefaultLocationPuck2D(topImage: list, shadowImage: Uint8List.fromList([]))))
+);
+```
 
 #### ⚠️ Breaking change
 
@@ -24,10 +36,6 @@ CameraOptions(
         51.50325,
     )))
 ```
-
-* Bump Pigeon to 17.1.2
-* [iOS] Fix crash in `onStyleImageMissingListener`.
-* Deprecate `cameraForCoordinates`, please use `cameraForCoordinatesPadding` instead.
 
 ### 1.0.0
 

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/LocationComponentController.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/LocationComponentController.kt
@@ -5,7 +5,6 @@ import com.mapbox.maps.MapView
 import com.mapbox.maps.mapbox_maps.mapping.applyFromFLT
 import com.mapbox.maps.mapbox_maps.mapping.toFLT
 import com.mapbox.maps.mapbox_maps.pigeons.*
-import com.mapbox.maps.plugin.LocationPuck2D
 import com.mapbox.maps.plugin.locationcomponent.createDefault2DPuck
 import com.mapbox.maps.plugin.locationcomponent.location
 
@@ -14,16 +13,9 @@ class LocationComponentController(private val mapView: MapView, private val cont
   override fun getSettings(): LocationComponentSettings = mapView.location.toFLT(context)
 
   override fun updateSettings(settings: LocationComponentSettings, useDefaultPuck2DIfNeeded: Boolean) {
-    mapView.location.applyFromFLT(settings, context)
-    mapView.location.apply {
-      if (locationPuck is LocationPuck2D && useDefaultPuck2DIfNeeded) {
-        locationPuck = createDefault2DPuck(withBearing = settings.puckBearingEnabled == true)
-          .apply {
-            (locationPuck as LocationPuck2D).topImage?.let { topImage = it }
-            (locationPuck as LocationPuck2D).bearingImage?.let { bearingImage = it }
-            (locationPuck as LocationPuck2D).shadowImage?.let { shadowImage = it }
-          }
-      }
+    if (useDefaultPuck2DIfNeeded) {
+      mapView.location.locationPuck = createDefault2DPuck(withBearing = settings.puckBearingEnabled == true)
     }
+    mapView.location.applyFromFLT(settings, useDefaultPuck2DIfNeeded, context)
   }
 }

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/mapping/LocationComponentMappings.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/mapping/LocationComponentMappings.kt
@@ -8,10 +8,11 @@ import com.mapbox.maps.ImageHolder
 import com.mapbox.maps.mapbox_maps.pigeons.*
 import com.mapbox.maps.mapbox_maps.toFLTModelScaleMode
 import com.mapbox.maps.mapbox_maps.toModelScaleMode
+import com.mapbox.maps.plugin.locationcomponent.createDefault2DPuck
 import com.mapbox.maps.plugin.locationcomponent.generated.LocationComponentSettingsInterface
 import java.io.ByteArrayOutputStream
 
-fun LocationComponentSettingsInterface.applyFromFLT(settings: LocationComponentSettings, context: Context) {
+fun LocationComponentSettingsInterface.applyFromFLT(settings: LocationComponentSettings, useDefaultPuck2DIfNeeded: Boolean, context: Context) {
   settings.enabled?.let { enabled = it }
   settings.pulsingEnabled?.let { pulsingEnabled = it }
   settings.pulsingColor?.let { pulsingColor = it.toInt() }
@@ -46,13 +47,14 @@ fun LocationComponentSettingsInterface.applyFromFLT(settings: LocationComponentS
         puck3D.modelEmissiveStrengthExpression?.let { modelEmissiveStrengthExpression = it }
       }
     } else {
-      com.mapbox.maps.plugin.LocationPuck2D().apply {
-        puck2D?.topImage?.let { topImage = ImageHolder.from(BitmapFactory.decodeByteArray(it, 0, it.size)) }
-        puck2D?.bearingImage?.let { bearingImage = ImageHolder.from(BitmapFactory.decodeByteArray(it, 0, it.size)) }
-        puck2D?.shadowImage?.let { shadowImage = ImageHolder.from(BitmapFactory.decodeByteArray(it, 0, it.size)) }
-        puck2D?.scaleExpression?.let { scaleExpression = it }
-        puck2D?.opacity?.let { opacity = it.toFloat() }
-      }
+      (if (useDefaultPuck2DIfNeeded) createDefault2DPuck(withBearing = puckBearingEnabled) else com.mapbox.maps.plugin.LocationPuck2D())
+        .apply {
+          puck2D?.topImage?.let { topImage = if (it.isNotEmpty()) ImageHolder.from(BitmapFactory.decodeByteArray(it, 0, it.size)) else null }
+          puck2D?.bearingImage?.let { bearingImage = if (it.isNotEmpty()) ImageHolder.from(BitmapFactory.decodeByteArray(it, 0, it.size)) else null }
+          puck2D?.shadowImage?.let { shadowImage = if (it.isNotEmpty()) ImageHolder.from(BitmapFactory.decodeByteArray(it, 0, it.size)) else null }
+          puck2D?.scaleExpression?.let { scaleExpression = it }
+          puck2D?.opacity?.let { opacity = it.toFloat() }
+        }
     }
   }
 }

--- a/example/lib/location.dart
+++ b/example/lib/location.dart
@@ -171,8 +171,10 @@ class LocationPageBodyState extends State<LocationPageBody> {
         final Uint8List list = bytes.buffer.asUint8List();
 
         mapboxMap?.location.updateSettings(LocationComponentSettings(
+          enabled: true,
+            puckBearingEnabled: true,
             locationPuck:
-                LocationPuck(locationPuck2D: LocationPuck2D(topImage: list))));
+                LocationPuck(locationPuck2D: DefaultLocationPuck2D(topImage: list, shadowImage: Uint8List.fromList([])))));
       },
     );
   }


### PR DESCRIPTION
### What does this pull request do?

Allows setting an empty byte array to puck's images, when this is set, the image will be disable on the puck
```
// This will use a puck with custom topImage, default bearing image and no shadow image
mapboxMap?.location.updateSettings(LocationComponentSettings(
          enabled: true,
          puckBearingEnabled: true,
          locationPuck:
                LocationPuck(locationPuck2D: DefaultLocationPuck2D(topImage: list, shadowImage: Uint8List.fromList([])))));
```

### What is the motivation and context behind this change?

### Pull request checklist:
 - [ ] Add a changelog entry.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
