### PR TITLE
Expose Raster Array Source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### main
 
+* Introduce experimental `RasterArraySource`, note that `rasterLayers` is a get-only property. Use `mapboxMap.style.getStyleSourceProperty()` to fetch a value of `RasterArraySource.rasterLayers`.
 * Introduce `TileCacheBudget`, a property to set per-source cache budgets in either megabytes or tiles. 
 * Expose `iconColorSaturation`, `rasterArrayBand`, `rasterElevation`, `rasterEmissiveStrength`, `hillshadeEmissiveStrength`, and `fillExtrusionEmissiveStrength` on their respective layers. 
 * Mark `MapboxMapsOptions.get/setWorldview()` and `MapboxMapsOptions.get/setLanguage()` as experimental.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### main
 
-* Introduce experimental `RasterArraySource`, note that `bounds`, `attribution`, `tileSize`, and `rasterLayers` are get-only properties. Use `mapboxMap.style.getStyleSourceProperty()` to fetch their values.
+* Introduce experimental `RasterArraySource`, note that `rasterLayers` is a get-only property and cannot be set.
 * Introduce `TileCacheBudget`, a property to set per-source cache budgets in either megabytes or tiles. 
 * Expose `iconColorSaturation`, `rasterArrayBand`, `rasterElevation`, `rasterEmissiveStrength`, `hillshadeEmissiveStrength`, and `fillExtrusionEmissiveStrength` on their respective layers. 
 * Mark `MapboxMapsOptions.get/setWorldview()` and `MapboxMapsOptions.get/setLanguage()` as experimental.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### main
 
-* Introduce experimental `RasterArraySource`, note that `rasterLayers` is a get-only property. Use `mapboxMap.style.getStyleSourceProperty()` to fetch a value of `RasterArraySource.rasterLayers`.
+* Introduce experimental `RasterArraySource`, note that `bounds`, `attribution`, `tileSize`, and `rasterLayers` are get-only properties. Use `mapboxMap.style.getStyleSourceProperty()` to fetch their values.
 * Introduce `TileCacheBudget`, a property to set per-source cache budgets in either megabytes or tiles. 
 * Expose `iconColorSaturation`, `rasterArrayBand`, `rasterElevation`, `rasterEmissiveStrength`, `hillshadeEmissiveStrength`, and `fillExtrusionEmissiveStrength` on their respective layers. 
 * Mark `MapboxMapsOptions.get/setWorldview()` and `MapboxMapsOptions.get/setLanguage()` as experimental.

--- a/example/assets/raster_array_layers.json
+++ b/example/assets/raster_array_layers.json
@@ -1,0 +1,76 @@
+{
+    "version": 8,
+    "name": "Temperature",
+    "sources": {
+    "mapbox": {
+        "type": "raster-array",
+        "tiles": ["mapbox://tiles/example/{z}/{x}/{y}.mrt"],
+        "scheme": "xyz",
+        "minzoom": 1,
+        "maxzoom": 4,
+        "attribution": "mapbox",
+        "volatile": true,
+        "raster_layers": [
+            {
+                "fields": {
+                    "bands": [
+                        "1659898800", "1659902400", "1659906000", "1659909600", "1659913200", "1659916800"
+                    ],
+                    "buffer": 1,
+                    "units": "degrees"
+                },
+                "id": "temperature",
+                "maxzoom": 3,
+                "minzoom": 0
+            },
+            {
+                "fields": {
+                    "bands": [
+                        "1659898800", "1659902400", "1659906000", "1659909600", "1659913200", "1659916800"
+                    ],
+                    "buffer": 1,
+                    "units": "percent"
+                },
+                "id": "humidity",
+                "maxzoom": 3,
+                "minzoom": 0
+            }
+        ]
+    }
+    },
+    "layers": [
+    {
+    "id": "temperature",
+    "type": "raster",
+    "source": "mapbox",
+    "source-layer": "temperature",
+    "paint": {
+        "raster-color": [
+            "interpolate",
+            [
+            "linear"
+            ],
+            [
+            "raster-value"
+            ],
+            -5,
+            "rgba(94, 79, 162, 0.8)",
+            0,
+            "rgba(75, 160, 177, 0.8)",
+            5,
+            "rgba(160, 217, 163, 0.8)",
+            10,
+            "rgba(235, 247, 166, 0.8)",
+            15,
+            "rgba(254, 232, 154, 0.8)",
+            20,
+            "rgba(251, 163, 94, 0.8)",
+            25,
+            "rgba(225, 82, 74, 0.8)",
+            30,
+            "rgba(158, 1, 66, 0.8)"
+        ],
+        "raster-color-range": [-5, 30]
+    }
+    }]
+}

