### PR TITLE
[ios] Fix flaky GeoJsonSource tests

### DIFF
--- a/example/integration_test/style/source/geojson_source_test.dart
+++ b/example/integration_test/style/source/geojson_source_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
 import 'package:mapbox_maps_example/empty_map_widget.dart' as app;
+import '../../utils/retry.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -54,31 +55,24 @@ void main() {
 
     var source = await mapboxMap.style.getSource('source') as GeoJsonSource;
     expect(source.id, 'source');
-    var maxzoom = await source.maxzoom;
+
+    final maxzoom = await source.maxzoom;
     expect(maxzoom, 1.0);
-
-    var attribution = await source.attribution;
+    final attribution = await source.attribution;
     expect(attribution, "abc");
-
-    var buffer = await source.buffer;
+    final buffer = await source.buffer;
     expect(buffer, 1.0);
-
-    var tolerance = await source.tolerance;
+    final tolerance = await source.tolerance;
     expect(tolerance, 1.0);
-
-    var cluster = await source.cluster;
+    final cluster = await source.cluster;
     expect(cluster, true);
-
-    var clusterRadius = await source.clusterRadius;
+    final clusterRadius = await source.clusterRadius;
     expect(clusterRadius, 1.0);
-
-    var clusterMaxZoom = await source.clusterMaxZoom;
+    final clusterMaxZoom = await source.clusterMaxZoom;
     expect(clusterMaxZoom, 1.0);
-
-    var clusterMinPoints = await source.clusterMinPoints;
+    final clusterMinPoints = await source.clusterMinPoints;
     expect(clusterMinPoints, 1.0);
-
-    var clusterProperties = await source.clusterProperties;
+    final clusterProperties = await source.clusterProperties;
     expect(clusterProperties, {
       "sum": [
         [
@@ -95,23 +89,19 @@ void main() {
         1.0
       ]
     });
-
-    var lineMetrics = await source.lineMetrics;
+    final lineMetrics = await source.lineMetrics;
     expect(lineMetrics, true);
-
-    var generateId = await source.generateId;
+    final generateId = await source.generateId;
     expect(generateId, true);
-
-    await Future.delayed(const Duration(seconds: 1), (){});
-    // https://mapbox.atlassian.net/browse/MAPSFLT-141
-      var prefetchZoomDelta = await source.prefetchZoomDelta;
-      expect(prefetchZoomDelta, 1.0);
-
-    var tileCacheBudget = await source.tileCacheBudget;
-    expect(tileCacheBudget?.size,
-        TileCacheBudget.inMegabytes(TileCacheBudgetInMegabytes(size: 3)).size);
-    expect(tileCacheBudget?.type,
-        TileCacheBudget.inMegabytes(TileCacheBudgetInMegabytes(size: 3)).type);
+    await retry(2, () async {
+      await expectLater(source.prefetchZoomDelta, completion(1.0));
+    });
+    await retry(2, () async {
+      await expectLater(
+          source.tileCacheBudget,
+          completion(TileCacheBudget.inMegabytes(
+              TileCacheBudgetInMegabytes(size: 3))));
+    });
   });
 }
 // End of generated file.

--- a/example/integration_test/style/source/geojson_source_test.dart
+++ b/example/integration_test/style/source/geojson_source_test.dart
@@ -102,12 +102,10 @@ void main() {
     var generateId = await source.generateId;
     expect(generateId, true);
 
-    // TODO: Investigate why this check is susceptible to fail on iOS
+    await Future.delayed(const Duration(seconds: 1), (){});
     // https://mapbox.atlassian.net/browse/MAPSFLT-141
-    if (Platform.isAndroid) {
       var prefetchZoomDelta = await source.prefetchZoomDelta;
       expect(prefetchZoomDelta, 1.0);
-    }
 
     var tileCacheBudget = await source.tileCacheBudget;
     expect(tileCacheBudget?.size,

--- a/example/integration_test/style/source/image_source_test.dart
+++ b/example/integration_test/style/source/image_source_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
 import 'package:mapbox_maps_example/empty_map_widget.dart' as app;
+import '../../utils/retry.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -31,15 +32,15 @@ void main() {
 
     var source = await mapboxMap.style.getSource('source') as ImageSource;
     expect(source.id, 'source');
-    var coordinates = await source.coordinates;
+
+    final coordinates = await source.coordinates;
     expect(coordinates, [
       [0.0, 1.0],
       [0.0, 1.0],
       [0.0, 1.0],
       [0.0, 1.0]
     ]);
-
-    var prefetchZoomDelta = await source.prefetchZoomDelta;
+    final prefetchZoomDelta = await source.prefetchZoomDelta;
     expect(prefetchZoomDelta, 1.0);
   });
 }

