### PR TITLE
Expose debug options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Support local assets for 3D puck and `ModelLayer`. To use a local assets, please specify it with `asset://` scheme in the uri.
 * Fix map view crashing upon host activity destruction when using a cached Flutter engine.
 * Fix a rare crash happening when map widget is being disposed.
+* `MapDebugOptions` got superseeded by `MapWidgetDebugOptions`, expanding existing debug options with the new `light`, `camera`, `padding` debug options in addition to the new Android-specific options: `layers2DWireframe`, `layers3DWireframe`.
 
 ### 2.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Support local assets for 3D puck and `ModelLayer`. To use a local assets, please specify it with `asset://` scheme in the uri.
 * Fix map view crashing upon host activity destruction when using a cached Flutter engine.
 * Fix a rare crash happening when map widget is being disposed.
-* `MapDebugOptions` got superseeded by `MapWidgetDebugOptions`, expanding existing debug options with the new `light`, `camera`, `padding` debug options in addition to the new Android-specific options: `layers2DWireframe`, `layers3DWireframe`.
+* `MapDebugOptions` is superseded by `MapWidgetDebugOptions`, expanding existing debug options with the new `light`, `camera`, and `padding` debug options in addition to the new Android-specific options: `layers2DWireframe` and `layers3DWireframe`.
 
 ### 2.1.0
 

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/Extentions.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/Extentions.kt
@@ -10,6 +10,7 @@ import com.mapbox.common.TileRegionError
 import com.mapbox.geojson.*
 import com.mapbox.maps.EdgeInsets
 import com.mapbox.maps.StylePackError
+import com.mapbox.maps.debugoptions.MapViewDebugOptions
 import com.mapbox.maps.extension.style.expressions.dsl.generated.min
 import com.mapbox.maps.extension.style.layers.properties.generated.ProjectionName
 import com.mapbox.maps.extension.style.light.LightPosition
@@ -25,6 +26,25 @@ import org.json.JSONObject
 import java.io.ByteArrayOutputStream
 
 // FLT to Android
