### PR TITLE
Bump maps sdk to 11.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### main
 
+* Update Maps SDK to 11.4.0.
+
 ### 2.0.0-rc.1
 
 * Update Maps SDK to 11.4.0-rc.2.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -78,7 +78,7 @@ if (file("$rootDir/gradle/ktlint.gradle").exists() && file("$rootDir/gradle/lint
 }
 
 dependencies {
-    implementation "com.mapbox.maps:android:11.4.0-rc.2"
+    implementation "com.mapbox.maps:android:11.4.0"
 
     implementation "androidx.annotation:annotation:1.7.1"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.3.0"

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -4,14 +4,14 @@ PODS:
     - Flutter
   - mapbox_maps_flutter (2.0.0-rc.1):
     - Flutter
-    - MapboxMaps (~> 11.4.0-rc.2)
+    - MapboxMaps (~> 11.4.0)
     - Turf (= 2.8.0)
-  - MapboxCommon (24.4.0-rc.2)
-  - MapboxCoreMaps (11.4.0-rc.2):
-    - MapboxCommon (~> 24.4.0-rc)
-  - MapboxMaps (11.4.0-rc.2):
-    - MapboxCommon (= 24.4.0-rc.2)
-    - MapboxCoreMaps (= 11.4.0-rc.2)
+  - MapboxCommon (24.4.0)
+  - MapboxCoreMaps (11.4.0):
+    - MapboxCommon (~> 24.4)
+  - MapboxMaps (11.4.0):
+    - MapboxCommon (= 24.4.0)
+    - MapboxCoreMaps (= 11.4.0)
     - Turf (= 2.8.0)
   - permission_handler_apple (9.1.1):
     - Flutter
@@ -43,10 +43,10 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   integration_test: ce0a3ffa1de96d1a89ca0ac26fca7ea18a749ef4
-  mapbox_maps_flutter: 677b6094f040e319151db7496f87e0176506f3cc
-  MapboxCommon: 382ac2426f53bbe673ddea9398671e8eee2d4057
-  MapboxCoreMaps: b60c8a4d7dd2378620b1f6175a7d8e9214d250a4
-  MapboxMaps: b881158fb698cd589bab38ca78113f1480393370
+  mapbox_maps_flutter: 2ef4455f071d3c707c30d37fc2990c7c927fb844
+  MapboxCommon: 6acbd8ff41d66abf498e1558b0739f25c562945a
+  MapboxCoreMaps: f306bb1b10ebe995a2247b40e99322ab7f9b8071
+  MapboxMaps: 82044383ae19ec124ff444ec4b5d3ce82cb36ba5
   permission_handler_apple: e76247795d700c14ea09e3a2d8855d41ee80a2e6
   Turf: aa2ede4298009639d10db36aba1a7ebaad072a5e
 

--- a/ios/mapbox_maps_flutter.podspec
+++ b/ios/mapbox_maps_flutter.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.dependency 'Flutter'
   s.platform = :ios, '12.0'
 
-  s.dependency 'MapboxMaps', '~> 11.4.0-rc.2'
+  s.dependency 'MapboxMaps', '~> 11.4.0'
   s.dependency 'Turf', '2.8.0'
 
   # Flutter.framework does not contain a i386 slice.


### PR DESCRIPTION
### What does this pull request do?

Increases Maps SDK dependency version to 11.4.0 both on Android and iOS.

### What is the motivation and context behind this change?



### Pull request checklist:
 - [x] Add a changelog entry.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
