### PR TITLE
remove enum_to_string from deps

### DIFF
--- a/example/integration_test/camera_test.dart
+++ b/example/integration_test/camera_test.dart
@@ -8,6 +8,12 @@ import 'package:mapbox_maps_example/empty_map_widget.dart' as app;
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  final initialCamera = CameraOptions(
+    center: Point(coordinates: Position(0, 0)),
+    zoom: 15,
+    pitch: 60,
+    bearing: 12,
+  );
 
   testWidgets('cameraForCoordinatesPadding', (WidgetTester tester) async {
     final mapFuture = app.main();
@@ -321,17 +327,17 @@ void main() {
   });
 
   testWidgets('getCameraState', (WidgetTester tester) async {
-    final mapFuture = app.main();
+    final mapFuture = app.runMapWithCustomCamera(initialCamera);
     await tester.pumpAndSettle();
 
     final mapboxMap = await mapFuture;
     var cameraState = await mapboxMap.getCameraState();
-    expect(cameraState.zoom.floor(), 15);
-    expect(cameraState.pitch.floor(), 60);
-    expect(cameraState.bearing.floor(), 12);
+    expect(cameraState.zoom, closeTo(15, 0.1));
+    expect(cameraState.pitch, closeTo(60, 1));
+    expect(cameraState.bearing, closeTo(12, 0.1));
     final position = cameraState.center;
-    expect(position.coordinates.lng.floor(), -88);
-    expect(position.coordinates.lat.floor(), 41);
+    expect(position.coordinates.lng, 0);
+    expect(position.coordinates.lat, 0);
     expect(cameraState.padding.top, 0);
     expect(cameraState.padding.right, 0);
     expect(cameraState.padding.bottom, 0);

--- a/example/lib/empty_map_widget.dart
+++ b/example/lib/empty_map_widget.dart
@@ -95,6 +95,24 @@ Future<MapboxMap> runFixedSizeMap() {
   return completer.future;
 }
 
+Future<MapboxMap> runMapWithCustomCamera(CameraOptions camera) {
+  final completer = Completer<MapboxMap>();
+
+  const ACCESS_TOKEN = String.fromEnvironment('ACCESS_TOKEN');
+  MapboxOptions.setAccessToken(ACCESS_TOKEN);
+
+  runApp(MaterialApp(
+      home: MapWidget(
+              key: ValueKey("mapWidget"),
+              cameraOptions: camera,
+              onMapCreated: (MapboxMap mapboxMap) {
+                completer.complete(mapboxMap);
+              }),
+        ));
+
+  return completer.future;
+}
+
 void runEmpty() {
   const ACCESS_TOKEN = String.fromEnvironment('ACCESS_TOKEN');
   MapboxOptions.setAccessToken(ACCESS_TOKEN);

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -73,14 +73,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.0.2+3"
-  enum_to_string:
-    dependency: transitive
-    description:
-      name: enum_to_string
-      sha256: bd9e83a33b754cb43a75b36a9af2a0b92a757bfd9847d2621ca0b1bed45f8e7a
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
   fake_async:
     dependency: transitive
     description:
@@ -192,7 +184,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0-rc.1"
+    version: "2.0.0"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,6 @@ environment:
   flutter: ">=3.10.0"
 
 dependencies:
-  enum_to_string: ^2.0.1
   flutter:
     sdk: flutter
   flutter_plugin_android_lifecycle: ^2.0.5


### PR DESCRIPTION
### What does this pull request do?

Address #574 
We don't actually use `enum_to_string` even though we declare it as dependency, so it is safe to remove it.
This PR also fixes failing getCameraState test, by explicitly set camera to the map and not just use the default camera of the style, which might be subjected to change.

### What is the motivation and context behind this change?



### Pull request checklist:
 - [ ] Add a changelog entry.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
