### PR TITLE
Fix style image methods hang&exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
-### main
-
+### 1.1.0
 
 * [Android] Fix `maps-lifecycle` plugin crash with `java.lang.IllegalStateException: Please ensure that the hosting activity/fragment is a valid LifecycleOwner`.
 * [Android] Fix `hasStyleImage()` method hanging.
 * [Android] Fix `getStyleImage()` method causing native exception.
 * [iOS] Fix crash in `onStyleImageMissingListener`.
-* Update Maps SDK to 11.3.0.
+* Update MapboxMaps version to 11.3.0. For platform-specific updates see: [iOS](https://github.com/mapbox/mapbox-maps-ios/releases/tag/v11.3.0)& [Android](https://github.com/mapbox/mapbox-maps-android/releases/tag/v11.3.0)
+
 
 ### 1.1.0-rc.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ### main
 
 * [Android] Fix `maps-lifecycle` plugin crash with `java.lang.IllegalStateException: Please ensure that the hosting activity/fragment is a valid LifecycleOwner`.
+* [Android] Fix `hasStyleImage()` method hanging.
+* [Android] Fix `getStyleImage()` method causing native exception.
 
 ### 1.1.0-rc.1
 

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/StyleController.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/StyleController.kt
@@ -500,7 +500,7 @@ class StyleController(private val mapboxMap: MapboxMap, private val context: Con
   }
 
   override fun hasStyleImage(imageId: String, result: FLTMapInterfaces.Result<Boolean>) {
-    mapboxMap.hasStyleImage(imageId)
+    result.success(mapboxMap.hasStyleImage(imageId))
   }
 
   override fun invalidateStyleCustomGeometrySourceTile(

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/StyleController.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/StyleController.kt
@@ -473,7 +473,9 @@ class StyleController(private val mapboxMap: MapboxMap, private val context: Con
     imageId: String,
     result: FLTMapInterfaces.NullableResult<FLTMapInterfaces.MbxImage>
   ) {
-    mapboxMap.getStyleImage(imageId)?.let { image ->
+    val image = mapboxMap.getStyleImage(imageId)
+
+    if (image != null) {
       val byteArray = ByteArray(image.data.buffer.capacity())
       image.data.buffer.get(byteArray)
       result.success(
@@ -483,8 +485,9 @@ class StyleController(private val mapboxMap: MapboxMap, private val context: Con
           .setData(byteArray)
           .build()
       )
+    } else {
+      result.success(null)
     }
-    result.success(null)
   }
 
   override fun removeStyleImage(imageId: String, result: FLTMapInterfaces.VoidResult) {

--- a/example/integration_test/style/style_test.dart
+++ b/example/integration_test/style/style_test.dart
@@ -463,12 +463,16 @@ void main() {
     await style.addStyleImage('icon', 1.0,
         MbxImage(width: 40, height: 40, data: list), true, [], [], null);
 
+    expect(await style.hasStyleImage('icon'), isTrue);
+
     getImage = await style.getStyleImage('icon');
     expect(getImage, isNotNull);
     expect(getImage!.width, 40);
     expect(getImage.height, 40);
 
     await style.removeStyleImage('icon');
+
+    expect(await style.hasStyleImage('icon'), isFalse);
 
     getImage = await style.getStyleImage('icon');
     expect(getImage, isNull);

--- a/ios/Classes/StyleController.swift
+++ b/ios/Classes/StyleController.swift
@@ -330,8 +330,8 @@ final class StyleController: NSObject, FLTStyleManager {
     }
 
     func hasStyleImageImageId(_ imageId: String, completion: @escaping (NSNumber?, FlutterError?) -> Void) {
-        let image = styleManager.image(withId: imageId)
-        completion(NSNumber(value: image != nil), nil)
+        let imageExists = styleManager.imageExists(withId: imageId)
+        completion(NSNumber(value: imageExists), nil)
     }
 //
 //    func setStyleCustomGeometrySourceTileDataSourceId(_ sourceId: String,


### PR DESCRIPTION
### What does this pull request do?

Fixes `hasStyleImage` hanging and `getStyleImage` causing exception from Flutter's method channel on Android.

### What is the motivation and context behind this change?



### Pull request checklist:
 - [ ] Add a changelog entry.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