--- a/example/integration_test/style/source/raster_source_test.dart
+++ b/example/integration_test/style/source/raster_source_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
 import 'package:mapbox_maps_example/empty_map_widget.dart' as app;
+import '../../utils/retry.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -39,50 +40,36 @@ void main() {
 
     var source = await mapboxMap.style.getSource('source') as RasterSource;
     expect(source.id, 'source');
-    var tiles = await source.tiles;
+
+    final tiles = await source.tiles;
     expect(tiles, ["a", "b", "c"]);
-
-    var bounds = await source.bounds;
+    final bounds = await source.bounds;
     expect(bounds, [0.0, 1.0, 2.0, 3.0]);
-
-    var minzoom = await source.minzoom;
+    final minzoom = await source.minzoom;
     expect(minzoom, 1.0);
-
-    var maxzoom = await source.maxzoom;
+    final maxzoom = await source.maxzoom;
     expect(maxzoom, 1.0);
-
-    var tileSize = await source.tileSize;
+    final tileSize = await source.tileSize;
     expect(tileSize, 1.0);
-
-    var scheme = await source.scheme;
+    final scheme = await source.scheme;
     expect(scheme, Scheme.XYZ);
-
-    var attribution = await source.attribution;
+    final attribution = await source.attribution;
     expect(attribution, "abc");
-
-    var volatile = await source.volatile;
+    final volatile = await source.volatile;
     expect(volatile, true);
-
-    var prefetchZoomDelta = await source.prefetchZoomDelta;
+    final prefetchZoomDelta = await source.prefetchZoomDelta;
     expect(prefetchZoomDelta, 1.0);
-
-    var tileCacheBudget = await source.tileCacheBudget;
-    expect(tileCacheBudget?.size,
-        TileCacheBudget.inMegabytes(TileCacheBudgetInMegabytes(size: 3)).size);
-    expect(tileCacheBudget?.type,
-        TileCacheBudget.inMegabytes(TileCacheBudgetInMegabytes(size: 3)).type);
-
-    var minimumTileUpdateInterval = await source.minimumTileUpdateInterval;
+    final tileCacheBudget = await source.tileCacheBudget;
+    expect(tileCacheBudget,
+        TileCacheBudget.inMegabytes(TileCacheBudgetInMegabytes(size: 3)));
+    final minimumTileUpdateInterval = await source.minimumTileUpdateInterval;
     expect(minimumTileUpdateInterval, 1.0);
-
-    var maxOverscaleFactorForParentTiles =
+    final maxOverscaleFactorForParentTiles =
         await source.maxOverscaleFactorForParentTiles;
     expect(maxOverscaleFactorForParentTiles, 1.0);
-
-    var tileRequestsDelay = await source.tileRequestsDelay;
+    final tileRequestsDelay = await source.tileRequestsDelay;
     expect(tileRequestsDelay, 1.0);
-
-    var tileNetworkRequestsDelay = await source.tileNetworkRequestsDelay;
+    final tileNetworkRequestsDelay = await source.tileNetworkRequestsDelay;
     expect(tileNetworkRequestsDelay, 1.0);
   });
 }

--- a/example/integration_test/style/source/rasterarray_source_test.dart
+++ b/example/integration_test/style/source/rasterarray_source_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
 import 'package:mapbox_maps_example/empty_map_widget.dart' as app;