+
+fun _MapWidgetDebugOptions.toMapViewDebugOptions(): MapViewDebugOptions {
+  return when (this) {
+    _MapWidgetDebugOptions.TILE_BORDERS -> MapViewDebugOptions.TILE_BORDERS
+    _MapWidgetDebugOptions.PARSE_STATUS -> MapViewDebugOptions.PARSE_STATUS
+    _MapWidgetDebugOptions.TIMESTAMPS -> MapViewDebugOptions.TIMESTAMPS
+    _MapWidgetDebugOptions.COLLISION -> MapViewDebugOptions.COLLISION
+    _MapWidgetDebugOptions.OVERDRAW -> MapViewDebugOptions.OVERDRAW
+    _MapWidgetDebugOptions.STENCIL_CLIP -> MapViewDebugOptions.STENCIL_CLIP
+    _MapWidgetDebugOptions.DEPTH_BUFFER -> MapViewDebugOptions.DEPTH_BUFFER
+    _MapWidgetDebugOptions.MODEL_BOUNDS -> MapViewDebugOptions.MODEL_BOUNDS
+    _MapWidgetDebugOptions.TERRAIN_WIREFRAME -> MapViewDebugOptions.TERRAIN_WIREFRAME
+    _MapWidgetDebugOptions.LAYERS2DWIREFRAME -> MapViewDebugOptions.LAYERS2_DWIREFRAME
+    _MapWidgetDebugOptions.LAYERS3DWIREFRAME -> MapViewDebugOptions.LAYERS3_DWIREFRAME
+    _MapWidgetDebugOptions.LIGHT -> MapViewDebugOptions.LIGHT
+    _MapWidgetDebugOptions.CAMERA -> MapViewDebugOptions.CAMERA
+    _MapWidgetDebugOptions.PADDING -> MapViewDebugOptions.PADDING
+  }
+}
 
 fun GlyphsRasterizationMode.toGlyphsRasterizationMode(): com.mapbox.maps.GlyphsRasterizationMode {
   return when (this) {
@@ -375,6 +395,26 @@ fun Number.toDevicePixels(context: Context): Float {
 }
 
 // Android to FLT
+
+fun MapViewDebugOptions.toFLTDebugOptions(): _MapWidgetDebugOptions? {
+  return when (this) {
+    MapViewDebugOptions.TILE_BORDERS -> _MapWidgetDebugOptions.TILE_BORDERS
+    MapViewDebugOptions.PARSE_STATUS -> _MapWidgetDebugOptions.PARSE_STATUS
+    MapViewDebugOptions.TIMESTAMPS -> _MapWidgetDebugOptions.TIMESTAMPS
+    MapViewDebugOptions.COLLISION -> _MapWidgetDebugOptions.COLLISION
+    MapViewDebugOptions.OVERDRAW -> _MapWidgetDebugOptions.OVERDRAW
+    MapViewDebugOptions.STENCIL_CLIP -> _MapWidgetDebugOptions.STENCIL_CLIP
+    MapViewDebugOptions.DEPTH_BUFFER -> _MapWidgetDebugOptions.DEPTH_BUFFER
+    MapViewDebugOptions.MODEL_BOUNDS -> _MapWidgetDebugOptions.MODEL_BOUNDS
+    MapViewDebugOptions.TERRAIN_WIREFRAME -> _MapWidgetDebugOptions.TERRAIN_WIREFRAME
+    MapViewDebugOptions.LAYERS2_DWIREFRAME -> _MapWidgetDebugOptions.LAYERS2DWIREFRAME
+    MapViewDebugOptions.LAYERS3_DWIREFRAME -> _MapWidgetDebugOptions.LAYERS3DWIREFRAME
+    MapViewDebugOptions.LIGHT -> _MapWidgetDebugOptions.LIGHT
+    MapViewDebugOptions.CAMERA -> _MapWidgetDebugOptions.CAMERA
+    MapViewDebugOptions.PADDING -> _MapWidgetDebugOptions.PADDING
+    else -> null
+  }
+}
 
 fun com.mapbox.maps.CanonicalTileID.toFLTCanonicalTileID(): CanonicalTileID {
   return CanonicalTileID(z = z.toLong(), x = x.toLong(), y = y.toLong())

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/MapInterfaceController.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/MapInterfaceController.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.google.gson.Gson
 import com.mapbox.geojson.Feature
 import com.mapbox.geojson.Point
+import com.mapbox.maps.MapView
 import com.mapbox.maps.MapboxMap
 import com.mapbox.maps.TileCacheBudget
 import com.mapbox.maps.extension.observable.eventdata.MapLoadingErrorEventData
@@ -24,9 +25,15 @@ import com.mapbox.maps.mapbox_maps.pigeons.TileCacheBudgetInTiles
 import com.mapbox.maps.mapbox_maps.pigeons.TileCoverOptions
 import com.mapbox.maps.mapbox_maps.pigeons.ViewportMode
 import com.mapbox.maps.mapbox_maps.pigeons._MapInterface
+import com.mapbox.maps.mapbox_maps.pigeons._MapWidgetDebugOptions
+import com.mapbox.maps.mapbox_maps.pigeons._MapWidgetDebugOptionsBox
 import com.mapbox.maps.plugin.delegates.listeners.OnMapLoadErrorListener
 
-class MapInterfaceController(private val mapboxMap: MapboxMap, private val context: Context) : _MapInterface {
+class MapInterfaceController(
+  private val mapboxMap: MapboxMap,
+  private val mapView: MapView,
+  private val context: Context
+) : _MapInterface {
   override fun loadStyleURI(styleURI: String, callback: (Result<Unit>) -> Unit) {
     mapboxMap.loadStyleUri(
       styleURI,
@@ -109,6 +116,16 @@ class MapInterfaceController(private val mapboxMap: MapboxMap, private val conte
 
   override fun getMapOptions(): MapOptions {
     return mapboxMap.getMapOptions().toFLTMapOptions(context)
+  }
+
+  override fun getDebugOptions(): List<_MapWidgetDebugOptionsBox?> {
+    return mapView.debugOptions.mapNotNull { nativeOption ->
+      nativeOption.toFLTDebugOptions()?.let { _MapWidgetDebugOptionsBox(it) }
+    }
+  }
+
+  override fun setDebugOptions(debugOptions: List<_MapWidgetDebugOptionsBox>) {
+    mapView.debugOptions = debugOptions.map { it.option.toMapViewDebugOptions() }.toSet()
   }
 
   override fun getDebug(): List<MapDebugOptions> {

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/MapInterfaceController.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/MapInterfaceController.kt
@@ -25,7 +25,6 @@ import com.mapbox.maps.mapbox_maps.pigeons.TileCacheBudgetInTiles
 import com.mapbox.maps.mapbox_maps.pigeons.TileCoverOptions
 import com.mapbox.maps.mapbox_maps.pigeons.ViewportMode
 import com.mapbox.maps.mapbox_maps.pigeons._MapInterface
-import com.mapbox.maps.mapbox_maps.pigeons._MapWidgetDebugOptions
 import com.mapbox.maps.mapbox_maps.pigeons._MapWidgetDebugOptionsBox
 import com.mapbox.maps.plugin.delegates.listeners.OnMapLoadErrorListener
 

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/MapboxMapController.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/MapboxMapController.kt
@@ -131,7 +131,7 @@ class MapboxMapController(
     styleController = StyleController(context, mapboxMap)
     cameraController = CameraController(mapboxMap, context)
     projectionController = MapProjectionController(mapboxMap)
-    mapInterfaceController = MapInterfaceController(mapboxMap, context)
+    mapInterfaceController = MapInterfaceController(mapboxMap, mapView, context)
     animationController = AnimationController(mapboxMap, context)
     annotationController = AnnotationController(mapView)
     locationComponentController = LocationComponentController(mapView, context)

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/MapInterfaces.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/MapInterfaces.kt
@@ -117,6 +117,29 @@ enum class NorthOrientation(val raw: Int) {
   }
 }
 
+enum class _MapWidgetDebugOptions(val raw: Int) {
+  TILE_BORDERS(0),
+  PARSE_STATUS(1),
+  TIMESTAMPS(2),
+  COLLISION(3),
+  OVERDRAW(4),
+  STENCIL_CLIP(5),
+  DEPTH_BUFFER(6),
+  MODEL_BOUNDS(7),
+  TERRAIN_WIREFRAME(8),
+  LAYERS2DWIREFRAME(9),
+  LAYERS3DWIREFRAME(10),
+  LIGHT(11),
+  CAMERA(12),
+  PADDING(13);
+
+  companion object {
+    fun ofRaw(raw: Int): _MapWidgetDebugOptions? {
+      return values().firstOrNull { it.raw == raw }
+    }
+  }
+}
+
 /** Options for enabling debugging features in a map. */
 enum class MapDebugOptionsData(val raw: Int) {
   /**
@@ -817,6 +840,29 @@ data class CoordinateBounds(
       southwest.toList(),
       northeast.toList(),
       infiniteBounds,
+    )
+  }
+}
+
+/**
+ * This class is needed because Pigeon does not encode properly arrays of enums.
+ *
+ * Generated class from Pigeon that represents data sent in messages.
+ */
+data class _MapWidgetDebugOptionsBox(
+  val option: _MapWidgetDebugOptions
+
+) {
+  companion object {
+    @Suppress("UNCHECKED_CAST")
+    fun fromList(list: List<Any?>): _MapWidgetDebugOptionsBox {
+      val option = _MapWidgetDebugOptions.ofRaw(list[0] as Int)!!
+      return _MapWidgetDebugOptionsBox(option)
+    }
+  }
+  fun toList(): List<Any?> {
+    return listOf<Any?>(
+      option.raw,
     )
   }
 }
@@ -2250,6 +2296,11 @@ private object _CameraManagerCodec : StandardMessageCodec() {
           TransitionOptions.fromList(it)
         }
       }
+      167.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let {
+          _MapWidgetDebugOptionsBox.fromList(it)
+        }
+      }
       else -> super.readValueOfType(type, buffer)
     }
   }
@@ -2409,6 +2460,10 @@ private object _CameraManagerCodec : StandardMessageCodec() {
       }
       is TransitionOptions -> {
         stream.write(166)
+        writeValue(stream, value.toList())
+      }
+      is _MapWidgetDebugOptionsBox -> {
+        stream.write(167)
         writeValue(stream, value.toList())
       }
       else -> super.writeValue(stream, value)
@@ -3143,6 +3198,11 @@ private object _MapInterfaceCodec : StandardMessageCodec() {
           TransitionOptions.fromList(it)
         }
       }
+      167.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let {
+          _MapWidgetDebugOptionsBox.fromList(it)
+        }
+      }
       else -> super.readValueOfType(type, buffer)
     }
   }
@@ -3304,6 +3364,10 @@ private object _MapInterfaceCodec : StandardMessageCodec() {
         stream.write(166)
         writeValue(stream, value.toList())
       }
+      is _MapWidgetDebugOptionsBox -> {
+        stream.write(167)
+        writeValue(stream, value.toList())
+      }
       else -> super.writeValue(stream, value)
     }
   }
