### PR TITLE
Add option to enable/disable map widget attribution

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,6 +33,16 @@ rootProject.allprojects {
                 password = token
             }
         }
+        maven {
+            url 'https://api.mapbox.com/downloads/v2/snapshots/maven'
+            authentication {
+                basic(BasicAuthentication)
+            }
+            credentials {
+                username = "mapbox"
+                password = token
+            }
+        }
     }
 }
 

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/mapping/AttributionMappings.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/mapping/AttributionMappings.kt
@@ -8,6 +8,7 @@ import com.mapbox.maps.mapbox_maps.toLogicalPixels
 import com.mapbox.maps.plugin.attribution.generated.AttributionSettingsInterface
 
 fun AttributionSettingsInterface.applyFromFLT(settings: AttributionSettings, context: Context) {
+  settings.enabled?.let { enabled = it }
   settings.iconColor?.let { iconColor = it.toInt() }
   settings.position?.let { position = it.toPosition() }
   settings.marginLeft?.let { marginLeft = it.toDevicePixels(context) }
@@ -18,6 +19,7 @@ fun AttributionSettingsInterface.applyFromFLT(settings: AttributionSettings, con
 }
 
 fun AttributionSettingsInterface.toFLT(context: Context) = AttributionSettings(
+  enabled = enabled,
   iconColor = iconColor.toUInt().toLong(),
   position = position.toOrnamentPosition(),
   marginLeft = marginLeft.toLogicalPixels(context),

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/mapping/AttributionMappings.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/mapping/AttributionMappings.kt
@@ -8,14 +8,16 @@ import com.mapbox.maps.mapbox_maps.toLogicalPixels
 import com.mapbox.maps.plugin.attribution.generated.AttributionSettingsInterface
 
 fun AttributionSettingsInterface.applyFromFLT(settings: AttributionSettings, context: Context) {
-  settings.enabled?.let { enabled = it }
-  settings.iconColor?.let { iconColor = it.toInt() }
-  settings.position?.let { position = it.toPosition() }
-  settings.marginLeft?.let { marginLeft = it.toDevicePixels(context) }
-  settings.marginTop?.let { marginTop = it.toDevicePixels(context) }
-  settings.marginRight?.let { marginRight = it.toDevicePixels(context) }
-  settings.marginBottom?.let { marginBottom = it.toDevicePixels(context) }
-  settings.clickable?.let { clickable = it }
+  updateSettings {
+    settings.enabled?.let { this.enabled = it }
+    settings.iconColor?.let { this.iconColor = it.toInt() }
+    settings.position?.let { this.position = it.toPosition() }
+    settings.marginLeft?.let { this.marginLeft = it.toDevicePixels(context) }
+    settings.marginTop?.let { this.marginTop = it.toDevicePixels(context) }
+    settings.marginRight?.let { this.marginRight = it.toDevicePixels(context) }
+    settings.marginBottom?.let { this.marginBottom = it.toDevicePixels(context) }
+    settings.clickable?.let { this.clickable = it }
+  }
 }
 
 fun AttributionSettingsInterface.toFLT(context: Context) = AttributionSettings(

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/mapping/LogoMappings.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/mapping/LogoMappings.kt
@@ -8,12 +8,14 @@ import com.mapbox.maps.mapbox_maps.toLogicalPixels
 import com.mapbox.maps.plugin.logo.generated.LogoSettingsInterface
 
 fun LogoSettingsInterface.applyFromFLT(settings: LogoSettings, context: Context) {
-  settings.enabled?.let { enabled = it }
-  settings.position?.let { position = it.toPosition() }
-  settings.marginLeft?.let { marginLeft = it.toDevicePixels(context) }
-  settings.marginTop?.let { marginTop = it.toDevicePixels(context) }
-  settings.marginRight?.let { marginRight = it.toDevicePixels(context) }
-  settings.marginBottom?.let { marginBottom = it.toDevicePixels(context) }
+  this.updateSettings {
+    settings.enabled?.let { this.enabled = it }
+    settings.position?.let { this.position = it.toPosition() }
+    settings.marginLeft?.let { this.marginLeft = it.toDevicePixels(context) }
+    settings.marginTop?.let { this.marginTop = it.toDevicePixels(context) }
+    settings.marginRight?.let { this.marginRight = it.toDevicePixels(context) }
+    settings.marginBottom?.let { this.marginBottom = it.toDevicePixels(context) }
+  }
 }
 
 fun LogoSettingsInterface.toFLT(context: Context) = LogoSettings(

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/mapping/LogoMappings.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/mapping/LogoMappings.kt
@@ -8,6 +8,7 @@ import com.mapbox.maps.mapbox_maps.toLogicalPixels
 import com.mapbox.maps.plugin.logo.generated.LogoSettingsInterface
 
 fun LogoSettingsInterface.applyFromFLT(settings: LogoSettings, context: Context) {
+  settings.enabled?.let { enabled = it }
   settings.position?.let { position = it.toPosition() }
   settings.marginLeft?.let { marginLeft = it.toDevicePixels(context) }
   settings.marginTop?.let { marginTop = it.toDevicePixels(context) }
@@ -16,6 +17,7 @@ fun LogoSettingsInterface.applyFromFLT(settings: LogoSettings, context: Context)
 }
 
 fun LogoSettingsInterface.toFLT(context: Context) = LogoSettings(
+  enabled = enabled,
   position = position.toOrnamentPosition(),
   marginLeft = marginLeft.toLogicalPixels(context),
   marginTop = marginTop.toLogicalPixels(context),

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/Settings.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/Settings.kt
@@ -558,6 +558,11 @@ data class CompassSettings(
  * Generated class from Pigeon that represents data sent in messages.
  */
 data class AttributionSettings(
+  /**
+   * Whether the attribution icon is visible on the map.
+   * Restricted API. Please contact Mapbox to discuss your use case if you intend to use this property.
+   */
+  val enabled: Boolean? = null,
   /** Defines text color of the attribution icon. */
   val iconColor: Long? = null,
   /** Defines where the attribution icon is positioned on the map */
@@ -577,20 +582,22 @@ data class AttributionSettings(
   companion object {
     @Suppress("UNCHECKED_CAST")
     fun fromList(list: List<Any?>): AttributionSettings {
-      val iconColor = list[0].let { if (it is Int) it.toLong() else it as Long? }
-      val position = (list[1] as Int?)?.let {
+      val enabled = list[0] as Boolean?
+      val iconColor = list[1].let { if (it is Int) it.toLong() else it as Long? }
+      val position = (list[2] as Int?)?.let {
         OrnamentPosition.ofRaw(it)
       }
-      val marginLeft = list[2] as Double?
-      val marginTop = list[3] as Double?
-      val marginRight = list[4] as Double?
-      val marginBottom = list[5] as Double?
-      val clickable = list[6] as Boolean?
-      return AttributionSettings(iconColor, position, marginLeft, marginTop, marginRight, marginBottom, clickable)
+      val marginLeft = list[3] as Double?
+      val marginTop = list[4] as Double?
+      val marginRight = list[5] as Double?
+      val marginBottom = list[6] as Double?
+      val clickable = list[7] as Boolean?
+      return AttributionSettings(enabled, iconColor, position, marginLeft, marginTop, marginRight, marginBottom, clickable)
     }
   }
   fun toList(): List<Any?> {
     return listOf<Any?>(
+      enabled,
       iconColor,
       position?.raw,
       marginLeft,
@@ -608,6 +615,11 @@ data class AttributionSettings(
  * Generated class from Pigeon that represents data sent in messages.
  */
 data class LogoSettings(
+  /**
+   * Whether the logo is visible on the map.
+   * Restricted API. Please contact Mapbox to discuss your use case if you intend to use this property.
+   */
+  val enabled: Boolean? = null,
   /** Defines where the logo is positioned on the map */
   val position: OrnamentPosition? = null,
   /** Defines the margin to the left that the attribution icon honors. This property is specified in pixels. */
@@ -623,18 +635,20 @@ data class LogoSettings(
   companion object {
     @Suppress("UNCHECKED_CAST")
     fun fromList(list: List<Any?>): LogoSettings {
-      val position = (list[0] as Int?)?.let {
+      val enabled = list[0] as Boolean?
+      val position = (list[1] as Int?)?.let {
         OrnamentPosition.ofRaw(it)
       }
-      val marginLeft = list[1] as Double?
-      val marginTop = list[2] as Double?
-      val marginRight = list[3] as Double?
-      val marginBottom = list[4] as Double?
-      return LogoSettings(position, marginLeft, marginTop, marginRight, marginBottom)
+      val marginLeft = list[2] as Double?
+      val marginTop = list[3] as Double?
+      val marginRight = list[4] as Double?
+      val marginBottom = list[5] as Double?
+      return LogoSettings(enabled, position, marginLeft, marginTop, marginRight, marginBottom)
     }
   }
   fun toList(): List<Any?> {
     return listOf<Any?>(
+      enabled,
       position?.raw,
       marginLeft,
       marginTop,

--- a/example/integration_test/attribution_test.dart
+++ b/example/integration_test/attribution_test.dart
@@ -15,6 +15,7 @@ void main() {
     final mapboxMap = await mapFuture;
     final attribution = mapboxMap.attribution;
     var settings = AttributionSettings(
+      enabled: false,
       iconColor: Colors.blue.value,
       position: OrnamentPosition.TOP_RIGHT,
       marginLeft: 1,
@@ -25,6 +26,7 @@ void main() {
     );
     await attribution.updateSettings(settings);
     var updatedSettings = await attribution.getSettings();
+    expect(updatedSettings.enabled, isFalse);
     expect(updatedSettings.position, OrnamentPosition.TOP_RIGHT);
     expect(updatedSettings.iconColor, Colors.blue.value);
     if (Platform.isIOS) {

--- a/example/integration_test/logo_test.dart
+++ b/example/integration_test/logo_test.dart
@@ -14,6 +14,7 @@ void main() {
     final mapboxMap = await mapFuture;
     final logo = mapboxMap.logo;
     var settings = LogoSettings(
+        enabled: false,
         position: OrnamentPosition.BOTTOM_LEFT,
         marginLeft: 1,
         marginTop: 2,
@@ -22,6 +23,7 @@ void main() {
     await logo.updateSettings(settings);
     var getSettings = await logo.getSettings();
     expect(getSettings.position, OrnamentPosition.BOTTOM_LEFT);
+    expect(getSettings.enabled, isFalse);
     if (Platform.isIOS) {
       expect(getSettings.marginLeft, 1);
       expect(getSettings.marginBottom, 4);

--- a/ios/Classes/AttributionController.swift
+++ b/ios/Classes/AttributionController.swift
@@ -1,5 +1,5 @@
 import Foundation
-@_spi(Experimental) import MapboxMaps
+@_spi(Experimental) @_spi(Restricted) import MapboxMaps
 
 final class AttributionController: AttributionSettingsInterface {
 
@@ -19,7 +19,7 @@ final class AttributionController: AttributionSettingsInterface {
             attributionButton.position = .topTrailing
             attributionButton.margins = CGPoint(x: settings.marginRight ?? 0, y: settings.marginTop ?? 0)
         }
-
+        attributionButton.visibility = (settings.enabled ?? true) ? .visible : .hidden
         ornaments.options.attributionButton = attributionButton
 
         if let iconColor = settings.iconColor {
@@ -33,6 +33,7 @@ final class AttributionController: AttributionSettingsInterface {
         let iconColor = ornaments.attributionButton.tintColor.rgb()
 
         return AttributionSettings(
+            enabled: options.visibility != .hidden,
             iconColor: Int64(iconColor),
             position: position,
             marginLeft: options.margins.x,

--- a/ios/Classes/Generated/Settings.swift
+++ b/ios/Classes/Generated/Settings.swift
@@ -609,6 +609,9 @@ struct CompassSettings {
 ///
 /// Generated class from Pigeon that represents data sent in messages.
 struct AttributionSettings {
+  /// Whether the attribution icon is visible on the map.
+  /// Restricted API. Please contact Mapbox to discuss your use case if you intend to use this property.
+  var enabled: Bool?
   /// Defines text color of the attribution icon.
   var iconColor: Int64?
   /// Defines where the attribution icon is positioned on the map
@@ -625,19 +628,21 @@ struct AttributionSettings {
   var clickable: Bool?
 
   static func fromList(_ list: [Any?]) -> AttributionSettings? {
-    let iconColor: Int64? = isNullish(list[0]) ? nil : (list[0] is Int64? ? list[0] as! Int64? : Int64(list[0] as! Int32))
+    let enabled: Bool? = nilOrValue(list[0])
+    let iconColor: Int64? = isNullish(list[1]) ? nil : (list[1] is Int64? ? list[1] as! Int64? : Int64(list[1] as! Int32))
     var position: OrnamentPosition?
-    let positionEnumVal: Int? = nilOrValue(list[1])
+    let positionEnumVal: Int? = nilOrValue(list[2])
     if let positionRawValue = positionEnumVal {
       position = OrnamentPosition(rawValue: positionRawValue)!
     }
-    let marginLeft: Double? = nilOrValue(list[2])
-    let marginTop: Double? = nilOrValue(list[3])
-    let marginRight: Double? = nilOrValue(list[4])
-    let marginBottom: Double? = nilOrValue(list[5])
-    let clickable: Bool? = nilOrValue(list[6])
+    let marginLeft: Double? = nilOrValue(list[3])
+    let marginTop: Double? = nilOrValue(list[4])
+    let marginRight: Double? = nilOrValue(list[5])
+    let marginBottom: Double? = nilOrValue(list[6])
+    let clickable: Bool? = nilOrValue(list[7])
 
     return AttributionSettings(
+      enabled: enabled,
       iconColor: iconColor,
       position: position,
       marginLeft: marginLeft,
@@ -649,6 +654,7 @@ struct AttributionSettings {
   }
   func toList() -> [Any?] {
     return [
+      enabled,
       iconColor,
       position?.rawValue,
       marginLeft,
@@ -664,6 +670,9 @@ struct AttributionSettings {
 ///
 /// Generated class from Pigeon that represents data sent in messages.
 struct LogoSettings {
+  /// Whether the logo is visible on the map.
+  /// Restricted API. Please contact Mapbox to discuss your use case if you intend to use this property.
+  var enabled: Bool?
   /// Defines where the logo is positioned on the map
   var position: OrnamentPosition?
   /// Defines the margin to the left that the attribution icon honors. This property is specified in pixels.
@@ -676,17 +685,19 @@ struct LogoSettings {
   var marginBottom: Double?
 
   static func fromList(_ list: [Any?]) -> LogoSettings? {
+    let enabled: Bool? = nilOrValue(list[0])
     var position: OrnamentPosition?
-    let positionEnumVal: Int? = nilOrValue(list[0])
+    let positionEnumVal: Int? = nilOrValue(list[1])
     if let positionRawValue = positionEnumVal {
       position = OrnamentPosition(rawValue: positionRawValue)!
     }
-    let marginLeft: Double? = nilOrValue(list[1])
-    let marginTop: Double? = nilOrValue(list[2])
-    let marginRight: Double? = nilOrValue(list[3])
-    let marginBottom: Double? = nilOrValue(list[4])
+    let marginLeft: Double? = nilOrValue(list[2])
+    let marginTop: Double? = nilOrValue(list[3])
+    let marginRight: Double? = nilOrValue(list[4])
+    let marginBottom: Double? = nilOrValue(list[5])
 
     return LogoSettings(
+      enabled: enabled,
       position: position,
       marginLeft: marginLeft,
       marginTop: marginTop,
@@ -696,6 +707,7 @@ struct LogoSettings {
   }
   func toList() -> [Any?] {
     return [
+      enabled,
       position?.rawValue,
       marginLeft,
       marginTop,

--- a/ios/Classes/LogoController.swift
+++ b/ios/Classes/LogoController.swift
@@ -1,5 +1,5 @@
 import Foundation
-@_spi(Experimental) import MapboxMaps
+@_spi(Experimental) @_spi(Restricted) import MapboxMaps
 
 final class LogoController: LogoSettingsInterface {
     func updateSettings(settings: LogoSettings) throws {
@@ -18,7 +18,7 @@ final class LogoController: LogoSettingsInterface {
             logo.position = .topTrailing
             logo.margins = CGPoint(x: settings.marginRight ?? 0, y: settings.marginTop ?? 0)
         }
-
+        logo.visibility = (settings.enabled ?? true) ? .visible : .hidden
         ornaments.options.logo = logo
     }
 
@@ -26,6 +26,7 @@ final class LogoController: LogoSettingsInterface {
         let options = ornaments.options.logo
         let position = getFLT_SETTINGSOrnamentPosition(position: options.position)
         return LogoSettings(
+            enabled: options.visibility != .hidden,
             position: position,
             marginLeft: options.margins.x,
             marginTop: options.margins.y,

--- a/lib/src/pigeons/settings.dart
+++ b/lib/src/pigeons/settings.dart
@@ -646,6 +646,7 @@ class CompassSettings {
 /// Shows the attribution icon on the map.
 class AttributionSettings {
   AttributionSettings({
+    this.enabled,
     this.iconColor,
     this.position,
     this.marginLeft,
@@ -654,6 +655,10 @@ class AttributionSettings {
     this.marginBottom,
     this.clickable,
   });
+
+  /// Whether the attribution icon is visible on the map.
+  /// Restricted API. Please contact Mapbox to discuss your use case if you intend to use this property.
+  bool? enabled;
 
   /// Defines text color of the attribution icon.
   int? iconColor;
@@ -678,6 +683,7 @@ class AttributionSettings {
 
   Object encode() {
     return <Object?>[
+      enabled,
       iconColor,
       position?.index,
       marginLeft,
@@ -691,14 +697,15 @@ class AttributionSettings {
   static AttributionSettings decode(Object result) {
     result as List<Object?>;
     return AttributionSettings(
-      iconColor: result[0] as int?,
+      enabled: result[0] as bool?,
+      iconColor: result[1] as int?,
       position:
-          result[1] != null ? OrnamentPosition.values[result[1]! as int] : null,
-      marginLeft: result[2] as double?,
-      marginTop: result[3] as double?,
-      marginRight: result[4] as double?,
-      marginBottom: result[5] as double?,
-      clickable: result[6] as bool?,
+          result[2] != null ? OrnamentPosition.values[result[2]! as int] : null,
+      marginLeft: result[3] as double?,
+      marginTop: result[4] as double?,
+      marginRight: result[5] as double?,
+      marginBottom: result[6] as double?,
+      clickable: result[7] as bool?,
     );
   }
 }
@@ -706,12 +713,17 @@ class AttributionSettings {
 /// Shows the Mapbox logo on the map.
 class LogoSettings {
   LogoSettings({
+    this.enabled,
     this.position,
     this.marginLeft,
     this.marginTop,
     this.marginRight,
     this.marginBottom,
   });
+
+  /// Whether the logo is visible on the map.
+  /// Restricted API. Please contact Mapbox to discuss your use case if you intend to use this property.
+  bool? enabled;
 
   /// Defines where the logo is positioned on the map
   OrnamentPosition? position;
@@ -730,6 +742,7 @@ class LogoSettings {
 
   Object encode() {
     return <Object?>[
+      enabled,
       position?.index,
       marginLeft,
       marginTop,
@@ -741,12 +754,13 @@ class LogoSettings {
   static LogoSettings decode(Object result) {
     result as List<Object?>;
     return LogoSettings(
+      enabled: result[0] as bool?,
       position:
-          result[0] != null ? OrnamentPosition.values[result[0]! as int] : null,
-      marginLeft: result[1] as double?,
-      marginTop: result[2] as double?,
-      marginRight: result[3] as double?,
-      marginBottom: result[4] as double?,
+          result[1] != null ? OrnamentPosition.values[result[1]! as int] : null,
+      marginLeft: result[2] as double?,
+      marginTop: result[3] as double?,
+      marginRight: result[4] as double?,
+      marginBottom: result[5] as double?,
     );
   }
 }


### PR DESCRIPTION
### What does this pull request do?

Adds configuration options to configure map widget logo and attribution visibility.

### What is the motivation and context behind this change?

Addresses: https://mapbox.atlassian.net/browse/MAPSFLT-207

### Pull request checklist:
 - [ ] Add a changelog entry.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add documentation comments for any added or updated public APIs.