+import '../../utils/retry.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -32,29 +33,22 @@ void main() {
 
     var source = await mapboxMap.style.getSource('source') as RasterArraySource;
     expect(source.id, 'source');
-    var tiles = await source.tiles;
+
+    final tiles = await source.tiles;
     expect(tiles, ["a", "b", "c"]);
-
-    var bounds = await source.bounds;
+    final bounds = await source.bounds;
     expect(bounds, [0.0, 1.0, 2.0, 3.0]);
-
-    var minzoom = await source.minzoom;
+    final minzoom = await source.minzoom;
     expect(minzoom, 1.0);
-
-    var maxzoom = await source.maxzoom;
+    final maxzoom = await source.maxzoom;
     expect(maxzoom, 1.0);
-
-    var tileSize = await source.tileSize;
+    final tileSize = await source.tileSize;
     expect(tileSize, 1.0);
-
-    var attribution = await source.attribution;
+    final attribution = await source.attribution;
     expect(attribution, "abc");
-
-    var tileCacheBudget = await source.tileCacheBudget;
-    expect(tileCacheBudget?.size,
-        TileCacheBudget.inMegabytes(TileCacheBudgetInMegabytes(size: 3)).size);
-    expect(tileCacheBudget?.type,
-        TileCacheBudget.inMegabytes(TileCacheBudgetInMegabytes(size: 3)).type);
+    final tileCacheBudget = await source.tileCacheBudget;
+    expect(tileCacheBudget,
+        TileCacheBudget.inMegabytes(TileCacheBudgetInMegabytes(size: 3)));
   });
 }
 // End of generated file.

--- a/example/integration_test/style/source/rasterdem_source_test.dart
+++ b/example/integration_test/style/source/rasterdem_source_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
 import 'package:mapbox_maps_example/empty_map_widget.dart' as app;
+import '../../utils/retry.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -39,50 +40,36 @@ void main() {
 
     var source = await mapboxMap.style.getSource('source') as RasterDemSource;
     expect(source.id, 'source');
-    var tiles = await source.tiles;
+
+    final tiles = await source.tiles;
     expect(tiles, ["a", "b", "c"]);
-
-    var bounds = await source.bounds;
+    final bounds = await source.bounds;
     expect(bounds, [0.0, 1.0, 2.0, 3.0]);
-
-    var minzoom = await source.minzoom;
+    final minzoom = await source.minzoom;
     expect(minzoom, 1.0);
-
-    var maxzoom = await source.maxzoom;
+    final maxzoom = await source.maxzoom;
     expect(maxzoom, 1.0);
-
-    var tileSize = await source.tileSize;
+    final tileSize = await source.tileSize;
     expect(tileSize, 1.0);
-
-    var attribution = await source.attribution;
+    final attribution = await source.attribution;
     expect(attribution, "abc");
-
-    var encoding = await source.encoding;
+    final encoding = await source.encoding;
     expect(encoding, Encoding.TERRARIUM);
-
-    var volatile = await source.volatile;
+    final volatile = await source.volatile;
     expect(volatile, true);
-
-    var prefetchZoomDelta = await source.prefetchZoomDelta;
+    final prefetchZoomDelta = await source.prefetchZoomDelta;
     expect(prefetchZoomDelta, 1.0);
-
-    var tileCacheBudget = await source.tileCacheBudget;
-    expect(tileCacheBudget?.size,
-        TileCacheBudget.inMegabytes(TileCacheBudgetInMegabytes(size: 3)).size);
-    expect(tileCacheBudget?.type,
-        TileCacheBudget.inMegabytes(TileCacheBudgetInMegabytes(size: 3)).type);
-
-    var minimumTileUpdateInterval = await source.minimumTileUpdateInterval;
+    final tileCacheBudget = await source.tileCacheBudget;
+    expect(tileCacheBudget,
+        TileCacheBudget.inMegabytes(TileCacheBudgetInMegabytes(size: 3)));
+    final minimumTileUpdateInterval = await source.minimumTileUpdateInterval;
     expect(minimumTileUpdateInterval, 1.0);
