### PR TITLE
Map events race condition fix

### DIFF
--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/EventHandler.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/EventHandler.kt
@@ -36,7 +36,8 @@ import java.util.Date
 
 class MapboxEventHandler(
   private val eventProvider: Observable,
-  binaryMessenger: BinaryMessenger
+  binaryMessenger: BinaryMessenger,
+  eventTypes: List<Int>
 ) : MethodChannel.MethodCallHandler {
   private val channel: MethodChannel
   private val cancellables = HashSet<Cancelable>()
@@ -48,6 +49,11 @@ class MapboxEventHandler(
   init {
     channel = MethodChannel(binaryMessenger, "com.mapbox.maps.flutter.map_events")
     channel.setMethodCallHandler(this)
+
+    eventTypes
+      .map { _MapEvent.ofRaw(it) }
+      .filterNotNull()
+      .forEach { subscribeToEvent(it) }
   }
 
   override fun onMethodCall(methodCall: MethodCall, result: MethodChannel.Result) {

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/MapboxMapController.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/MapboxMapController.kt
@@ -38,7 +38,8 @@ class MapboxMapController(
   private val lifecycleProvider: MapboxMapsPlugin.LifecycleProvider,
   messenger: BinaryMessenger,
   channelSuffix: Int,
-  pluginVersion: String
+  pluginVersion: String,
+  eventTypes: List<Int>
 ) : PlatformView,
   DefaultLifecycleObserver,
   MethodChannel.MethodCallHandler {
@@ -122,7 +123,7 @@ class MapboxMapController(
     val mapboxMap = mapView.mapboxMap
     this.mapView = mapView
     this.mapboxMap = mapboxMap
-    eventHandler = MapboxEventHandler(mapboxMap.styleManager, proxyBinaryMessenger)
+    eventHandler = MapboxEventHandler(mapboxMap.styleManager, proxyBinaryMessenger, eventTypes)
     styleController = StyleController(context, mapboxMap)
     cameraController = CameraController(mapboxMap, context)
     projectionController = MapProjectionController(mapboxMap)

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/MapboxMapFactory.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/MapboxMapFactory.kt
@@ -116,6 +116,8 @@ class MapboxMapFactory(
     val textureView = params["textureView"] as? Boolean ?: false
     val styleUri = params["styleUri"] as? String ?: Style.MAPBOX_STREETS
     val pluginVersion = params["mapboxPluginVersion"] as String
+    val eventTypes: List<Int> = params["eventTypes"] as List<Int>
+
     val mapInitOptions = MapInitOptions(
       context = context,
       mapOptions = mapOptionsBuilder.build(),
@@ -130,6 +132,7 @@ class MapboxMapFactory(
       messenger,
       channelSuffix,
       pluginVersion,
+      eventTypes
     )
   }
 

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/SnapshotterMessenger.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/SnapshotterMessenger.kt
@@ -198,7 +198,7 @@ private object _SnapshotterInstanceManagerCodec : StandardMessageCodec() {
 
 /** Generated interface from Pigeon that represents a handler of messages from Flutter. */
 interface _SnapshotterInstanceManager {
-  fun setupSnapshotterForSuffix(suffix: String, options: MapSnapshotOptions)
+  fun setupSnapshotterForSuffix(suffix: String, eventTypes: List<Long>, options: MapSnapshotOptions)
   fun tearDownSnapshotterForSuffix(suffix: String)
 
   companion object {
@@ -216,10 +216,11 @@ interface _SnapshotterInstanceManager {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val suffixArg = args[0] as String
-            val optionsArg = args[1] as MapSnapshotOptions
+            val eventTypesArg = args[1] as List<Long>
+            val optionsArg = args[2] as MapSnapshotOptions
             var wrapped: List<Any?>
             try {
-              api.setupSnapshotterForSuffix(suffixArg, optionsArg)
+              api.setupSnapshotterForSuffix(suffixArg, eventTypesArg, optionsArg)
               wrapped = listOf<Any?>(null)
             } catch (exception: Throwable) {
               wrapped = wrapError(exception)

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/snapshotter/SnapshotterInstanceManager.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/snapshotter/SnapshotterInstanceManager.kt
@@ -24,7 +24,11 @@ class SnapshotterInstanceManager(
   private var proxyMessengers = HashMap<String, ProxyBinaryMessenger>()
 
   @SuppressLint("RestrictedApi")
-  override fun setupSnapshotterForSuffix(suffix: String, options: MapSnapshotOptions) {
+  override fun setupSnapshotterForSuffix(
+    suffix: String,
+    eventTypes: List<Long>,
+    options: MapSnapshotOptions
+  ) {
     val snapshotter = Snapshotter(
       context,
       options = options.toSnapshotOptions(context),
@@ -32,7 +36,7 @@ class SnapshotterInstanceManager(
     )
     val proxyBinaryMessenger = ProxyBinaryMessenger(messenger, suffix)
     val styleManager: com.mapbox.maps.StyleManager = snapshotter.styleManager() // TODO: expose this on Android
-    val eventHandler = MapboxEventHandler(styleManager, proxyBinaryMessenger)
+    val eventHandler = MapboxEventHandler(styleManager, proxyBinaryMessenger, eventTypes.map { it.toInt() })
     val snapshotterController = SnapshotterController(context, snapshotter, eventHandler)
     val mapboxStyleManager = MapboxStyleManager(
       styleManager,

--- a/example/integration_test/snapshotter/snapshotter_test.dart
+++ b/example/integration_test/snapshotter/snapshotter_test.dart
@@ -46,10 +46,10 @@ void main() {
       pixelRatio: 1.5,
     );
     final snapshotter = await Snapshotter.create(
-        options: options,
-        onStyleLoadedListener: styleLoaded.complete,
-        onStyleDataLoadedListener: styleDataLoaded.complete,
-        );
+      options: options,
+      onStyleLoadedListener: styleLoaded.complete,
+      onStyleDataLoadedListener: styleDataLoaded.complete,
+    );
 
     await snapshotter.style.setStyleURI(MapboxStyles.LIGHT);
 
@@ -98,8 +98,10 @@ void main() {
       bearing: cameraOptions.bearing,
       pitch: cameraOptions.pitch,
     );
-    expect(camera.center?.coordinates.lat, closeTo(cameraOptions.center!.coordinates.lat, 0.001));
-    expect(camera.center?.coordinates.lng, closeTo(cameraOptions.center!.coordinates.lng, 0.001));
+    expect(camera.center?.coordinates.lat,
+        closeTo(cameraOptions.center!.coordinates.lat, 0.001));
+    expect(camera.center?.coordinates.lng,
+        closeTo(cameraOptions.center!.coordinates.lng, 0.001));
     expect(camera.bearing, closeTo(cameraOptions.bearing!, 0.001));
     expect(camera.pitch, closeTo(cameraOptions.pitch!, 0.001));
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2,15 +2,15 @@ PODS:
   - Flutter (1.0.0)
   - integration_test (0.0.1):
     - Flutter
-  - mapbox_maps_flutter (1.1.0):
+  - mapbox_maps_flutter (2.0.0-beta.1):
     - Flutter
     - MapboxMaps (~> 11.4.0-beta.2)
     - Turf (= 2.8.0)
-  - MapboxCommon (24.4.0-beta.2)
+  - MapboxCommon (24.4.0-beta.3)
   - MapboxCoreMaps (11.4.0-beta.2):
     - MapboxCommon (~> 24.4.0-beta)
-  - MapboxMaps (11.4.0-beta.2):
-    - MapboxCommon (= 24.4.0-beta.2)
+  - MapboxMaps (11.4.0-beta.3):
+    - MapboxCommon (= 24.4.0-beta.3)
     - MapboxCoreMaps (= 11.4.0-beta.2)
     - Turf (= 2.8.0)
   - permission_handler_apple (9.1.1):
@@ -43,10 +43,10 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   integration_test: 13825b8a9334a850581300559b8839134b124670
-  mapbox_maps_flutter: a5b851d1c13a23e6232400375af26b63307223f4
-  MapboxCommon: 7e0be4c0792c7f037e1a52faada7b9ffec6abdee
+  mapbox_maps_flutter: f749f291a37f900866ee4981e2919b7223364095
+  MapboxCommon: 163268386543eccc75daadf33251e06dad0df25c
   MapboxCoreMaps: 5120129b4c1b46eeccf19dd260f77c83e345e081
-  MapboxMaps: 7111c4812c5a6b4692bd46913db0bcc1b4db8b9f
+  MapboxMaps: 37c72ec739d5fa48b87eb2ba283f6937a61419f9
   permission_handler_apple: e76247795d700c14ea09e3a2d8855d41ee80a2e6
   Turf: aa2ede4298009639d10db36aba1a7ebaad072a5e
 

--- a/example/lib/geojson_line.dart
+++ b/example/lib/geojson_line.dart
@@ -35,13 +35,13 @@ class DrawGeoJsonLineWidgetState extends State<DrawGeoJsonLineWidget> {
         lineJoin: LineJoin.ROUND,
         lineCap: LineCap.ROUND,
         lineColor: Colors.red.value,
-        lineWidth:  6.0));
+        lineWidth: 6.0));
   }
 
   @override
   Widget build(BuildContext context) {
     return new Scaffold(
-      body: MapWidget(
+        body: MapWidget(
       key: ValueKey("mapWidget"),
       styleUri: MapboxStyles.MAPBOX_STREETS,
       cameraOptions: CameraOptions(

--- a/example/lib/snapshotter.dart
+++ b/example/lib/snapshotter.dart
@@ -91,7 +91,9 @@ class SnapshotterPageBodyState extends State<SnapshotterPageBody> {
               color: Colors.amber,
             ),
           ),
-          Expanded(key: _snapshotKey, child: snapshotImage ?? ColoredBox(color: Colors.grey)),
+          Expanded(
+              key: _snapshotKey,
+              child: snapshotImage ?? ColoredBox(color: Colors.grey)),
         ],
       ),
     );

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -192,7 +192,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.1.0"
+    version: "2.0.0-beta.1"
   matcher:
     dependency: transitive
     description:

--- a/ios/Classes/EventHandler.swift
+++ b/ios/Classes/EventHandler.swift
@@ -45,7 +45,7 @@ final class MapboxEventHandler {
     private let channel: FlutterMethodChannel
     private var cancelables = Set<AnyCancelable>()
 
-    init(eventProvider: EventProvider, binaryMessenger: FlutterBinaryMessenger) {
+    init(eventProvider: EventProvider, binaryMessenger: FlutterBinaryMessenger, eventTypes: [Int]) {
         self.eventProvider = eventProvider
         self.binaryMessenger = binaryMessenger
 
@@ -56,6 +56,10 @@ final class MapboxEventHandler {
         channel.setMethodCallHandler { [weak self] methodCall, result in
             self?.handleMethodCall(methodCall, result: result)
         }
+
+        eventTypes
+            .compactMap(_MapEvent.init)
+            .forEach(subscribeToEvent)
     }
 
     private func handleMethodCall(_ methodCall: FlutterMethodCall, result: FlutterResult) {

--- a/ios/Classes/Generated/MapInterfaces.swift
+++ b/ios/Classes/Generated/MapInterfaces.swift
@@ -4144,7 +4144,7 @@ protocol Projection {
   ///
   /// @param projectedMeters Spherical Mercator ProjectedMeters coordinates for
   /// which to calculate a longitude-latitude pair.
-  /// 
+  ///
   /// @return Returns a longitude-latitude pair.
   func coordinateForProjectedMeters(projectedMeters: ProjectedMeters) throws -> Point
   /// Calculate a point on the map in Mercator Projection for a given
@@ -4224,7 +4224,7 @@ class ProjectionSetup {
     ///
     /// @param projectedMeters Spherical Mercator ProjectedMeters coordinates for
     /// which to calculate a longitude-latitude pair.
-    /// 
+    ///
     /// @return Returns a longitude-latitude pair.
     let coordinateForProjectedMetersChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.mapbox_maps_flutter.Projection.coordinateForProjectedMeters\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {

--- a/ios/Classes/Generated/SnapshotterMessenger.swift
+++ b/ios/Classes/Generated/SnapshotterMessenger.swift
@@ -223,7 +223,7 @@ class _SnapshotterInstanceManagerCodec: FlutterStandardMessageCodec {
 
 /// Generated protocol from Pigeon that represents a handler of messages from Flutter.
 protocol _SnapshotterInstanceManager {
-  func setupSnapshotterForSuffix(suffix: String, options: MapSnapshotOptions) throws
+  func setupSnapshotterForSuffix(suffix: String, eventTypes: [Int64], options: MapSnapshotOptions) throws
   func tearDownSnapshotterForSuffix(suffix: String) throws
 }
 
@@ -239,9 +239,10 @@ class _SnapshotterInstanceManagerSetup {
       setupSnapshotterForSuffixChannel.setMessageHandler { message, reply in
         let args = message as! [Any?]
         let suffixArg = args[0] as! String
-        let optionsArg = args[1] as! MapSnapshotOptions
+        let eventTypesArg = args[1] as! [Int64]
+        let optionsArg = args[2] as! MapSnapshotOptions
         do {
-          try api.setupSnapshotterForSuffix(suffix: suffixArg, options: optionsArg)
+          try api.setupSnapshotterForSuffix(suffix: suffixArg, eventTypes: eventTypesArg, options: optionsArg)
           reply(wrapResult(nil))
         } catch {
           reply(wrapError(error))

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -49,13 +49,15 @@ final class MapboxMapController: NSObject, FlutterPlatformView {
         channelSuffix: Int,
         arguments args: Any?,
         registrar: FlutterPluginRegistrar,
-        pluginVersion: String
+        pluginVersion: String,
+        eventTypes: [Int]
     ) {
         self.proxyBinaryMessenger = ProxyBinaryMessenger(with: registrar.messenger(), channelSuffix: "\(channelSuffix)")
         _ = SettingsServiceFactory.getInstanceFor(.nonPersistent)
             .set(key: "com.mapbox.common.telemetry.internal.custom_user_agent_fragment", value: "FlutterPlugin/\(pluginVersion)")
 
         mapView = MapView(frame: frame, mapInitOptions: mapInitOptions)
+        mapView.debugOptions = [.camera]
         mapboxMap = mapView.mapboxMap
 
         self.registrar = registrar
@@ -64,7 +66,11 @@ final class MapboxMapController: NSObject, FlutterPlatformView {
             name: "plugins.flutter.io",
             binaryMessenger: proxyBinaryMessenger
         )
-        self.eventHandler = MapboxEventHandler(eventProvider: mapboxMap, binaryMessenger: proxyBinaryMessenger)
+        self.eventHandler = MapboxEventHandler(
+            eventProvider: mapboxMap,
+            binaryMessenger: proxyBinaryMessenger,
+            eventTypes: eventTypes
+        )
 
         let styleController = StyleController(styleManager: mapboxMap)
         StyleManagerSetup.setUp(binaryMessenger: proxyBinaryMessenger, api: styleController)

--- a/ios/Classes/MapboxMapFactory.swift
+++ b/ios/Classes/MapboxMapFactory.swift
@@ -131,7 +131,8 @@ class MapboxMapFactory: NSObject, FlutterPlatformViewFactory {
                 channelSuffix: channelSuffix,
                 arguments: args,
                 registrar: registrar,
-                pluginVersion: pluginVersion
+                pluginVersion: pluginVersion,
+                eventTypes: []
             )
         }
         var styleURI: StyleURI? = .streets
@@ -153,13 +154,16 @@ class MapboxMapFactory: NSObject, FlutterPlatformViewFactory {
             channelSuffix = suffix
         }
 
+        var eventTypes = args["eventTypes"] as? [Int] ?? []
+
         return MapboxMapController(
             withFrame: frame,
             mapInitOptions: mapInitOptions,
             channelSuffix: channelSuffix,
             arguments: args,
             registrar: registrar,
-            pluginVersion: pluginVersion
+            pluginVersion: pluginVersion,
+            eventTypes: eventTypes
         )
     }
 }

--- a/ios/Classes/Snapshotter/SnapshotterController.swift
+++ b/ios/Classes/Snapshotter/SnapshotterController.swift
@@ -10,10 +10,14 @@ final class SnapshotterController: _SnapshotterMessenger {
     private var snapshotter: Snapshotter!
     private let eventHandler: MapboxEventHandler
 
-    init(snapshotter: Snapshotter, binaryMessenger: FlutterBinaryMessenger) {
+    init(snapshotter: Snapshotter, eventTypes: [Int], binaryMessenger: FlutterBinaryMessenger) {
         self.snapshotter = snapshotter
 
-        eventHandler = MapboxEventHandler(eventProvider: snapshotter, binaryMessenger: binaryMessenger)
+        eventHandler = MapboxEventHandler(
+            eventProvider: snapshotter,
+            binaryMessenger: binaryMessenger,
+            eventTypes: eventTypes
+        )
     }
 
     func getCameraState() throws -> CameraState {

--- a/ios/Classes/Snapshotter/SnapshotterInstanceManager.swift
+++ b/ios/Classes/Snapshotter/SnapshotterInstanceManager.swift
@@ -10,12 +10,13 @@ final class SnapshotterInstanceManager: _SnapshotterInstanceManager {
         self.binaryMessenger = binaryMessenger
     }
 
-    func setupSnapshotterForSuffix(suffix: String, options: MapSnapshotOptions) throws {
+    func setupSnapshotterForSuffix(suffix: String, eventTypes: [Int64], options: MapSnapshotOptions) throws {
         let snapshotter = Snapshotter(options: options.toMapSnapshotOptions())
 
         let proxyMessenger = ProxyBinaryMessenger(with: binaryMessenger, channelSuffix: suffix)
         let snapshotterController = SnapshotterController(
             snapshotter: snapshotter,
+            eventTypes: eventTypes.map(Int.init),
             binaryMessenger: proxyMessenger
         )
         let snapshotStyleController = StyleController(styleManager: snapshotter)

--- a/lib/src/map_events.dart
+++ b/lib/src/map_events.dart
@@ -16,51 +16,40 @@ final class _MapEvents {
   OnStyleImageUnusedListener? _onStyleImageUnusedListener;
   OnResourceRequestListener? _onResourceRequestListener;
   late final MethodChannel _channel;
-  List<_MapEvent> _eventTypes = [];
+  List<_MapEvent> _subscribedEventTypes = [];
 
-  _MapEvents({BinaryMessenger? binaryMessenger, String? suffix}) {
+  List<_MapEvent> get eventTypes {
+    final listenersMap = {
+      _onStyleLoadedListener: _MapEvent.styleLoaded,
+      _onCameraChangeListener: _MapEvent.cameraChanged,
+      _onMapIdleListener: _MapEvent.mapIdle,
+      _onMapLoadedListener: _MapEvent.mapLoaded,
+      _onMapLoadErrorListener: _MapEvent.mapLoadingError,
+      _onRenderFrameFinishedListener: _MapEvent.renderFrameFinished,
+      _onRenderFrameStartedListener: _MapEvent.renderFrameStarted,
+      _onSourceAddedListener: _MapEvent.sourceAdded,
+      _onSourceDataLoadedListener: _MapEvent.sourceDataLoaded,
+      _onSourceRemovedListener: _MapEvent.sourceRemoved,
+      _onStyleDataLoadedListener: _MapEvent.styleDataLoaded,
+      _onStyleImageMissingListener: _MapEvent.styleImageMissing,
+      _onStyleImageUnusedListener: _MapEvent.styleImageRemoveUnused,
+      _onResourceRequestListener: _MapEvent.resourceRequest,
+    };
+    listenersMap.remove(null);
+
+    return listenersMap.values.toList();
+  }
+
+  _MapEvents({BinaryMessenger? binaryMessenger}) {
     _channel = MethodChannel('com.mapbox.maps.flutter.map_events',
         const StandardMethodCodec(), binaryMessenger);
     _channel.setMethodCallHandler(_handleMethodCall);
   }
 
-  void updateSubscriptions({
-    OnStyleLoadedListener? onStyleLoadedListener,
-    OnCameraChangeListener? onCameraChangeListener,
-    OnMapIdleListener? onMapIdleListener,
-    OnMapLoadedListener? onMapLoadedListener,
-    OnMapLoadErrorListener? onMapLoadErrorListener,
-    OnRenderFrameFinishedListener? onRenderFrameFinishedListener,
-    OnRenderFrameStartedListener? onRenderFrameStartedListener,
-    OnSourceAddedListener? onSourceAddedListener,
-    OnSourceDataLoadedListener? onSourceDataLoadedListener,
-    OnSourceRemovedListener? onSourceRemovedListener,
-    OnStyleDataLoadedListener? onStyleDataLoadedListener,
-    OnStyleImageMissingListener? onStyleImageMissingListener,
-    OnStyleImageUnusedListener? onStyleImageUnusedListener,
-    OnResourceRequestListener? onResourceRequestListener,
-  }) {
-    final listenersMap = {
-      onStyleLoadedListener: _MapEvent.styleLoaded,
-      onCameraChangeListener: _MapEvent.cameraChanged,
-      onMapIdleListener: _MapEvent.mapIdle,
-      onMapLoadedListener: _MapEvent.mapLoaded,
-      onMapLoadErrorListener: _MapEvent.mapLoadingError,
-      onRenderFrameFinishedListener: _MapEvent.renderFrameFinished,
-      onRenderFrameStartedListener: _MapEvent.renderFrameStarted,
-      onSourceAddedListener: _MapEvent.sourceAdded,
-      onSourceDataLoadedListener: _MapEvent.sourceDataLoaded,
-      onSourceRemovedListener: _MapEvent.sourceRemoved,
-      onStyleDataLoadedListener: _MapEvent.styleDataLoaded,
-      onStyleImageMissingListener: _MapEvent.styleImageMissing,
-      onStyleImageUnusedListener: _MapEvent.styleImageRemoveUnused,
-      onResourceRequestListener: _MapEvent.resourceRequest,
-    };
-    listenersMap.remove(null);
+  void updateSubscriptions() {
+    final newEventTypes = eventTypes;
 
-    final newEventTypes = listenersMap.values.toList();
-
-    if (listEquals(newEventTypes, _eventTypes)) {
+    if (listEquals(newEventTypes, _subscribedEventTypes)) {
       return;
     }
 
@@ -68,22 +57,7 @@ final class _MapEvents {
     _channel.invokeMethod(
         "subscribeToEvents", newEventTypes.map((e) => e.index).toList());
 
-    _onStyleLoadedListener = onStyleLoadedListener;
-    _onCameraChangeListener = onCameraChangeListener;
-    _onMapIdleListener = onMapIdleListener;
-    _onMapLoadedListener = onMapLoadedListener;
-    _onMapLoadErrorListener = onMapLoadErrorListener;
-    _onRenderFrameFinishedListener = onRenderFrameFinishedListener;
-    _onRenderFrameStartedListener = onRenderFrameStartedListener;
-    _onSourceAddedListener = onSourceAddedListener;
-    _onSourceDataLoadedListener = onSourceDataLoadedListener;
-    _onSourceRemovedListener = onSourceRemovedListener;
-    _onStyleDataLoadedListener = onStyleDataLoadedListener;
-    _onStyleImageMissingListener = onStyleImageMissingListener;
-    _onStyleImageUnusedListener = onStyleImageUnusedListener;
-    _onResourceRequestListener = onResourceRequestListener;
-
-    _eventTypes = newEventTypes;
+    _subscribedEventTypes = newEventTypes;
   }
 
   void dispose() {

--- a/lib/src/map_widget.dart
+++ b/lib/src/map_widget.dart
@@ -187,7 +187,8 @@ class _MapWidgetState extends State<MapWidget> {
       'textureView': widget.textureView,
       'styleUri': widget.styleUri,
       'channelSuffix': _suffix,
-      'mapboxPluginVersion': '2.0.0-beta.1'
+      'mapboxPluginVersion': '2.0.0-beta.1',
+      'eventTypes': _events.eventTypes.map((e) => e.index).toList(),
     };
 
     return _mapboxMapsPlatform.buildView(widget.androidHostingMode,
@@ -199,6 +200,7 @@ class _MapWidgetState extends State<MapWidget> {
     super.initState();
 
     _events = _MapEvents(binaryMessenger: _binaryMessenger);
+    _updateEventListeners();
   }
 
   @override
@@ -216,28 +218,29 @@ class _MapWidgetState extends State<MapWidget> {
   void didUpdateWidget(MapWidget oldWidget) {
     super.didUpdateWidget(oldWidget);
 
-    _updateSubscriptions();
+    _updateEventListeners();
+    _events.updateSubscriptions();
   }
 
-  void _updateSubscriptions() {
-    _events.updateSubscriptions(
-        onStyleLoadedListener: widget.onStyleLoadedListener,
-        onCameraChangeListener: widget.onCameraChangeListener,
-        onMapIdleListener: widget.onMapIdleListener,
-        onMapLoadedListener: widget.onMapLoadedListener,
-        onMapLoadErrorListener: widget.onMapLoadErrorListener,
-        onRenderFrameFinishedListener: widget.onRenderFrameFinishedListener,
-        onRenderFrameStartedListener: widget.onRenderFrameStartedListener,
-        onSourceAddedListener: widget.onSourceAddedListener,
-        onSourceDataLoadedListener: widget.onSourceDataLoadedListener,
-        onSourceRemovedListener: widget.onSourceRemovedListener,
-        onStyleDataLoadedListener: widget.onStyleDataLoadedListener,
-        onStyleImageMissingListener: widget.onStyleImageMissingListener,
-        onStyleImageUnusedListener: widget.onStyleImageUnusedListener,
-        onResourceRequestListener: widget.onResourceRequestListener);
+  void _updateEventListeners() {
+    _events._onStyleLoadedListener = widget.onStyleLoadedListener;
+    _events._onCameraChangeListener = widget.onCameraChangeListener;
+    _events._onMapIdleListener = widget.onMapIdleListener;
+    _events._onMapLoadedListener = widget.onMapLoadedListener;
+    _events._onMapLoadErrorListener = widget.onMapLoadErrorListener;
+    _events._onRenderFrameFinishedListener =
+        widget.onRenderFrameFinishedListener;
+    _events._onRenderFrameStartedListener = widget.onRenderFrameStartedListener;
+    _events._onSourceAddedListener = widget.onSourceAddedListener;
+    _events._onSourceDataLoadedListener = widget.onSourceDataLoadedListener;
+    _events._onSourceRemovedListener = widget.onSourceRemovedListener;
+    _events._onStyleDataLoadedListener = widget.onStyleDataLoadedListener;
+    _events._onStyleImageMissingListener = widget.onStyleImageMissingListener;
+    _events._onStyleImageUnusedListener = widget.onStyleImageUnusedListener;
+    _events._onResourceRequestListener = widget.onResourceRequestListener;
   }
 
-  void onPlatformViewCreated(int id) {
+  Future<void> onPlatformViewCreated(int id) async {
     final MapboxMap controller = MapboxMap(
       mapboxMapsPlatform: _mapboxMapsPlatform,
       onMapTapListener: widget.onTapListener,
@@ -249,6 +252,5 @@ class _MapWidgetState extends State<MapWidget> {
       widget.onMapCreated!(controller);
     }
     mapboxMap = controller;
-    _updateSubscriptions();
   }
 }

--- a/lib/src/snapshotter/snapshotter.dart
+++ b/lib/src/snapshotter/snapshotter.dart
@@ -67,15 +67,17 @@ final class Snapshotter {
         onStyleDataLoadedListener: onStyleDataLoadedListener,
         onStyleImageMissingListener: onStyleImageMissingListener);
 
-    await _snapshotterInstanceManager.setupSnapshotterForSuffix(
-        snapshotter._suffix.toString(), options);
+    snapshotter._mapEvents._onStyleLoadedListener = onStyleLoadedListener;
+    snapshotter._mapEvents._onMapLoadErrorListener = onMapLoadErrorListener;
+    snapshotter._mapEvents._onStyleDataLoadedListener =
+        onStyleDataLoadedListener;
+    snapshotter._mapEvents._onStyleImageMissingListener =
+        onStyleImageMissingListener;
 
-    snapshotter._mapEvents.updateSubscriptions(
-      onStyleLoadedListener: onStyleLoadedListener,
-      onMapLoadErrorListener: onMapLoadErrorListener,
-      onStyleDataLoadedListener: onStyleDataLoadedListener,
-      onStyleImageMissingListener: onStyleImageMissingListener,
-    );
+    await _snapshotterInstanceManager.setupSnapshotterForSuffix(
+        snapshotter._suffix.toString(),
+        snapshotter._mapEvents.eventTypes.map((e) => e.index).toList(),
+        options);
 
     Snapshotter._finalizer.attach(snapshotter, snapshotter._suffix);
     return snapshotter;

--- a/lib/src/snapshotter/snapshotter_messenger.dart
+++ b/lib/src/snapshotter/snapshotter_messenger.dart
@@ -226,7 +226,7 @@ class _SnapshotterInstanceManager {
   final String __pigeon_messageChannelSuffix;
 
   Future<void> setupSnapshotterForSuffix(
-      String suffix, MapSnapshotOptions options) async {
+      String suffix, List<int?> eventTypes, MapSnapshotOptions options) async {
     final String __pigeon_channelName =
         'dev.flutter.pigeon.mapbox_maps_flutter._SnapshotterInstanceManager.setupSnapshotterForSuffix$__pigeon_messageChannelSuffix';
     final BasicMessageChannel<Object?> __pigeon_channel =
@@ -236,7 +236,7 @@ class _SnapshotterInstanceManager {
       binaryMessenger: __pigeon_binaryMessenger,
     );
     final List<Object?>? __pigeon_replyList = await __pigeon_channel
-        .send(<Object?>[suffix, options]) as List<Object?>?;
+        .send(<Object?>[suffix, eventTypes, options]) as List<Object?>?;
     if (__pigeon_replyList == null) {
       throw _createConnectionError(__pigeon_channelName);
     } else if (__pigeon_replyList.length > 1) {

--- a/lib/src/style/source/rasterarray_source.dart
+++ b/lib/src/style/source/rasterarray_source.dart
@@ -6,7 +6,7 @@ part of mapbox_maps_flutter;
 @experimental
 class RasterArraySource extends Source {
   RasterArraySource({
-    required id,
+    required String id,
     String? url,
     List<String?>? tiles,
     List<double?>? bounds,


### PR DESCRIPTION
### What does this pull request do?

Fixes race condition in events when method call to subscribe to map events from dart side was competing with early map events.
The fix is to pass event types upon map widget initialization.

### What is the motivation and context behind this change?

Bugfix.

### Pull request checklist:
 - [ ] Add a changelog entry.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
