### PR TITLE
Fix crash due to lifecycle plugin.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### main
 
 * [iOS] Free up resources upon map widget disposal. This should help to reduce the amount of used memory when previously shown map widget is removed from the widget tree.
+* [Android] Fix `maps-lifecycle` plugin crash with `java.lang.IllegalStateException: Please ensure that the hosting activity/fragment is a valid LifecycleOwner`.
 
 ### 1.0.0-beta.2
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -63,9 +63,7 @@ if (file("$rootDir/gradle/ktlint.gradle").exists() && file("$rootDir/gradle/lint
 }
 
 dependencies {
-    implementation ("com.mapbox.maps:android:11.2.0") {
-        exclude group: 'com.mapbox.plugin', module: 'maps-lifecycle'
-    }
+    implementation "com.mapbox.maps:android:11.2.0"
 
     implementation "androidx.annotation:annotation:1.7.1"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.3.0"

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/MapboxMapController.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/MapboxMapController.kt
@@ -1,6 +1,5 @@
 package com.mapbox.maps.mapbox_maps
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.view.View
 import androidx.lifecycle.DefaultLifecycleObserver

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/MapboxMapController.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/MapboxMapController.kt
@@ -1,9 +1,13 @@
 package com.mapbox.maps.mapbox_maps
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.view.View
 import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.ViewTreeLifecycleOwner
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonElement
@@ -40,30 +44,106 @@ class MapboxMapController(
   DefaultLifecycleObserver,
   MethodChannel.MethodCallHandler {
 
-  private val mapView: MapView = MapView(context, mapInitOptions)
-  private val mapboxMap: MapboxMap = mapView.mapboxMap
+  private var mapView: MapView? = null
+  private var mapboxMap: MapboxMap? = null
   private val methodChannel: MethodChannel
-  private val styleController: StyleController = StyleController(mapboxMap, context)
-  private val cameraController: CameraController = CameraController(mapboxMap, context)
-  private val projectionController: MapProjectionController = MapProjectionController(mapboxMap)
-  private val mapInterfaceController: MapInterfaceController = MapInterfaceController(mapboxMap, context)
-  private val animationController: AnimationController = AnimationController(mapboxMap, context)
-  private val annotationController: AnnotationController = AnnotationController(mapView)
-  private val locationComponentController = LocationComponentController(mapView, context)
-  private val gestureController = GestureController(mapView)
-  private val logoController = LogoController(mapView)
-  private val attributionController = AttributionController(mapView)
-  private val scaleBarController = ScaleBarController(mapView)
-  private val compassController = CompassController(mapView)
+  private val styleController: StyleController
+  private val cameraController: CameraController
+  private val projectionController: MapProjectionController
+  private val mapInterfaceController: MapInterfaceController
+  private val animationController: AnimationController
+  private val annotationController: AnnotationController
+  private val locationComponentController: LocationComponentController
+  private val gestureController: GestureController
+  private val logoController: LogoController
+  private val attributionController: AttributionController
+  private val scaleBarController: ScaleBarController
+  private val compassController: CompassController
 
   private val proxyBinaryMessenger = ProxyBinaryMessenger(messenger, "/map_$channelSuffix")
   private val gson = GsonBuilder()
     .registerTypeAdapter(Date::class.java, MicrosecondsDateTypeAdapter)
     .registerTypeAdapterFactory(EnumOrdinalTypeAdapterFactory)
     .create()
+
+  /*
+    Mirrors lifecycle of the parent, with one addition - switches to DESTROYED state
+    when `dispose` is called.
+    `parentLifecycle` is the lifecycle of the Flutter activity, which may live much longer then
+    the MapView attached.
+  */
+  private class LifecycleHelper(
+    val parentLifecycle: Lifecycle,
+  ) : LifecycleOwner, DefaultLifecycleObserver {
+
+    val lifecycleRegistry: LifecycleRegistry = LifecycleRegistry(this)
+
+    init {
+      parentLifecycle.addObserver(this)
+    }
+
+    override fun getLifecycle(): Lifecycle {
+      return lifecycleRegistry
+    }
+
+    override fun onCreate(owner: LifecycleOwner) {
+      lifecycleRegistry.currentState = Lifecycle.State.CREATED
+    }
+
+    override fun onStart(owner: LifecycleOwner) {
+      lifecycleRegistry.currentState = Lifecycle.State.STARTED
+    }
+
+    override fun onResume(owner: LifecycleOwner) {
+      lifecycleRegistry.currentState = Lifecycle.State.RESUMED
+    }
+
+    override fun onPause(owner: LifecycleOwner) {
+      lifecycleRegistry.currentState = Lifecycle.State.STARTED
+    }
+
+    override fun onStop(owner: LifecycleOwner) {
+      lifecycleRegistry.currentState = Lifecycle.State.CREATED
+    }
+
+    override fun onDestroy(owner: LifecycleOwner) {
+      lifecycleRegistry.currentState = Lifecycle.State.DESTROYED
+    }
+
+    fun dispose() {
+      parentLifecycle.removeObserver(this)
+      // fires MapView.onStop
+      lifecycleRegistry.currentState = Lifecycle.State.CREATED
+      // fires MapView.onDestroy
+      lifecycleRegistry.currentState = Lifecycle.State.DESTROYED
+    }
+  }
+
+  private val lifecycleHelper: LifecycleHelper
+
   init {
+    val mapView = MapView(context, mapInitOptions)
+    val mapboxMap = mapView.mapboxMap
+    this.mapView = mapView
+    this.mapboxMap = mapboxMap
+    styleController = StyleController(mapboxMap, context)
+    cameraController = CameraController(mapboxMap, context)
+    projectionController = MapProjectionController(mapboxMap)
+    mapInterfaceController = MapInterfaceController(mapboxMap, context)
+    animationController = AnimationController(mapboxMap, context)
+    annotationController = AnnotationController(mapView)
+    locationComponentController = LocationComponentController(mapView, context)
+    gestureController = GestureController(mapView)
+    logoController = LogoController(mapView)
+    attributionController = AttributionController(mapView)
+    scaleBarController = ScaleBarController(mapView)
+    compassController = CompassController(mapView)
+
     changeUserAgent(pluginVersion)
-    lifecycleProvider.getLifecycle()?.addObserver(this)
+
+    lifecycleHelper = LifecycleHelper(lifecycleProvider.getLifecycle()!!)
+    ViewTreeLifecycleOwner.set(mapView, lifecycleHelper)
+
     StyleManager.setUp(proxyBinaryMessenger, styleController)
     _CameraManager.setUp(proxyBinaryMessenger, cameraController)
     Projection.setUp(proxyBinaryMessenger, projectionController)
@@ -82,67 +162,68 @@ class MapboxMapController(
 
     // TODO: check if state-triggered subscription change does not lead to multiple subscriptions/not unsubscribing when listener becomes null
     for (event in eventTypes) {
-      subscribeToEvent(_MapEvent.values()[event])
+      mapboxMap.subscribeToEvent(_MapEvent.values()[event])
     }
   }
 
-  private fun subscribeToEvent(event: _MapEvent) {
+  private fun MapboxMap.subscribeToEvent(event: _MapEvent) {
     when (event) {
-      _MapEvent.MAP_LOADED -> mapboxMap.subscribeMapLoaded {
+      _MapEvent.MAP_LOADED -> subscribeMapLoaded {
         methodChannel.invokeMethod(event.methodName, gson.toJson(it))
       }
-      _MapEvent.MAP_LOADING_ERROR -> mapboxMap.subscribeMapLoadingError {
+      _MapEvent.MAP_LOADING_ERROR -> subscribeMapLoadingError {
         methodChannel.invokeMethod(event.methodName, gson.toJson(it))
       }
-      _MapEvent.STYLE_LOADED -> mapboxMap.subscribeStyleLoaded {
+      _MapEvent.STYLE_LOADED -> subscribeStyleLoaded {
         methodChannel.invokeMethod(event.methodName, gson.toJson(it))
       }
-      _MapEvent.STYLE_DATA_LOADED -> mapboxMap.subscribeStyleDataLoaded {
+      _MapEvent.STYLE_DATA_LOADED -> subscribeStyleDataLoaded {
         methodChannel.invokeMethod(event.methodName, gson.toJson(it))
       }
-      _MapEvent.CAMERA_CHANGED -> mapboxMap.subscribeCameraChanged {
+      _MapEvent.CAMERA_CHANGED -> subscribeCameraChanged {
         methodChannel.invokeMethod(event.methodName, gson.toJson(it))
       }
-      _MapEvent.MAP_IDLE -> mapboxMap.subscribeMapIdle {
+      _MapEvent.MAP_IDLE -> subscribeMapIdle {
         methodChannel.invokeMethod(event.methodName, gson.toJson(it))
       }
-      _MapEvent.SOURCE_ADDED -> mapboxMap.subscribeSourceAdded {
+      _MapEvent.SOURCE_ADDED -> subscribeSourceAdded {
         methodChannel.invokeMethod(event.methodName, gson.toJson(it))
       }
-      _MapEvent.SOURCE_REMOVED -> mapboxMap.subscribeSourceRemoved {
+      _MapEvent.SOURCE_REMOVED -> subscribeSourceRemoved {
         methodChannel.invokeMethod(event.methodName, gson.toJson(it))
       }
-      _MapEvent.SOURCE_DATA_LOADED -> mapboxMap.subscribeSourceDataLoaded {
+      _MapEvent.SOURCE_DATA_LOADED -> subscribeSourceDataLoaded {
         methodChannel.invokeMethod(event.methodName, gson.toJson(it))
       }
-      _MapEvent.STYLE_IMAGE_MISSING -> mapboxMap.subscribeStyleImageMissing {
+      _MapEvent.STYLE_IMAGE_MISSING -> subscribeStyleImageMissing {
         methodChannel.invokeMethod(event.methodName, gson.toJson(it))
       }
-      _MapEvent.STYLE_IMAGE_REMOVE_UNUSED -> mapboxMap.subscribeStyleImageRemoveUnused {
+      _MapEvent.STYLE_IMAGE_REMOVE_UNUSED -> subscribeStyleImageRemoveUnused {
         methodChannel.invokeMethod(event.methodName, gson.toJson(it))
       }
-      _MapEvent.RENDER_FRAME_STARTED -> mapboxMap.subscribeRenderFrameStarted {
+      _MapEvent.RENDER_FRAME_STARTED -> subscribeRenderFrameStarted {
         methodChannel.invokeMethod(event.methodName, gson.toJson(it))
       }
-      _MapEvent.RENDER_FRAME_FINISHED -> mapboxMap.subscribeRenderFrameFinished {
+      _MapEvent.RENDER_FRAME_FINISHED -> subscribeRenderFrameFinished {
         methodChannel.invokeMethod(event.methodName, gson.toJson(it))
       }
-      _MapEvent.RESOURCE_REQUEST -> mapboxMap.subscribeResourceRequest {
+      _MapEvent.RESOURCE_REQUEST -> subscribeResourceRequest {
         methodChannel.invokeMethod(event.methodName, gson.toJson(it))
       }
     }
   }
 
-  override fun getView(): View {
+  override fun getView(): View? {
     return mapView
   }
 
-  override fun dispose() { }
-
-  private fun releaseMethodChannels() {
-    lifecycleProvider.getLifecycle()?.removeObserver(this)
-    mapView.onStop()
-    mapView.onDestroy()
+  override fun dispose() {
+    if (mapView == null) {
+      return
+    }
+    lifecycleHelper.dispose()
+    mapView = null
+    mapboxMap = null
     methodChannel.setMethodCallHandler(null)
     StyleManager.setUp(proxyBinaryMessenger, null)
     _CameraManager.setUp(proxyBinaryMessenger, null)
@@ -156,16 +237,6 @@ class MapboxMapController(
     CompassSettingsInterface.setUp(proxyBinaryMessenger, null)
     ScaleBarSettingsInterface.setUp(proxyBinaryMessenger, null)
     AttributionSettingsInterface.setUp(proxyBinaryMessenger, null)
-  }
-
-  override fun onStart(owner: LifecycleOwner) {
-    super.onStart(owner)
-    mapView.onStart()
-  }
-
-  override fun onStop(owner: LifecycleOwner) {
-    super.onStop(owner)
-    mapView.onStop()
   }
 
   override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
@@ -185,7 +256,7 @@ class MapboxMapController(
         result.success(null)
       }
       "platform#releaseMethodChannels" -> {
-        releaseMethodChannels()
+        dispose()
         result.success(null)
       }
       else -> {

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/MapboxMapsPlugin.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/MapboxMapsPlugin.kt
@@ -13,21 +13,12 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 
 /** MapboxMapsPlugin */
-class MapboxMapsPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
+class MapboxMapsPlugin : FlutterPlugin, ActivityAware {
   private val optionsController = MapboxOptionsController()
 
   private var lifecycle: Lifecycle? = null
 
-  // / The MethodChannel that will the communication between Flutter and native Android
-  // /
-  // / This local reference serves to register the plugin with the Flutter Engine and unregister it
-  // / when the Flutter Engine is detached from the Activity
-  private lateinit var channel: MethodChannel
-
   override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
-    channel = MethodChannel(flutterPluginBinding.binaryMessenger, "mapbox_maps")
-    channel.setMethodCallHandler(this)
-
     // static options handling should be setup upon attachment,
     // as options can before configured before the map view is setup
     _MapboxMapsOptions.setUp(flutterPluginBinding.binaryMessenger, optionsController)
@@ -50,11 +41,7 @@ class MapboxMapsPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
       )
   }
 
-  override fun onMethodCall(call: MethodCall, result: Result) {
-  }
-
   override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
-    channel.setMethodCallHandler(null)
   }
 
   override fun onAttachedToActivity(binding: ActivityPluginBinding) {

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/MapboxMapsPlugin.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/MapboxMapsPlugin.kt
@@ -7,10 +7,6 @@ import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 import io.flutter.embedding.engine.plugins.lifecycle.FlutterLifecycleAdapter
-import io.flutter.plugin.common.MethodCall
-import io.flutter.plugin.common.MethodChannel
-import io.flutter.plugin.common.MethodChannel.MethodCallHandler
-import io.flutter.plugin.common.MethodChannel.Result
 
 /** MapboxMapsPlugin */
 class MapboxMapsPlugin : FlutterPlugin, ActivityAware {


### PR DESCRIPTION
### What does this pull request do?

Addresses the issue that was caused by the `maps-lifecycle` plugin being pulled to the build.
Normally it was excluded from the flutter plugin explicitly [here](https://github.com/mapbox/mapbox-maps-flutter/blob/main/android/build.gradle#L66), and instead lifecycle methods onStart/onStop/onDestroy were called directly on the MapView.

However, other 3-party plugins could still bring the dependency. 
The plugin then crashes internally within [ViewLifecycleOwner](https://github.com/mapbox/mapbox-maps-android/blob/main/plugin-lifecycle/src/main/java/com/mapbox/maps/plugin/lifecycle/ViewLifecycleOwner.kt#L69).

In this PR custom Lifecycle is implemented to manage MapView lifecycle calls, `maps-lifecycle` dependency is no longer excluded. 
Custom Lifecycle mirrors lifecycle of the hosting Flutter activity + additionally triggers MapView stop/destroy when widget is disposed but Flutter activity keeps living (that happens easily when MapView is added / removed from the screen).

### What is the motivation and context behind this change?

Should fix multiple reported issues about `java.lang.IllegalStateException: Please ensure that the hosting activity/fragment is a valid LifecycleOwner` : #259, #152, #60, #291, #477, #308, #50. 

### Pull request checklist:
 - [x] Add a changelog entry.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