-
-    var maxOverscaleFactorForParentTiles =
+    final maxOverscaleFactorForParentTiles =
         await source.maxOverscaleFactorForParentTiles;
     expect(maxOverscaleFactorForParentTiles, 1.0);
-
-    var tileRequestsDelay = await source.tileRequestsDelay;
+    final tileRequestsDelay = await source.tileRequestsDelay;
     expect(tileRequestsDelay, 1.0);
-
-    var tileNetworkRequestsDelay = await source.tileNetworkRequestsDelay;
+    final tileNetworkRequestsDelay = await source.tileNetworkRequestsDelay;
     expect(tileNetworkRequestsDelay, 1.0);
   });
 }

--- a/example/integration_test/style/source/vector_source_test.dart
+++ b/example/integration_test/style/source/vector_source_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
 import 'package:mapbox_maps_example/empty_map_widget.dart' as app;
+import '../../utils/retry.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -38,47 +39,34 @@ void main() {
 
     var source = await mapboxMap.style.getSource('source') as VectorSource;
     expect(source.id, 'source');
-    var tiles = await source.tiles;
+
+    final tiles = await source.tiles;
     expect(tiles, ["a", "b", "c"]);
-
-    var bounds = await source.bounds;
+    final bounds = await source.bounds;
     expect(bounds, [0.0, 1.0, 2.0, 3.0]);
-
-    var scheme = await source.scheme;
+    final scheme = await source.scheme;
     expect(scheme, Scheme.XYZ);
-
-    var minzoom = await source.minzoom;
+    final minzoom = await source.minzoom;
     expect(minzoom, 1.0);
-
-    var maxzoom = await source.maxzoom;
+    final maxzoom = await source.maxzoom;
     expect(maxzoom, 1.0);
-
-    var attribution = await source.attribution;
+    final attribution = await source.attribution;
     expect(attribution, "abc");
-
-    var volatile = await source.volatile;
+    final volatile = await source.volatile;
     expect(volatile, true);
-
-    var prefetchZoomDelta = await source.prefetchZoomDelta;
+    final prefetchZoomDelta = await source.prefetchZoomDelta;
     expect(prefetchZoomDelta, 1.0);
-
-    var tileCacheBudget = await source.tileCacheBudget;
-    expect(tileCacheBudget?.size,
-        TileCacheBudget.inMegabytes(TileCacheBudgetInMegabytes(size: 3)).size);
-    expect(tileCacheBudget?.type,
-        TileCacheBudget.inMegabytes(TileCacheBudgetInMegabytes(size: 3)).type);
-
-    var minimumTileUpdateInterval = await source.minimumTileUpdateInterval;
+    final tileCacheBudget = await source.tileCacheBudget;
+    expect(tileCacheBudget,
+        TileCacheBudget.inMegabytes(TileCacheBudgetInMegabytes(size: 3)));
+    final minimumTileUpdateInterval = await source.minimumTileUpdateInterval;
     expect(minimumTileUpdateInterval, 1.0);
-
-    var maxOverscaleFactorForParentTiles =
+    final maxOverscaleFactorForParentTiles =
         await source.maxOverscaleFactorForParentTiles;
     expect(maxOverscaleFactorForParentTiles, 1.0);
-
-    var tileRequestsDelay = await source.tileRequestsDelay;
+    final tileRequestsDelay = await source.tileRequestsDelay;
     expect(tileRequestsDelay, 1.0);
-
-    var tileNetworkRequestsDelay = await source.tileNetworkRequestsDelay;
+    final tileNetworkRequestsDelay = await source.tileNetworkRequestsDelay;
     expect(tileNetworkRequestsDelay, 1.0);
   });
 }

