### PR TITLE
Restore map tap/long tap/scroll listeners

### DIFF
--- a/lib/src/map_widget.dart
+++ b/lib/src/map_widget.dart
@@ -238,8 +238,12 @@ class _MapWidgetState extends State<MapWidget> {
   }
 
   void onPlatformViewCreated(int id) {
-    final MapboxMap controller =
-        MapboxMap(mapboxMapsPlatform: _mapboxMapsPlatform);
+    final MapboxMap controller = MapboxMap(
+      mapboxMapsPlatform: _mapboxMapsPlatform,
+      onMapTapListener: widget.onTapListener,
+      onMapLongTapListener: widget.onLongTapListener,
+      onMapScrollListener: widget.onScrollListener,
+    );
     _controller.complete(controller);
     if (widget.onMapCreated != null) {
       widget.onMapCreated!(controller);

--- a/lib/src/mapbox_map.dart
+++ b/lib/src/mapbox_map.dart
@@ -4,6 +4,9 @@ part of mapbox_maps_flutter;
 class MapboxMap extends ChangeNotifier {
   MapboxMap({
     required _MapboxMapsPlatform mapboxMapsPlatform,
+    this.onMapTapListener,
+    this.onMapLongTapListener,
+    this.onMapScrollListener,
   }) : _mapboxMapsPlatform = mapboxMapsPlatform {
     _proxyBinaryMessenger = _mapboxMapsPlatform.binaryMessenger;
 


### PR DESCRIPTION
### What does this pull request do?

Restore gesture listeners setup that was accidentally removed in https://github.com/mapbox/mapbox-maps-flutter/pull/512

### What is the motivation and context behind this change?



### Pull request checklist:
 - [ ] Add a changelog entry.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