--- a/example/integration_test/all_test.dart
+++ b/example/integration_test/all_test.dart
@@ -32,6 +32,7 @@ import 'style/source/geojson_source_test.dart' as geojson_source_test;
 import 'style/source/image_source_test.dart' as image_source_test;
 import 'style/source/raster_source_test.dart' as raster_source_test;
 import 'style/source/rasterdem_source_test.dart' as rasterdem_source_test;
+import 'style/source/rasterarray_source_test.dart' as rasterarray_source_test;
 import 'style/source/vector_source_test.dart' as vector_source_test;
 import 'style/style_test.dart' as style_test;
 import 'location_test.dart' as location_test;

--- a/example/integration_test/map_interface_test.dart
+++ b/example/integration_test/map_interface_test.dart
@@ -33,6 +33,56 @@ void main() {
     expect(styleJson, getStyleJson);
   });
 
+  testWidgets('loadRasterArray', (WidgetTester tester) async {
+    final mapFuture = app.main();
+    await tester.pumpAndSettle();
+    final mapboxMap = await mapFuture;
+    var styleJson =
+        await rootBundle.loadString('assets/raster_array_layers.json');
+    app.events.resetOnStyleLoaded();
+    mapboxMap.loadStyleJson(styleJson);
+
+    await app.events.onStyleLoaded.future;
+
+    var getStyleJson = await mapboxMap.style.getStyleJSON();
+    expect(styleJson, getStyleJson);
+
+    var rasterLayers =
+        await mapboxMap.style.getStyleSourceProperty("mapbox", "rasterLayers");
+    final Map<Object?, Object?> dataMap =
+        rasterLayers.value as Map<Object?, Object?>;
+    List<RasterDataLayer> rasterDataLayers = [];
+
+    dataMap.forEach((key, value) {
+      rasterDataLayers
+          .add(RasterDataLayer(key as String, (value as List).cast<String>()));
+    });
+
+    var expectedValue = [
+      RasterDataLayer("temperature", [
+        "1659898800",
+        "1659902400",
+        "1659906000",
+        "1659909600",
+        "1659913200",
+        "1659916800"
+      ]),
+      RasterDataLayer("humidity", [
+        "1659898800",
+        "1659902400",
+        "1659906000",
+        "1659909600",
+        "1659913200",
+        "1659916800"
+      ])
+    ];
+
+    expect(rasterDataLayers.first.layerId, expectedValue.first.layerId);
+    expect(rasterDataLayers.first.bands, expectedValue.first.bands);
+    expect(rasterDataLayers.last.layerId, expectedValue.last.layerId);
+    expect(rasterDataLayers.last.bands, expectedValue.last.bands);
+  });
+
   testWidgets('clearData', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();

--- a/example/integration_test/map_interface_test.dart
+++ b/example/integration_test/map_interface_test.dart
@@ -77,10 +77,8 @@ void main() {
       ])
     ];
 