--- a/example/integration_test/utils/retry.dart
+++ b/example/integration_test/utils/retry.dart
@@ -1,0 +1,15 @@
+Future<T> retry<T>(int retries, Future<T> Function() function,
+    {Duration? delay = const Duration(milliseconds: 500)}) async {
+  try {
+    return await function();
+  } catch (e) {
+    if (retries > 1) {
+      print("MMM retry");
+      if (delay != null) {
+        await Future.delayed(delay);
+      }
+      return retry(retries - 1, function);
+    }
+    rethrow;
+  }
+}

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -48,7 +48,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  integration_test: ce0a3ffa1de96d1a89ca0ac26fca7ea18a749ef4
+  integration_test: 13825b8a9334a850581300559b8839134b124670
   mapbox_maps_flutter: 6de31691b2709239722521b5530d2eeb97d6b8d4
   MapboxCommon: 06dd0a0e277ae06e88fe3dc6dba6c90c632b909c
   MapboxCoreMaps: 335fc5d65b32376b30955caa18217f1f2fe724c0

--- a/ios/Classes/StyleController.swift
+++ b/ios/Classes/StyleController.swift
@@ -170,7 +170,8 @@ final class StyleController: StyleManager {
 
     func addStyleSource(sourceId: String, properties: String, completion: @escaping (Result<Void, Error>) -> Void) {
         do {
-            try styleManager.addSource(createStyleSource(id: sourceId, data: convertStringToDictionary(properties: properties)))
+            try styleManager.addSource(withId: sourceId,
+                                          properties: convertStringToDictionary(properties: properties))
             completion(.success(()))
         } catch {
             completion(.failure(FlutterError(code: StyleController.errorCode, message: error.localizedDescription, details: nil)))
@@ -475,12 +476,4 @@ final class StyleController: StyleManager {
         }))
     }
 
-}
-
-private func createStyleSource(id: String, data: [String: Any]) throws -> MapboxMaps.Source {
-    guard let rawType = data["type"] as? String, let sourceType = SourceType(rawValue: rawType).sourceType else {
-        throw FlutterError(code: "0", message: "Invalid style source type", details: nil)
-    }
-
-    return try sourceType.init(jsonObject: data)
 }

--- a/ios/Classes/StyleController.swift
+++ b/ios/Classes/StyleController.swift
@@ -170,8 +170,7 @@ final class StyleController: StyleManager {
 
     func addStyleSource(sourceId: String, properties: String, completion: @escaping (Result<Void, Error>) -> Void) {
         do {
-            try styleManager.addSource(withId: sourceId,
-                                          properties: convertStringToDictionary(properties: properties))
+            try styleManager.addSource(createStyleSource(id: sourceId, data: convertStringToDictionary(properties: properties)))
             completion(.success(()))
         } catch {
             completion(.failure(FlutterError(code: StyleController.errorCode, message: error.localizedDescription, details: nil)))
@@ -476,4 +475,12 @@ final class StyleController: StyleManager {
         }))
     }
 
+}
+
+private func createStyleSource(id: String, data: [String: Any]) throws -> MapboxMaps.Source {
+    guard let rawType = data["type"] as? String, let sourceType = SourceType(rawValue: rawType).sourceType else {
+        throw FlutterError(code: "0", message: "Invalid style source type", details: nil)
+    }
+
+    return try sourceType.init(jsonObject: data)
 }

--- a/lib/src/style/style.dart
+++ b/lib/src/style/style.dart
@@ -129,6 +129,14 @@ class TileCacheBudget {
         size = budget.size;
 
   TileCacheBudget(this.type, this.size);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is TileCacheBudget &&
+          runtimeType == other.runtimeType &&
+          type == other.type &&
+          size == other.size;
 }
 
 /// The description of the raster data layers and the bands contained within the tiles.


### PR DESCRIPTION
- Use StyleManager/addSource(_:dataId:) so GeoJsonSource's data will be applied in a background queue.
- Add a delay in GeoJsonSource test when checking for volatile properties, since these properties are added later after the source is added to the style.

**TODO** It might be better for us to adopt StyleDSL from both platforms to Flutter.  I created an [internal ticket](https://mapbox.atlassian.net/browse/MAPSFLT-221) to track work


### Pull request checklist:
 - [x] Add a changelog entry.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
