### PR TITLE
Remove camera debug overlay from iOS code

### DIFF
--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -57,7 +57,6 @@ final class MapboxMapController: NSObject, FlutterPlatformView {
             .set(key: "com.mapbox.common.telemetry.internal.custom_user_agent_fragment", value: "FlutterPlugin/\(pluginVersion)")
 
         mapView = MapView(frame: frame, mapInitOptions: mapInitOptions)
-        mapView.debugOptions = [.camera]
         mapboxMap = mapView.mapboxMap
 
         self.registrar = registrar


### PR DESCRIPTION
### What does this pull request do?

Removes accidentally committed camera overlay debug option from iOS.

### What is the motivation and context behind this change?



### Pull request checklist:
 - [ ] Add a changelog entry.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