-    expect(rasterDataLayers.first.layerId, expectedValue.first.layerId);
-    expect(rasterDataLayers.first.bands, expectedValue.first.bands);
-    expect(rasterDataLayers.last.layerId, expectedValue.last.layerId);
-    expect(rasterDataLayers.last.bands, expectedValue.last.bands);
+    expect(rasterDataLayers.contains(expectedValue.first), true);
+    expect(rasterDataLayers.contains(expectedValue.last), true);
   });
 
   testWidgets('clearData', (WidgetTester tester) async {

--- a/example/integration_test/style/source/rasterarray_source_test.dart
+++ b/example/integration_test/style/source/rasterarray_source_test.dart
@@ -1,0 +1,60 @@
+// This file is generated.
+import 'dart:convert';
+import 'dart:io';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart' hide Visibility;
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
+import 'package:mapbox_maps_example/empty_map_widget.dart' as app;
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('Add RasterArraySource', (WidgetTester tester) async {
+    final mapFuture = app.main();
+    await tester.pumpAndSettle();
+    final mapboxMap = await mapFuture;
+    await app.events.onMapLoaded.future;
+
+    await mapboxMap.style.addSource(RasterArraySource(
+      id: "source",
+      tiles: ["a", "b", "c"],
+      bounds: [0.0, 1.0, 2.0, 3.0],
+      minzoom: 1.0,
+      maxzoom: 1.0,
+      tileSize: 1.0,
+      attribution: "abc",
+      tileCacheBudget:
+          TileCacheBudget.inMegabytes(TileCacheBudgetInMegabytes(size: 3)),
+    ));
+
+    var source = await mapboxMap.style.getSource('source') as RasterArraySource;
+    expect(source.id, 'source');
+    var tiles = await source.tiles;
+    expect(tiles, ["a", "b", "c"]);
+
+    var bounds = await source.bounds;
+    expect(bounds, [0.0, 1.0, 2.0, 3.0]);
+
+    var minzoom = await source.minzoom;
+    expect(minzoom, 1.0);
+
+    var maxzoom = await source.maxzoom;
+    expect(maxzoom, 1.0);
+
+    var tileSize = await source.tileSize;
+    expect(tileSize, 1.0);
+
+    var attribution = await source.attribution;
+    expect(attribution, "abc");
+
+    var tileCacheBudget = await source.tileCacheBudget;
+    expect(tileCacheBudget?.size,
+        TileCacheBudget.inMegabytes(TileCacheBudgetInMegabytes(size: 3)).size);
+    expect(tileCacheBudget?.type,
+        TileCacheBudget.inMegabytes(TileCacheBudgetInMegabytes(size: 3)).type);
+  });
+}
+// End of generated file.

--- a/example/integration_test/style/source/rasterarray_source_test.dart
+++ b/example/integration_test/style/source/rasterarray_source_test.dart
@@ -21,8 +21,11 @@ void main() {
     await mapboxMap.style.addSource(RasterArraySource(
       id: "source",
       tiles: ["a", "b", "c"],
+      bounds: [0.0, 1.0, 2.0, 3.0],
       minzoom: 1.0,
       maxzoom: 1.0,
+      tileSize: 1.0,
+      attribution: "abc",
       tileCacheBudget:
           TileCacheBudget.inMegabytes(TileCacheBudgetInMegabytes(size: 3)),
     ));
@@ -32,11 +35,20 @@ void main() {
     var tiles = await source.tiles;
     expect(tiles, ["a", "b", "c"]);
 
+    var bounds = await source.bounds;
+    expect(bounds, [0.0, 1.0, 2.0, 3.0]);
+
     var minzoom = await source.minzoom;
     expect(minzoom, 1.0);
 
     var maxzoom = await source.maxzoom;
     expect(maxzoom, 1.0);
+
+    var tileSize = await source.tileSize;
+    expect(tileSize, 1.0);
+
+    var attribution = await source.attribution;
+    expect(attribution, "abc");
 
     var tileCacheBudget = await source.tileCacheBudget;
     expect(tileCacheBudget?.size,

--- a/example/integration_test/style/source/rasterarray_source_test.dart
+++ b/example/integration_test/style/source/rasterarray_source_test.dart
@@ -21,11 +21,8 @@ void main() {
     await mapboxMap.style.addSource(RasterArraySource(
       id: "source",
       tiles: ["a", "b", "c"],
-      bounds: [0.0, 1.0, 2.0, 3.0],
       minzoom: 1.0,
       maxzoom: 1.0,
-      tileSize: 1.0,
-      attribution: "abc",
       tileCacheBudget:
           TileCacheBudget.inMegabytes(TileCacheBudgetInMegabytes(size: 3)),
     ));
@@ -35,20 +32,11 @@ void main() {
     var tiles = await source.tiles;
     expect(tiles, ["a", "b", "c"]);
 
-    var bounds = await source.bounds;
-    expect(bounds, [0.0, 1.0, 2.0, 3.0]);
-
     var minzoom = await source.minzoom;
     expect(minzoom, 1.0);
 
     var maxzoom = await source.maxzoom;
     expect(maxzoom, 1.0);
-
-    var tileSize = await source.tileSize;
-    expect(tileSize, 1.0);
-
-    var attribution = await source.attribution;
-    expect(attribution, "abc");
 
     var tileCacheBudget = await source.tileCacheBudget;
     expect(tileCacheBudget?.size,

--- a/lib/mapbox_maps_flutter.dart
+++ b/lib/mapbox_maps_flutter.dart
@@ -52,6 +52,7 @@ part 'src/style/source/geojson_source.dart';
 part 'src/style/source/image_source.dart';
 part 'src/style/source/raster_source.dart';
 part 'src/style/source/rasterdem_source.dart';
+part 'src/style/source/rasterarray_source.dart';
 part 'src/style/source/vector_source.dart';
 part 'src/style/style.dart';
 part 'src/location_settings.dart';

--- a/lib/src/style/source/rasterarray_source.dart
+++ b/lib/src/style/source/rasterarray_source.dart
@@ -9,22 +9,14 @@ class RasterArraySource extends Source {
     required id,
     String? url,
     List<String?>? tiles,
-    List<double?>? bounds,
     double? minzoom,
     double? maxzoom,
-    double? tileSize,
-    String? attribution,
-    List<RasterDataLayer?>? rasterLayers,
     TileCacheBudget? tileCacheBudget,
   }) : super(id: id) {
     _url = url;
     _tiles = tiles;
-    _bounds = bounds;
     _minzoom = minzoom;
     _maxzoom = maxzoom;
-    _tileSize = tileSize;
-    _attribution = attribution;
-    _rasterLayers = rasterLayers;
     _tileCacheBudget = tileCacheBudget;
   }
 
@@ -56,8 +48,6 @@ class RasterArraySource extends Source {
       }
     });
   }
-
-  List<double?>? _bounds;
 
   /// An array containing the longitude and latitude of the southwest and northeast corners of the source's bounding box in the following order: `[sw.lng, sw.lat, ne.lng, ne.lat]`. When this property is included in a source, no tiles outside of the given bounds are requested by Mapbox GL.
   Future<List<double?>?> get bounds async {
@@ -96,8 +86,6 @@ class RasterArraySource extends Source {
     });
   }
 
-  double? _tileSize;
-
   /// The minimum visual size to display tiles for this layer. Only configurable for raster layers.
   Future<double?> get tileSize async {
     return _style?.getStyleSourceProperty(id, "tileSize").then((value) {
@@ -109,8 +97,6 @@ class RasterArraySource extends Source {
     });
   }
 
-  String? _attribution;
-
   /// Contains an attribution to be displayed when the map is shown to a user.
   Future<String?> get attribution async {
     return _style?.getStyleSourceProperty(id, "attribution").then((value) {
@@ -121,8 +107,6 @@ class RasterArraySource extends Source {
       }
     });
   }
-
-  List<RasterDataLayer?>? _rasterLayers;
 
   /// Contains the description of the raster data layers and the bands contained within the tiles.
   Future<List<RasterDataLayer?>?> get rasterLayers async {
@@ -167,23 +151,11 @@ class RasterArraySource extends Source {
       if (_tiles != null) {
         properties["tiles"] = _tiles;
       }
-      if (_bounds != null) {
-        properties["bounds"] = _bounds;
-      }
       if (_minzoom != null) {
         properties["minzoom"] = _minzoom;
       }
       if (_maxzoom != null) {
         properties["maxzoom"] = _maxzoom;
-      }
-      if (_tileSize != null) {
-        properties["tileSize"] = _tileSize;
-      }
-      if (_attribution != null) {
-        properties["attribution"] = _attribution;
-      }
-      if (_rasterLayers != null) {
-        properties["rasterLayers"] = _rasterLayers;
       }
     }
 

--- a/lib/src/style/source/rasterarray_source.dart
+++ b/lib/src/style/source/rasterarray_source.dart
@@ -9,14 +9,20 @@ class RasterArraySource extends Source {
     required id,
     String? url,
     List<String?>? tiles,
+    List<double?>? bounds,
     double? minzoom,
     double? maxzoom,
+    double? tileSize,
+    String? attribution,
     TileCacheBudget? tileCacheBudget,
   }) : super(id: id) {
     _url = url;
     _tiles = tiles;
+    _bounds = bounds;
     _minzoom = minzoom;
     _maxzoom = maxzoom;
+    _tileSize = tileSize;
+    _attribution = attribution;
     _tileCacheBudget = tileCacheBudget;
   }
 
@@ -48,6 +54,8 @@ class RasterArraySource extends Source {
       }
     });
   }
