### PR TITLE
Add missing constructors to turf-derived types

### DIFF
--- a/lib/src/turf_adapters.dart
+++ b/lib/src/turf_adapters.dart
@@ -34,6 +34,10 @@ final class Polygon extends turf.Polygon {
     final polygon = turf.Polygon.fromJson(json);
     return Polygon(bbox: polygon.bbox, coordinates: polygon.coordinates);
   }
+
+  Polygon.fromPoints({turf.BBox? bbox, required List<List<Point>> points}) {
+    turf.Polygon.fromPoints(points: points, bbox: bbox);
+  }
 }
 
 final class LineString extends turf.LineString {
@@ -51,5 +55,9 @@ final class LineString extends turf.LineString {
   factory LineString.fromJson(Map<String, dynamic> json) {
     final line = turf.LineString.fromJson(json);
     return LineString(bbox: line.bbox, coordinates: line.coordinates);
+  }
+
+  LineString.fromPoints({turf.BBox? bbox, required List<Point> points}) {
+    turf.LineString.fromPoints(points: points, bbox: bbox);
   }
 }

--- a/lib/src/turf_adapters.dart
+++ b/lib/src/turf_adapters.dart
@@ -35,9 +35,7 @@ final class Polygon extends turf.Polygon {
     return Polygon(bbox: polygon.bbox, coordinates: polygon.coordinates);
   }
 
-  Polygon.fromPoints({turf.BBox? bbox, required List<List<Point>> points}) {
-    turf.Polygon.fromPoints(points: points, bbox: bbox);
-  }
+    Polygon.fromPoints({turf.BBox? bbox, required List<List<Point>> points}) : super.fromPoints(bbox: bbox, points: points);
 }
 
 final class LineString extends turf.LineString {
@@ -57,7 +55,5 @@ final class LineString extends turf.LineString {
     return LineString(bbox: line.bbox, coordinates: line.coordinates);
   }
 
-  LineString.fromPoints({turf.BBox? bbox, required List<Point> points}) {
-    turf.LineString.fromPoints(points: points, bbox: bbox);
-  }
+  LineString.fromPoints({turf.BBox? bbox, required List<Point> points}) : super.fromPoints(bbox: bbox, points: points);
 }


### PR DESCRIPTION
### What does this pull request do?

It seems that named constructors are not inherited by our turf-derived types. This PR adds them back.

### What is the motivation and context behind this change?

Addresses: https://github.com/mapbox/mapbox-maps-flutter/issues/594

### Pull request checklist:
 - [ ] Add a changelog entry.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