@@ -3382,6 +3446,8 @@ interface _MapInterface {
    * @return The map's `map options`.
    */
   fun getMapOptions(): MapOptions
+  fun getDebugOptions(): List<_MapWidgetDebugOptionsBox?>
+  fun setDebugOptions(debugOptions: List<_MapWidgetDebugOptionsBox>)
   /**
    * Returns the `map debug options`.
    *
@@ -3793,6 +3859,41 @@ interface _MapInterface {
             var wrapped: List<Any?>
             try {
               wrapped = listOf<Any?>(api.getMapOptions())
+            } catch (exception: Throwable) {
+              wrapped = wrapError(exception)
+            }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.mapbox_maps_flutter._MapInterface.getDebugOptions$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { _, reply ->
+            var wrapped: List<Any?>
+            try {
+              wrapped = listOf<Any?>(api.getDebugOptions())
+            } catch (exception: Throwable) {
+              wrapped = wrapError(exception)
+            }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.mapbox_maps_flutter._MapInterface.setDebugOptions$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val debugOptionsArg = args[0] as List<_MapWidgetDebugOptionsBox>
+            var wrapped: List<Any?>
+            try {
+              api.setDebugOptions(debugOptionsArg)
+              wrapped = listOf<Any?>(null)
             } catch (exception: Throwable) {
               wrapped = wrapError(exception)
             }
@@ -4851,6 +4952,11 @@ private object StyleManagerCodec : StandardMessageCodec() {
           TransitionOptions.fromList(it)
         }
       }
+      167.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let {
+          _MapWidgetDebugOptionsBox.fromList(it)
+        }
+      }
       else -> super.readValueOfType(type, buffer)
     }
   }
@@ -5010,6 +5116,10 @@ private object StyleManagerCodec : StandardMessageCodec() {
       }
       is TransitionOptions -> {
         stream.write(166)
+        writeValue(stream, value.toList())
+      }
+      is _MapWidgetDebugOptionsBox -> {
+        stream.write(167)
         writeValue(stream, value.toList())
       }
       else -> super.writeValue(stream, value)

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -1,0 +1,30 @@
+# This file configures the static analysis results for your project (errors,
+# warnings, and lints).
+#
+# This enables the 'recommended' set of lints from `package:lints`.
+# This set helps identify many issues that may lead to problems when running
+# or consuming Dart code, and enforces writing Dart using a single, idiomatic
+# style and format.
+#
+# If you want a smaller set of lints you can change this to specify
+# 'package:lints/core.yaml'. These are just the most critical lints
+# (the recommended set includes the core lints).
+# The core lints are also what is used by pub.dev for scoring packages.
+
+include: package:lints/recommended.yaml
+
+# Uncomment the following section to specify additional rules.
+
+linter:
+  rules:
+    - exhaustive_cases
+
+# analyzer:
+#   exclude:
+#     - path/to/excluded/files/**
+
+# For more information about the core and recommended set of lints, see
+# https://dart.dev/go/core-lints
+
+# For additional information about configuring this file, see
+# https://dart.dev/guides/language/analysis-options

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - Flutter (1.0.0)
   - integration_test (0.0.1):
     - Flutter
-  - mapbox_maps_flutter (2.1.0):
+  - mapbox_maps_flutter (2.2.0-beta.1):
     - Flutter
     - MapboxMaps (~> 11.6.0-beta.1)
     - Turf (= 2.8.0)
@@ -48,8 +48,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  integration_test: 13825b8a9334a850581300559b8839134b124670
-  mapbox_maps_flutter: 3f554cc330f15648f06ed8fef15a1c579af7b5df
+  integration_test: ce0a3ffa1de96d1a89ca0ac26fca7ea18a749ef4
+  mapbox_maps_flutter: 92560c1fe819ca74f83016cff9046a82e08533e6
   MapboxCommon: 79432665253799a69280297bd630d8d4bdba0d94
   MapboxCoreMaps: 5f7cb13a79665e5907315a47aaa49f341aba3f31
   MapboxMaps: 45a3753ed3fa10b5c99ea040dfc4537f28f6da57

--- a/example/lib/debug_options.dart
+++ b/example/lib/debug_options.dart
@@ -39,21 +39,24 @@ class DebugOptionsPageBodyState extends State<DebugOptionsPageBody> {
         key: const ValueKey<String>('mapWidget'),
         onMapCreated: _onMapCreated,
       ),
-      floatingActionButton: FloatingActionButton(
-        child: const Icon(Icons.construction),
-        onPressed: () async {
-          if (mapboxMap == null) {
-            return;
-          }
-          showModalBottomSheet(
-            context: context,
-            useSafeArea: true,
-            showDragHandle: true,
-            builder: (context) {
-              return DebugOptionsList(mapboxMap!);
-            },
-          );
-        },
+      floatingActionButton: Padding(
+        padding: const EdgeInsets.only(bottom: 32.0),
+        child: FloatingActionButton(
+          child: const Icon(Icons.construction),
+          onPressed: () async {
+            if (mapboxMap == null) {
+              return;
+            }
+            showModalBottomSheet(
+              context: context,
+              useSafeArea: true,
+              showDragHandle: true,
+              builder: (context) {
+                return DebugOptionsList(mapboxMap!);
+              },
+            );
+          },
+        ),
       ),
     );
   }

--- a/example/lib/debug_options.dart
+++ b/example/lib/debug_options.dart
@@ -1,0 +1,182 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
+import 'page.dart';
+
+class DebugOptionsPage extends ExamplePage {
+  DebugOptionsPage()
+      : super(const Icon(Icons.construction), 'Map debug options');
+
+  @override
+  Widget build(BuildContext context) {
+    return const DebugOptionsPageBody();
+  }
+}
+
+class DebugOptionsPageBody extends StatefulWidget {
+  const DebugOptionsPageBody();
+
+  @override
+  State createState() => DebugOptionsPageBodyState();
+}
+
+class DebugOptionsPageBodyState extends State<DebugOptionsPageBody> {
+  DebugOptionsPageBodyState();
+
+  MapboxMap? mapboxMap;
+  List<MapWidgetDebugOptions> enabledOptions = [];
+
+  _onMapCreated(MapboxMap mapboxMap) async {
+    enabledOptions = await mapboxMap.getDebugOptions();
+    this.mapboxMap = mapboxMap;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: MapWidget(
+        key: const ValueKey<String>('mapWidget'),
+        onMapCreated: _onMapCreated,
+      ),
+      floatingActionButton: FloatingActionButton(
+        child: const Icon(Icons.construction),
+        onPressed: () async {
+          if (mapboxMap == null) {
+            return;
+          }
+          showModalBottomSheet(
+            context: context,
+            useSafeArea: true,
+            showDragHandle: true,
+            builder: (context) {
+              return DebugOptionsList(mapboxMap!);
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+
+class DebugOptionsList extends StatefulWidget {
+  final MapboxMap mapController;
+  const DebugOptionsList(this.mapController);
+
+  @override
+  State createState() => DebugOptionsListState();
+}
+
+class DebugOptionsListState extends State<DebugOptionsList> {
+  List<MapWidgetDebugOptions> enabledOptions = [];
+
+  @override
+  void initState() {
+    super.initState();
+    widget.mapController.getDebugOptions().then((value) {
+      setState(() {
+        enabledOptions = value;
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Text(
+          "Debug options",
+          style: TextStyle(fontWeight: FontWeight.bold, fontSize: 22),
+        ),
+        Expanded(
+          child: ListView(
+            children: this
+                .allOptions
+                .map(
+                  (e) => SwitchListTile(
+                    title: Text(e.description),
+                    value: enabledOptions.contains(e),
+                    onChanged: (value) {
+                      if (value) {
+                        enabledOptions.add(e);
+                      } else {
+                        enabledOptions.remove(e);
+                      }
+                      setState(() {
+                        widget.mapController.setDebugOptions(enabledOptions);
+                      });
+                    },
+                  ),
+                )
+                .toList(),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+extension on DebugOptionsListState {
+  List<MapWidgetDebugOptions> get allOptions {
+    final values = [
+      MapWidgetDebugOptions.tileBorders,
+      MapWidgetDebugOptions.parseStatus,
+      MapWidgetDebugOptions.timestamps,
+      MapWidgetDebugOptions.collision,
+      MapWidgetDebugOptions.overdraw,
+      MapWidgetDebugOptions.stencilClip,
+      MapWidgetDebugOptions.depthBuffer,
+      MapWidgetDebugOptions.modelBounds,
+    ];
+    if (Platform.isAndroid) {
+      values.addAll({
+        MapWidgetDebugOptions.terrainWireframe,
+        MapWidgetDebugOptions.layers2DWireframe,
+        MapWidgetDebugOptions.layers3DWireframe,
+      });
+    }
+    values.addAll({
+      MapWidgetDebugOptions.light,
+      MapWidgetDebugOptions.camera,
+      MapWidgetDebugOptions.padding,
+    });
+    return values;
+  }
+}
+
+extension on MapWidgetDebugOptions {
+  String get description {
+    switch (this) {
+      case MapWidgetDebugOptions.tileBorders:
+        return 'Tile borders';
+      case MapWidgetDebugOptions.parseStatus:
+        return 'Parse status';
+      case MapWidgetDebugOptions.timestamps:
+        return 'Timestamps';
+      case MapWidgetDebugOptions.collision:
+        return 'Collision';
+      case MapWidgetDebugOptions.overdraw:
+        return 'Overdraw';
+      case MapWidgetDebugOptions.stencilClip:
+        return 'Stencil clip';
+      case MapWidgetDebugOptions.depthBuffer:
+        return 'Depth buffer';
+      case MapWidgetDebugOptions.modelBounds:
+        return 'Model bounds';
+      case MapWidgetDebugOptions.terrainWireframe:
+        return 'Terrain wireframe';
+      case MapWidgetDebugOptions.layers2DWireframe:
+        return '2D layers wireframe';
+      case MapWidgetDebugOptions.layers3DWireframe:
+        return '3D layers wireframe';
+      case MapWidgetDebugOptions.light:
+        return 'Light';
+      case MapWidgetDebugOptions.camera:
+        return 'Camera';
+      case MapWidgetDebugOptions.padding:
+        return 'Padding';
+      default:
+        return 'Unknown';
+    }
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -25,6 +25,7 @@ import 'point_annotations.dart';
 import 'projection.dart';
 import 'style.dart';
 import 'gestures.dart';
+import 'debug_options.dart';
 
 final List<ExamplePage> _allPages = <ExamplePage>[
   FullMapPage(),
@@ -50,6 +51,7 @@ final List<ExamplePage> _allPages = <ExamplePage>[
   TrafficRouteLinePage(),
   OfflineMapPage(),
   ModelLayerPage(),
+  DebugOptionsPage(),
 ];
 
 class MapsDemo extends StatelessWidget {

--- a/example/lib/model_layer.dart
+++ b/example/lib/model_layer.dart
@@ -5,7 +5,7 @@ import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
 import 'page.dart';
 
 class ModelLayerPage extends ExamplePage {
-  ModelLayerPage() : super(const Icon(Icons.map), 'Model layer');
+  ModelLayerPage() : super(const Icon(Icons.view_in_ar), 'Model layer');
 
   @override
   Widget build(BuildContext context) {

--- a/example/lib/offline_map.dart
+++ b/example/lib/offline_map.dart
@@ -10,7 +10,7 @@ import 'page.dart';
 import 'utils.dart';
 
 class OfflineMapPage extends ExamplePage {
-  OfflineMapPage() : super(const Icon(Icons.map), 'Offline Map');
+  OfflineMapPage() : super(const Icon(Icons.wifi_off), 'Offline Map');
 
   @override
   Widget build(BuildContext context) {

--- a/example/lib/traffic-route-line.dart
+++ b/example/lib/traffic-route-line.dart
@@ -5,7 +5,7 @@ import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
 
 class TrafficRouteLinePage extends ExamplePage {
   TrafficRouteLinePage()
-      : super(const Icon(Icons.map), 'Style a route showing traffic');
+      : super(const Icon(Icons.turn_sharp_left), 'Style a route showing traffic');
 
   @override
   Widget build(BuildContext context) {

--- a/ios/Classes/Extensions.swift
+++ b/ios/Classes/Extensions.swift
@@ -9,6 +9,27 @@ extension FlutterError: Error { }
 
 // FLT to Mapbox
 
+extension [_MapWidgetDebugOptions] {
+    func toDebugOptions() -> MapViewDebugOptions {
+        return reduce(into: []) { partialResult, option in
+            switch option {
+            case .tileBorders: partialResult.insert(.tileBorders)
+            case .parseStatus: partialResult.insert(.parseStatus)
+            case .timestamps: partialResult.insert(.timestamps)
+            case .collision: partialResult.insert(.collision)
+            case .overdraw: partialResult.insert(.overdraw)
+            case .stencilClip: partialResult.insert(.stencilClip)
+            case .depthBuffer: partialResult.insert(.depthBuffer)
+            case .modelBounds: partialResult.insert(.modelBounds)
+            case .light: partialResult.insert(.light)
+            case .camera: partialResult.insert(.camera)
+            case .padding: partialResult.insert(.padding)
+            case .terrainWireframe, .layers2DWireframe, .layers3DWireframe: break
+            }
+        }
+    }
+}
+
 extension GlyphsRasterizationMode {
     func toGlyphsRasterizationMode() -> MapboxMaps.GlyphsRasterizationMode {
         switch self {
@@ -221,6 +242,25 @@ extension MbxEdgeInsets {
 }
 
 // Mapbox to FLT
+
+extension MapViewDebugOptions {
+    func toFLTDebugOptions() -> [_MapWidgetDebugOptions] {
+        var debugOptions = [_MapWidgetDebugOptions]()
+        if contains(.tileBorders) { debugOptions.append(.tileBorders) }
+        if contains(.tileBorders) { debugOptions.append(.tileBorders) }
+        if contains(.parseStatus) { debugOptions.append(.parseStatus) }
+        if contains(.timestamps) { debugOptions.append(.timestamps) }
+        if contains(.collision) { debugOptions.append(.collision) }
+        if contains(.overdraw) { debugOptions.append(.overdraw) }
+        if contains(.stencilClip) { debugOptions.append(.stencilClip) }
+        if contains(.depthBuffer) { debugOptions.append(.depthBuffer) }
+        if contains(.modelBounds) { debugOptions.append(.modelBounds) }
+        if contains(.light) { debugOptions.append(.light) }
+        if contains(.camera) { debugOptions.append(.camera) }
+        if contains(.padding) { debugOptions.append(.padding) }
+        return debugOptions
+    }
+}
 
 extension MapboxMaps.CanonicalTileID {
     func toFLTCanonicalTileID() -> CanonicalTileID {

--- a/ios/Classes/Generated/MapInterfaces.swift
+++ b/ios/Classes/Generated/MapInterfaces.swift
@@ -82,6 +82,23 @@ enum NorthOrientation: Int {
   case lEFTWARDS = 3
 }
 
+enum _MapWidgetDebugOptions: Int {
+  case tileBorders = 0
+  case parseStatus = 1
+  case timestamps = 2
+  case collision = 3
+  case overdraw = 4
+  case stencilClip = 5
+  case depthBuffer = 6
+  case modelBounds = 7
+  case terrainWireframe = 8
+  case layers2DWireframe = 9
+  case layers3DWireframe = 10
+  case light = 11
+  case camera = 12
+  case padding = 13
+}
+
 /// Options for enabling debugging features in a map.
 enum MapDebugOptionsData: Int {
   /// Edges of tile boundaries are shown as thick, red lines to help diagnose
@@ -648,6 +665,26 @@ struct CoordinateBounds {
       southwest.toList(),
       northeast.toList(),
       infiniteBounds,
+    ]
+  }
+}
+
+/// This class is needed because Pigeon does not encode properly arrays of enums.
+///
+/// Generated class from Pigeon that represents data sent in messages.
+struct _MapWidgetDebugOptionsBox {
+  var option: _MapWidgetDebugOptions
+
+  static func fromList(_ list: [Any?]) -> _MapWidgetDebugOptionsBox? {
+    let option = _MapWidgetDebugOptions(rawValue: list[0] as! Int)!
+
+    return _MapWidgetDebugOptionsBox(
+      option: option
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      option.rawValue
     ]
   }
 }
@@ -1895,6 +1932,8 @@ private class _CameraManagerCodecReader: FlutterStandardReader {
       return TileCoverOptions.fromList(self.readValue() as! [Any?])
     case 166:
       return TransitionOptions.fromList(self.readValue() as! [Any?])
+    case 167:
+      return _MapWidgetDebugOptionsBox.fromList(self.readValue() as! [Any?])
     default:
       return super.readValue(ofType: type)
     }
@@ -2019,6 +2058,9 @@ private class _CameraManagerCodecWriter: FlutterStandardWriter {
       super.writeValue(value.toList())
     } else if let value = value as? TransitionOptions {
       super.writeByte(166)
+      super.writeValue(value.toList())
+    } else if let value = value as? _MapWidgetDebugOptionsBox {
+      super.writeByte(167)
       super.writeValue(value.toList())
     } else {
       super.writeValue(value)
@@ -2695,6 +2737,8 @@ private class _MapInterfaceCodecReader: FlutterStandardReader {
       return TileCoverOptions.fromList(self.readValue() as! [Any?])
     case 166:
       return TransitionOptions.fromList(self.readValue() as! [Any?])
+    case 167:
+      return _MapWidgetDebugOptionsBox.fromList(self.readValue() as! [Any?])
     default:
       return super.readValue(ofType: type)
     }
@@ -2820,6 +2864,9 @@ private class _MapInterfaceCodecWriter: FlutterStandardWriter {
     } else if let value = value as? TransitionOptions {
       super.writeByte(166)
       super.writeValue(value.toList())
+    } else if let value = value as? _MapWidgetDebugOptionsBox {
+      super.writeByte(167)
+      super.writeValue(value.toList())
     } else {
       super.writeValue(value)
     }
@@ -2895,6 +2942,8 @@ protocol _MapInterface {
   ///
   /// @return The map's `map options`.
   func getMapOptions() throws -> MapOptions
+  func getDebugOptions() throws -> [_MapWidgetDebugOptionsBox?]
+  func setDebugOptions(debugOptions: [_MapWidgetDebugOptionsBox]) throws
   /// Returns the `map debug options`.
   ///
   /// @return An array of `map debug options` flags currently set to the map.
@@ -3272,6 +3321,34 @@ class _MapInterfaceSetup {
       }
     } else {
       getMapOptionsChannel.setMessageHandler(nil)
+    }
+    let getDebugOptionsChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.mapbox_maps_flutter._MapInterface.getDebugOptions\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      getDebugOptionsChannel.setMessageHandler { _, reply in
+        do {
+          let result = try api.getDebugOptions()
+          reply(wrapResult(result))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      getDebugOptionsChannel.setMessageHandler(nil)
+    }
+    let setDebugOptionsChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.mapbox_maps_flutter._MapInterface.setDebugOptions\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      setDebugOptionsChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let debugOptionsArg = args[0] as! [_MapWidgetDebugOptionsBox]
+        do {
+          try api.setDebugOptions(debugOptions: debugOptionsArg)
+          reply(wrapResult(nil))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      setDebugOptionsChannel.setMessageHandler(nil)
     }
     /// Returns the `map debug options`.
     ///
@@ -4201,6 +4278,8 @@ private class StyleManagerCodecReader: FlutterStandardReader {
       return TileCoverOptions.fromList(self.readValue() as! [Any?])
     case 166:
       return TransitionOptions.fromList(self.readValue() as! [Any?])
+    case 167:
+      return _MapWidgetDebugOptionsBox.fromList(self.readValue() as! [Any?])
     default:
       return super.readValue(ofType: type)
     }
@@ -4325,6 +4404,9 @@ private class StyleManagerCodecWriter: FlutterStandardWriter {
       super.writeValue(value.toList())
     } else if let value = value as? TransitionOptions {
       super.writeByte(166)
+      super.writeValue(value.toList())
+    } else if let value = value as? _MapWidgetDebugOptionsBox {
+      super.writeByte(167)
       super.writeValue(value.toList())
     } else {
       super.writeValue(value)

--- a/ios/Classes/MapInterfaceController.swift
+++ b/ios/Classes/MapInterfaceController.swift
@@ -6,9 +6,12 @@ import Turf
 
 final class MapInterfaceController: _MapInterface {
     private static let errorCode = "0"
-    private var mapboxMap: MapboxMap
-    init(withMapboxMap mapboxMap: MapboxMap) {
+    private let mapboxMap: MapboxMap
+    private let mapView: MapView
+
+    init(withMapboxMap mapboxMap: MapboxMap, mapView: MapView) {
         self.mapboxMap = mapboxMap
+        self.mapView = mapView
     }
 
     func loadStyleURI(styleURI: String, completion: @escaping (Result<Void, Error>) -> Void) {
@@ -115,6 +118,14 @@ final class MapInterfaceController: _MapInterface {
 
     func getMapOptions() throws -> MapOptions {
         return self.mapboxMap.options.toFLTMapOptions()
+    }
+
+    func getDebugOptions() throws -> [_MapWidgetDebugOptionsBox?] {
+        return mapView.debugOptions.toFLTDebugOptions().map(_MapWidgetDebugOptionsBox.init)
+    }
+
+    func setDebugOptions(debugOptions: [_MapWidgetDebugOptionsBox]) throws {
+        mapView.debugOptions = debugOptions.map(\.option).toDebugOptions()
     }
 
     func getDebug() throws -> [MapDebugOptions?] {

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -77,7 +77,7 @@ final class MapboxMapController: NSObject, FlutterPlatformView {
         let cameraController = CameraController(withMapboxMap: mapboxMap)
         _CameraManagerSetup.setUp(binaryMessenger: proxyBinaryMessenger, api: cameraController)
 
-        let mapInterfaceController = MapInterfaceController(withMapboxMap: mapboxMap)
+        let mapInterfaceController = MapInterfaceController(withMapboxMap: mapboxMap, mapView: mapView)
         _MapInterfaceSetup.setUp(binaryMessenger: proxyBinaryMessenger, api: mapInterfaceController)
 
         let mapProjectionController = MapProjectionController()

--- a/lib/src/mapbox_map.dart
+++ b/lib/src/mapbox_map.dart
@@ -1,5 +1,112 @@
 part of mapbox_maps_flutter;
 
+/// Options for enabling debugging features in a map.
+class MapWidgetDebugOptions {
+  final _MapWidgetDebugOptions option;
+
+  const MapWidgetDebugOptions._(this.option);
+
+  /// Edges of tile boundaries are shown as thick, red lines to help diagnose
+  /// tile clipping issues.
+  static const MapWidgetDebugOptions tileBorders =
+      MapWidgetDebugOptions._(_MapWidgetDebugOptions.tileBorders);
+
+  /// Each tile shows its tile coordinate (x/y/z) in the upper-left corner.
+  static const MapWidgetDebugOptions parseStatus =
+      MapWidgetDebugOptions._(_MapWidgetDebugOptions.parseStatus);
+
+  /// Each tile shows a timestamps with modified and expires dates or n/a if
+  /// timestamp is not available.
+  static const MapWidgetDebugOptions timestamps =
+      MapWidgetDebugOptions._(_MapWidgetDebugOptions.timestamps);
+
+  /// Edges of glyphs and symbols are shown as faint, green lines to help
+  /// diagnose collision and label placement issues.
+  static const MapWidgetDebugOptions collision =
+      MapWidgetDebugOptions._(_MapWidgetDebugOptions.collision);
+
+  /// Each drawing operation is replaced by a translucent fill. Overlapping
+  /// drawing operations appear more prominent to help diagnose overdrawing.
+  static const MapWidgetDebugOptions overdraw =
+      MapWidgetDebugOptions._(_MapWidgetDebugOptions.overdraw);
+
+  /// The stencil buffer is shown instead of the color buffer.
+  static const MapWidgetDebugOptions stencilClip =
+      MapWidgetDebugOptions._(_MapWidgetDebugOptions.stencilClip);
+
+  /// The depth buffer is shown instead of the color buffer.
+  static const MapWidgetDebugOptions depthBuffer =
+      MapWidgetDebugOptions._(_MapWidgetDebugOptions.depthBuffer);
+
+  /// Show 3D model bounding boxes.
+  static const MapWidgetDebugOptions modelBounds =
+      MapWidgetDebugOptions._(_MapWidgetDebugOptions.modelBounds);
+
+  /// Show a wireframe for terrain.
+  /// Supported on Android only.
+  static const MapWidgetDebugOptions terrainWireframe =
+      MapWidgetDebugOptions._(_MapWidgetDebugOptions.terrainWireframe);
+
+  /// Show a wireframe for 2D layers.
+  /// Supported on Android only.
+  static const MapWidgetDebugOptions layers2DWireframe =
+      MapWidgetDebugOptions._(_MapWidgetDebugOptions.layers2DWireframe);
+
+  /// Show a wireframe for 3D layers.
+  /// Supported on Android only.
+  static const MapWidgetDebugOptions layers3DWireframe =
+      MapWidgetDebugOptions._(_MapWidgetDebugOptions.layers3DWireframe);
+
+  /// Each tile shows its local lighting conditions in the upper-left corner.
+  /// (If `lights` properties are used, otherwise they show zero.)
+  static const MapWidgetDebugOptions light =
+      MapWidgetDebugOptions._(_MapWidgetDebugOptions.light);
+
+  /// Show a debug overlay with information about the CameraState
+  /// including lat, long, zoom, pitch, & bearing.
+  static const MapWidgetDebugOptions camera =
+      MapWidgetDebugOptions._(_MapWidgetDebugOptions.camera);
+
+  /// Draws camera padding frame.
+  static const MapWidgetDebugOptions padding =
+      MapWidgetDebugOptions._(_MapWidgetDebugOptions.padding);
+}
+
+extension on _MapWidgetDebugOptions {
+  MapWidgetDebugOptions get widgetDebugOptions {
+    switch (this) {
+      case _MapWidgetDebugOptions.tileBorders:
+        return MapWidgetDebugOptions.tileBorders;
+      case _MapWidgetDebugOptions.parseStatus:
+        return MapWidgetDebugOptions.parseStatus;
+      case _MapWidgetDebugOptions.timestamps:
+        return MapWidgetDebugOptions.timestamps;
+      case _MapWidgetDebugOptions.collision:
+        return MapWidgetDebugOptions.collision;
+      case _MapWidgetDebugOptions.overdraw:
+        return MapWidgetDebugOptions.overdraw;
+      case _MapWidgetDebugOptions.stencilClip:
+        return MapWidgetDebugOptions.stencilClip;
+      case _MapWidgetDebugOptions.depthBuffer:
+        return MapWidgetDebugOptions.depthBuffer;
+      case _MapWidgetDebugOptions.modelBounds:
+        return MapWidgetDebugOptions.modelBounds;
+      case _MapWidgetDebugOptions.terrainWireframe:
+        return MapWidgetDebugOptions.terrainWireframe;
+      case _MapWidgetDebugOptions.layers2DWireframe:
+        return MapWidgetDebugOptions.layers2DWireframe;
+      case _MapWidgetDebugOptions.layers3DWireframe:
+        return MapWidgetDebugOptions.layers3DWireframe;
+      case _MapWidgetDebugOptions.light:
+        return MapWidgetDebugOptions.light;
+      case _MapWidgetDebugOptions.camera:
+        return MapWidgetDebugOptions.camera;
+      case _MapWidgetDebugOptions.padding:
+        return MapWidgetDebugOptions.padding;
+    }
+  }
+}
+
 /// Controller for a single MapboxMap instance running on the host platform.
 class MapboxMap extends ChangeNotifier {
   MapboxMap({
@@ -253,10 +360,24 @@ class MapboxMap extends ChangeNotifier {
   /// Returns the `map options`.
   Future<MapOptions> getMapOptions() => _mapInterface.getMapOptions();
 
+  /// Debug options for the widget associated with the map.
+  Future<List<MapWidgetDebugOptions>> getDebugOptions() async {
+    return _mapInterface.getDebugOptions().then((value) {
+      return value.map((e) => e?.option.widgetDebugOptions).nonNulls.toList();
+    });
+  }
+
+  /// Set debug options for the widget associated with the map.
+  Future<void> setDebugOptions(List<MapWidgetDebugOptions> debugOptions) {
+    return _mapInterface.setDebugOptions(debugOptions.map((e) => _MapWidgetDebugOptionsBox(option: e.option)).toList());
+  }
+
   /// Returns the `map debug options`.
+  @Deprecated("Use 'getDebugOptions()' instead")
   Future<List<MapDebugOptions?>> getDebug() => _mapInterface.getDebug();
 
   /// Sets the `map debug options` and enables debug mode based on the passed value.
+  @Deprecated("Use 'setDebugOptions()' instead")
   Future<void> setDebug(List<MapDebugOptions?> debugOptions, bool value) =>
       _mapInterface.setDebug(debugOptions, value);
 

--- a/lib/src/pigeons/map_interfaces.dart
+++ b/lib/src/pigeons/map_interfaces.dart
@@ -71,6 +71,23 @@ enum NorthOrientation {
   LEFTWARDS,
 }
 
+enum _MapWidgetDebugOptions {
+  tileBorders,
+  parseStatus,
+  timestamps,
+  collision,
+  overdraw,
+  stencilClip,
+  depthBuffer,
+  modelBounds,
+  terrainWireframe,
+  layers2DWireframe,
+  layers3DWireframe,
+  light,
+  camera,
+  padding,
+}
+
 /// Options for enabling debugging features in a map.
 enum MapDebugOptionsData {
   /// Edges of tile boundaries are shown as thick, red lines to help diagnose
@@ -727,6 +744,28 @@ class CoordinateBounds {
       southwest: Point.decode(result[0]! as List<Object?>),
       northeast: Point.decode(result[1]! as List<Object?>),
       infiniteBounds: result[2]! as bool,
+    );
+  }
+}
+
+/// This class is needed because Pigeon does not encode properly arrays of enums.
+class _MapWidgetDebugOptionsBox {
+  _MapWidgetDebugOptionsBox({
+    required this.option,
+  });
+
+  _MapWidgetDebugOptions option;
+
+  Object encode() {
+    return <Object?>[
+      option.index,
+    ];
+  }
+
+  static _MapWidgetDebugOptionsBox decode(Object result) {
+    result as List<Object?>;
+    return _MapWidgetDebugOptionsBox(
+      option: _MapWidgetDebugOptions.values[result[0]! as int],
     );
   }
 }
@@ -2151,6 +2190,9 @@ class __CameraManagerCodec extends StandardMessageCodec {
     } else if (value is TransitionOptions) {
       buffer.putUint8(166);
       writeValue(buffer, value.encode());
+    } else if (value is _MapWidgetDebugOptionsBox) {
+      buffer.putUint8(167);
+      writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
     }
@@ -2237,6 +2279,8 @@ class __CameraManagerCodec extends StandardMessageCodec {
         return TileCoverOptions.decode(readValue(buffer)!);
       case 166:
         return TransitionOptions.decode(readValue(buffer)!);
+      case 167:
+        return _MapWidgetDebugOptionsBox.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
     }
@@ -3026,6 +3070,9 @@ class __MapInterfaceCodec extends StandardMessageCodec {
     } else if (value is TransitionOptions) {
       buffer.putUint8(166);
       writeValue(buffer, value.encode());
+    } else if (value is _MapWidgetDebugOptionsBox) {
+      buffer.putUint8(167);
+      writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
     }
@@ -3112,6 +3159,8 @@ class __MapInterfaceCodec extends StandardMessageCodec {
         return TileCoverOptions.decode(readValue(buffer)!);
       case 166:
         return TransitionOptions.decode(readValue(buffer)!);
+      case 167:
+        return _MapWidgetDebugOptionsBox.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
     }
@@ -3578,6 +3627,61 @@ class _MapInterface {
       );
     } else {
       return (__pigeon_replyList[0] as MapOptions?)!;
+    }
+  }
+
+  Future<List<_MapWidgetDebugOptionsBox?>> getDebugOptions() async {
+    final String __pigeon_channelName =
+        'dev.flutter.pigeon.mapbox_maps_flutter._MapInterface.getDebugOptions$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel =
+        BasicMessageChannel<Object?>(
+      __pigeon_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: __pigeon_binaryMessenger,
+    );
+    final List<Object?>? __pigeon_replyList =
+        await __pigeon_channel.send(null) as List<Object?>?;
+    if (__pigeon_replyList == null) {
+      throw _createConnectionError(__pigeon_channelName);
+    } else if (__pigeon_replyList.length > 1) {
+      throw PlatformException(
+        code: __pigeon_replyList[0]! as String,
+        message: __pigeon_replyList[1] as String?,
+        details: __pigeon_replyList[2],
+      );
+    } else if (__pigeon_replyList[0] == null) {
+      throw PlatformException(
+        code: 'null-error',
+        message: 'Host platform returned null value for non-null return value.',
+      );
+    } else {
+      return (__pigeon_replyList[0] as List<Object?>?)!
+          .cast<_MapWidgetDebugOptionsBox?>();
+    }
+  }
+
+  Future<void> setDebugOptions(
+      List<_MapWidgetDebugOptionsBox?> debugOptions) async {
+    final String __pigeon_channelName =
+        'dev.flutter.pigeon.mapbox_maps_flutter._MapInterface.setDebugOptions$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel =
+        BasicMessageChannel<Object?>(
+      __pigeon_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: __pigeon_binaryMessenger,
+    );
+    final List<Object?>? __pigeon_replyList =
+        await __pigeon_channel.send(<Object?>[debugOptions]) as List<Object?>?;
+    if (__pigeon_replyList == null) {
+      throw _createConnectionError(__pigeon_channelName);
+    } else if (__pigeon_replyList.length > 1) {
+      throw PlatformException(
+        code: __pigeon_replyList[0]! as String,
+        message: __pigeon_replyList[1] as String?,
+        details: __pigeon_replyList[2],
+      );
+    } else {
+      return;
     }
   }
 
@@ -4892,6 +4996,9 @@ class _StyleManagerCodec extends StandardMessageCodec {
     } else if (value is TransitionOptions) {
       buffer.putUint8(166);
       writeValue(buffer, value.encode());
+    } else if (value is _MapWidgetDebugOptionsBox) {
+      buffer.putUint8(167);
+      writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
     }
@@ -4978,6 +5085,8 @@ class _StyleManagerCodec extends StandardMessageCodec {
         return TileCoverOptions.decode(readValue(buffer)!);
       case 166:
         return TransitionOptions.decode(readValue(buffer)!);
+      case 167:
+        return _MapWidgetDebugOptionsBox.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
     }


### PR DESCRIPTION
### What does this pull request do?

Exposes native map debug options.

| Option | Description |
| ------ | ------------ |
| `tileBorders` | Edges of tile boundaries are shown as thick, red lines to help diagnose tile clipping issues. |
| `parseStatus` | Each tile shows its tile coordinate (x/y/z) in the upper-left corner. |
| `timestamps` | Each tile shows a timestamps with modified and expires dates or n/a if timestamp is not available. |
| `collision` | Edges of glyphs and symbols are shown as faint, green lines to help diagnose collision and label placement issues. |
| `overdraw` | Each drawing operation is replaced by a translucent fill. Overlapping drawing operations appear more prominent to help diagnose overdrawing. |
| `stencilClip` | The stencil buffer is shown instead of the color buffer. |
| `depthBuffer` | The depth buffer is shown instead of the color buffer. |
| `modelBounds` | Show 3D model bounding boxes. |
| `terrainWireframe` | Show a wireframe for terrain. _Supported on Android only._ |
| `layers2DWireframe` | Show a wireframe for 2D layers. _Supported on Android only._ |
| `layers3DWireframe` | Show a wireframe for 3D layers. _Supported on Android only._ |
| `light` | Each tile shows its local lighting conditions in the upper-left corner. (If `lights` properties are used, otherwise they show zero.) |
| `camera` | Show a debug overlay with information about the CameraState including lat, long, zoom, pitch, & bearing. |
| `padding` | Draws camera padding frame. |

### What is the motivation and context behind this change?



### Pull request checklist:
 - [x] Add a changelog entry.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add documentation comments for any added or updated public APIs.