+
+  List<double?>? _bounds;
 
   /// An array containing the longitude and latitude of the southwest and northeast corners of the source's bounding box in the following order: `[sw.lng, sw.lat, ne.lng, ne.lat]`. When this property is included in a source, no tiles outside of the given bounds are requested by Mapbox GL.
   Future<List<double?>?> get bounds async {
@@ -86,6 +94,8 @@ class RasterArraySource extends Source {
     });
   }
 
+  double? _tileSize;
+
   /// The minimum visual size to display tiles for this layer. Only configurable for raster layers.
   Future<double?> get tileSize async {
     return _style?.getStyleSourceProperty(id, "tileSize").then((value) {
@@ -96,6 +106,8 @@ class RasterArraySource extends Source {
       }
     });
   }
+
+  String? _attribution;
 
   /// Contains an attribution to be displayed when the map is shown to a user.
   Future<String?> get attribution async {
@@ -108,11 +120,17 @@ class RasterArraySource extends Source {
     });
   }
 
+  List<RasterDataLayer?>? _rasterLayers;
+
   /// Contains the description of the raster data layers and the bands contained within the tiles.
   Future<List<RasterDataLayer?>?> get rasterLayers async {
     return _style?.getStyleSourceProperty(id, "rasterLayers").then((value) {
       if (value.value != null) {
-        return (value.value as List<dynamic>).cast();
+        return (value.value as Map<Object?, Object?>).entries.map((entry) {
+          return RasterDataLayer(
+              entry.key as String, (entry.value as List).cast<String>());
+        }).toList();
+        ;
       } else {
         return null;
       }
@@ -151,11 +169,23 @@ class RasterArraySource extends Source {
       if (_tiles != null) {
         properties["tiles"] = _tiles;
       }
+      if (_bounds != null) {
+        properties["bounds"] = _bounds;
+      }
       if (_minzoom != null) {
         properties["minzoom"] = _minzoom;
       }
       if (_maxzoom != null) {
         properties["maxzoom"] = _maxzoom;
+      }
+      if (_tileSize != null) {
+        properties["tileSize"] = _tileSize;
+      }
+      if (_attribution != null) {
+        properties["attribution"] = _attribution;
+      }
+      if (_rasterLayers != null) {
+        properties["rasterLayers"] = _rasterLayers;
       }
     }
 

--- a/lib/src/style/source/rasterarray_source.dart
+++ b/lib/src/style/source/rasterarray_source.dart
@@ -1,0 +1,194 @@
+// This file is generated.
+part of mapbox_maps_flutter;
+
+/// A raster array source
+/// @see [The online documentation](https://docs.mapbox.com/mapbox-gl-js/style-spec/sources/#raster_array)
+@experimental
+class RasterArraySource extends Source {
+  RasterArraySource({
+    required id,
+    String? url,
+    List<String?>? tiles,
+    List<double?>? bounds,
+    double? minzoom,
+    double? maxzoom,
+    double? tileSize,
+    String? attribution,
+    List<RasterDataLayer?>? rasterLayers,
+    TileCacheBudget? tileCacheBudget,
+  }) : super(id: id) {
+    _url = url;
+    _tiles = tiles;
+    _bounds = bounds;
+    _minzoom = minzoom;
+    _maxzoom = maxzoom;
+    _tileSize = tileSize;
+    _attribution = attribution;
+    _rasterLayers = rasterLayers;
+    _tileCacheBudget = tileCacheBudget;
+  }
+
+  @override
+  String getType() => "raster-array";
+
+  String? _url;
+
+  /// A URL to a TileJSON resource. Supported protocols are `http:`, `https:`, and `mapbox://<Tileset ID>`.
+  Future<String?> get url async {
+    return _style?.getStyleSourceProperty(id, "url").then((value) {
+      if (value.value != null) {
+        return value.value as String;
+      } else {
+        return null;
+      }
+    });
+  }
+
+  List<String?>? _tiles;
+
+  /// An array of one or more tile source URLs, as in the TileJSON spec.
+  Future<List<String?>?> get tiles async {
+    return _style?.getStyleSourceProperty(id, "tiles").then((value) {
+      if (value.value != null) {
+        return (value.value as List<dynamic>).cast();
+      } else {
+        return null;
+      }
+    });
+  }
+
+  List<double?>? _bounds;
+
+  /// An array containing the longitude and latitude of the southwest and northeast corners of the source's bounding box in the following order: `[sw.lng, sw.lat, ne.lng, ne.lat]`. When this property is included in a source, no tiles outside of the given bounds are requested by Mapbox GL.
+  Future<List<double?>?> get bounds async {
+    return _style?.getStyleSourceProperty(id, "bounds").then((value) {
+      if (value.value != null) {
+        return (value.value as List<dynamic>).cast();
+      } else {
+        return null;
+      }
+    });
+  }
+
+  double? _minzoom;
+
+  /// Minimum zoom level for which tiles are available, as in the TileJSON spec.
+  Future<double?> get minzoom async {
+    return _style?.getStyleSourceProperty(id, "minzoom").then((value) {
+      if (value.value != null) {
+        return (value.value as num).toDouble();
+      } else {
+        return null;
+      }
+    });
+  }
+
+  double? _maxzoom;
+
+  /// Maximum zoom level for which tiles are available, as in the TileJSON spec. Data from tiles at the maxzoom are used when displaying the map at higher zoom levels.
+  Future<double?> get maxzoom async {
+    return _style?.getStyleSourceProperty(id, "maxzoom").then((value) {
+      if (value.value != null) {
+        return (value.value as num).toDouble();
+      } else {
+        return null;
+      }
+    });
+  }
+
+  double? _tileSize;
+
+  /// The minimum visual size to display tiles for this layer. Only configurable for raster layers.
+  Future<double?> get tileSize async {
+    return _style?.getStyleSourceProperty(id, "tileSize").then((value) {
+      if (value.value != null) {
+        return (value.value as num).toDouble();
+      } else {
+        return null;
+      }
+    });
+  }
+
+  String? _attribution;
+
+  /// Contains an attribution to be displayed when the map is shown to a user.
+  Future<String?> get attribution async {
+    return _style?.getStyleSourceProperty(id, "attribution").then((value) {
+      if (value.value != null) {
+        return value.value as String;
+      } else {
+        return null;
+      }
+    });
+  }
+
+  List<RasterDataLayer?>? _rasterLayers;
+
+  /// Contains the description of the raster data layers and the bands contained within the tiles.
+  Future<List<RasterDataLayer?>?> get rasterLayers async {
+    return _style?.getStyleSourceProperty(id, "rasterLayers").then((value) {
+      if (value.value != null) {
+        return (value.value as List<dynamic>).cast();
+      } else {
+        return null;
+      }
+    });
+  }
+
+  TileCacheBudget? _tileCacheBudget;
+
+  /// This property defines a source-specific resource budget, either in tile units or in megabytes. Whenever the tile cache goes over the defined limit, the least recently used tile will be evicted from the in-memory cache. Note that the current implementation does not take into account resources allocated by the visible tiles.
+  Future<TileCacheBudget?> get tileCacheBudget async {
+    return _style
+        ?.getStyleSourceProperty(id, "tile-cache-budget")
+        .then((value) {
+      if (value.value != null) {
+        return TileCacheBudget.decode(value.value);
+      } else {
+        return null;
+      }
+    });
+  }
+
+  @override
+  String _encode(bool volatile) {
+    var properties = <String, dynamic>{};
+
+    if (volatile) {
+      if (_tileCacheBudget != null) {
+        properties["tile-cache-budget"] = _tileCacheBudget;
+      }
+    } else {
+      properties["id"] = id;
+      properties["type"] = getType();
+      if (_url != null) {
+        properties["url"] = _url;
+      }
+      if (_tiles != null) {
+        properties["tiles"] = _tiles;
+      }
+      if (_bounds != null) {
+        properties["bounds"] = _bounds;
+      }
+      if (_minzoom != null) {
+        properties["minzoom"] = _minzoom;
+      }
+      if (_maxzoom != null) {
+        properties["maxzoom"] = _maxzoom;
+      }
+      if (_tileSize != null) {
+        properties["tileSize"] = _tileSize;
+      }
+      if (_attribution != null) {
+        properties["attribution"] = _attribution;
+      }
+      if (_rasterLayers != null) {
+        properties["rasterLayers"] = _rasterLayers;
+      }
+    }
+
+    return json.encode(properties);
+  }
+}
+
+// End of generated file.

--- a/lib/src/style/style.dart
+++ b/lib/src/style/style.dart
@@ -142,12 +142,6 @@ class RasterDataLayer {
 
   Map<String, List<String>> toJson() => {layerId: bands};
 
-  static RasterDataLayer? decode(Object? layer) {
-    var layerObject = Map<String, dynamic>.from(layer as Map<dynamic, dynamic>)
-        .cast<String, dynamic>();
-    return RasterDataLayer(layerObject.keys.first, layerObject.values.first);
-  }
-
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||

--- a/lib/src/style/style.dart
+++ b/lib/src/style/style.dart
@@ -131,6 +131,26 @@ class TileCacheBudget {
   TileCacheBudget(this.type, this.size);
 }
 
+/// The description of the raster data layers and the bands contained within the tiles.
+@experimental
+class RasterDataLayer {
+  /// Identifier of the data layer fetched from tiles.
+  String layerId;
+
+  /// An array of bands found in the data layer.
+  List<String> bands;
+
+  Map<String, List<String>> toJson() => {layerId: bands};
+
+  static RasterDataLayer? decode(Object? layer) {
+    var layerObject = Map<String, dynamic>.from(layer as Map<dynamic, dynamic>)
+        .cast<String, dynamic>();
+    return RasterDataLayer(layerObject.keys.first, layerObject.values.first);
+  }
+
+  RasterDataLayer(this.layerId, this.bands);
+}
+
 /// Define the duration and delay for a style transition.
 class StyleTransition {
   StyleTransition({this.duration, this.delay});
@@ -313,6 +333,9 @@ extension StyleSource on StyleManager {
         break;
       case "raster":
         source = RasterSource(id: sourceId);
+        break;
+      case "raster-array":
+        source = RasterArraySource(id: sourceId);
         break;
       default:
         print("Source type: $type unknown.");

--- a/lib/src/style/style.dart
+++ b/lib/src/style/style.dart
@@ -148,6 +148,14 @@ class RasterDataLayer {
     return RasterDataLayer(layerObject.keys.first, layerObject.values.first);
   }
 
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RasterDataLayer &&
+          runtimeType == other.runtimeType &&
+          layerId == other.layerId &&
+          listEquals(bands, other.bands);
+
   RasterDataLayer(this.layerId, this.bands);
 }
 


### PR DESCRIPTION
### What does this pull request do?

This PR exposes `RasterArraySource`. Note that `rasterLayers` is a get-only property.

### What is the motivation and context behind this change?

Parity with [iOS](https://github.com/mapbox/mapbox-maps-ios/blob/main/Sources/MapboxMaps/Style/Generated/Sources/RasterArraySource.swift) and [Android](https://github.com/mapbox/mapbox-maps-android/blob/main/extension-style/src/main/java/com/mapbox/maps/extension/style/sources/generated/RasterArraySource.kt) SDKs. 


### Pull request checklist:
 - [ ] Add a changelog entry.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
