### PR TITLE
MapWidget snapshotting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ mapboxMap?.location.updateSettings(LocationComponentSettings(
         LocationPuck(locationPuck2D: DefaultLocationPuck2D(topImage: list, shadowImage: Uint8List.fromList([]))))
 );
 ```
-##### Snapshotter
+##### Snapshots
+
+###### Standalone snapshotter
 
 Show multiple maps in at the same time with no performance penalty. With all new `Snapshotter` you can get image snapshots of the map, styled the same way as `MapWidget`.
 
@@ -35,11 +37,25 @@ final snapshotter = await Snapshotter.create(
   },
 );
 snapshotter.style.setStyleURI(MapboxStyles.STANDARD);
+snapshotter.setCamera(CameraOptions(center: Point(...)));
 
 ...
 
 final snapshotImage = await snapshotter.start()
 ```
+##### Map wiget snapshotting
+
+Create snapshots of the map displayed in the `MapWidget` with `MapboxMap.snapshot()`. This new feature allows you to capture a static image of the current map view.
+
+The `snapshot()` method captures the current state of the Mapbox map, including all visible layers, markers, and user interactions.
+
+To use the snapshot() method, simply call it on your Mapbox map instance. The method will return a Future that resolves to the image of the current map view.
+
+```dart
+final snapshotImage = await mapboxMap.snapshot();
+```
+
+Please note that the `snapshot()` method works best if the Mapbox Map is fully loaded before capturing an image. If the map is not fully loaded, the method might return a blank image.
 
 #### ⚠️ Breaking changes
 

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/MapboxMapController.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/MapboxMapController.kt
@@ -1,6 +1,7 @@
 package com.mapbox.maps.mapbox_maps
 
 import android.content.Context
+import android.graphics.Bitmap
 import android.view.View
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
@@ -29,6 +30,7 @@ import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.platform.PlatformView
+import java.io.ByteArrayOutputStream
 
 class MapboxMapController(
   context: Context,
@@ -201,6 +203,21 @@ class MapboxMapController(
       "platform#releaseMethodChannels" -> {
         dispose()
         result.success(null)
+      }
+      "map#snapshot" -> {
+        val mapView = mapView
+        val snapshot = mapView?.snapshot()
+        if (mapView == null) {
+          result.error("2342345", "Failed to create snapshot: map view is not found.", null)
+        } else if (snapshot == null) {
+          result.error("2342345", "Failed to create snapshot: snapshotting timed out.", null)
+        } else {
+          val byteArray = ByteArrayOutputStream().also { stream ->
+            snapshot.compress(Bitmap.CompressFormat.PNG, 100, stream)
+          }.toByteArray()
+
+          result.success(byteArray)
+        }
       }
       else -> {
         result.notImplemented()

--- a/example/integration_test/map_interface_test.dart
+++ b/example/integration_test/map_interface_test.dart
@@ -376,4 +376,14 @@ void main() {
         await mapboxMap.getGeoJsonClusterExpansionZoom('earthquakes', feature);
     expect(clusterExpansionZoom.value, '1');
   });
+
+  testWidgets('snapshot', (WidgetTester tester) async {
+    final mapFuture = app.main();
+    await tester.pumpAndSettle();
+    final mapboxMap = await mapFuture;
+    await mapboxMap.loadStyleURI(MapboxStyles.DARK);
+    await app.events.onMapIdle.future;
+    final snapshot = await mapboxMap.snapshot();
+    expect(snapshot, isNotNull);
+  });
 }

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -122,6 +122,13 @@ final class MapboxMapController: NSObject, FlutterPlatformView {
         case "platform#releaseMethodChannels":
             releaseMethodChannels()
             result(nil)
+        case "map#snapshot":
+            do {
+                let snapshot = try mapView.snapshot()
+                result(snapshot.pngData())
+            } catch {
+                result(FlutterError(code: "2342345", message: error.localizedDescription, details: nil))
+            }
         default:
             result(FlutterMethodNotImplemented)
         }

--- a/lib/src/mapbox_map.dart
+++ b/lib/src/mapbox_map.dart
@@ -453,8 +453,7 @@ class MapboxMap extends ChangeNotifier {
 
   /// Returns a snapshot of the map.
   /// The snapshot is taken from the current state of the map.
-  Future<Image> snapshot() =>
-      _mapboxMapsPlatform.snapshot().then((value) => Image.memory(value));
+  Future<Uint8List> snapshot() => _mapboxMapsPlatform.snapshot();
 }
 
 class _GestureListener extends GestureListener {

--- a/lib/src/mapbox_map.dart
+++ b/lib/src/mapbox_map.dart
@@ -450,6 +450,11 @@ class MapboxMap extends ChangeNotifier {
     this.onMapScrollListener = onMapScrollListener;
     _setupGestures();
   }
+
+  /// Returns a snapshot of the map.
+  /// The snapshot is taken from the current state of the map.
+  Future<Image> snapshot() =>
+      _mapboxMapsPlatform.snapshot().then((value) => Image.memory(value));
 }
 
 class _GestureListener extends GestureListener {

--- a/lib/src/mapbox_maps_platform.dart
+++ b/lib/src/mapbox_maps_platform.dart
@@ -142,6 +142,15 @@ class _MapboxMapsPlatform {
       return new Future.error(e);
     }
   }
+
+  Future<Uint8List> snapshot() async {
+    try {
+      final List<int> data = await _channel.invokeMethod('map#snapshot');
+      return Uint8List.fromList(data);
+    } on PlatformException catch (e) {
+      return new Future.error(e);
+    }
+  }
 }
 
 /// A registry to hold suffixes for Channels.


### PR DESCRIPTION
### What does this pull request do?

Adds `MapWidget.snapshot()` method allowing to capture a snapshot image of the current state of the map widget.

### What is the motivation and context behind this change?

API parity with platform SDKs. 

### Pull request checklist:
 - [x] Add a changelog entry.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add documentation comments for any added or updated public APIs.
