### PR TITLE
[ios] Adapt GesturesManager/onMapTap and onMapLongPress

### DIFF
--- a/ios/Classes/Extensions.swift
+++ b/ios/Classes/Extensions.swift
@@ -374,6 +374,14 @@ extension CGPoint {
         return ScreenCoordinate(x: x, y: y)
     }
 }
+
+extension MapboxMaps.MapContentGestureContext {
+
+    func toFLTMapContentGestureContext() -> MapContentGestureContext {
+        MapContentGestureContext(touchPosition: point.toFLTScreenCoordinate(), point: Point(coordinate))
+    }
+}
+
 extension MapboxMaps.CoordinateBoundsZoom {
     func toFLTCoordinateBoundsZoom() -> CoordinateBoundsZoom {
         return CoordinateBoundsZoom(bounds: self.bounds.toFLTCoordinateBounds(), zoom: zoom)


### PR DESCRIPTION
### What does this pull request do?
We should take advantage of existing gesture recognizers of MapView, namely onMapTap and onMapLongPress.

Remove extra tap and long press recognizer in GesturesController, replace them with `onMapTap` and `onMapLongPress`
This should fix https://github.com/mapbox/mapbox-maps-flutter/issues/605 as `onMapLongPress` will emit events when the long press is recognized (after a minimum press duration), current approach with target/action will report event when the fingers are lifted off the screen.


### Pull request checklist:
 - [ ] Add a changelog entry.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
