### PR TITLE
Mark `MapDebugOptions` as deprecated

### DIFF
--- a/lib/src/pigeons/map_interfaces.dart
+++ b/lib/src/pigeons/map_interfaces.dart
@@ -816,6 +816,7 @@ class _MapWidgetDebugOptionsBox {
 }
 
 /// Options for enabling debugging features in a map.
+@Deprecated("Use 'MapWidgetDebugOptions' instead")
 class MapDebugOptions {
   MapDebugOptions({
     required this.data,
@@ -3582,6 +3583,7 @@ class _MapInterface {
   /// Returns the `map debug options`.
   ///
   /// @return An array of `map debug options` flags currently set to the map.
+  @Deprecated("Use [MapboxMap.debugOptions] instead")
   Future<List<MapDebugOptions?>> getDebug() async {
     final String __pigeon_channelName =
         'dev.flutter.pigeon.mapbox_maps_flutter._MapInterface.getDebug$__pigeon_messageChannelSuffix';
@@ -3617,6 +3619,7 @@ class _MapInterface {
   /// @param debugOptions An array of `map debug options` to be set.
   /// @param value A `boolean` value representing the state for a given `map debug options`.
   ///
+  @Deprecated("Use [MapboxMap.debugOptions] instead")
   Future<void> setDebug(List<MapDebugOptions?> debugOptions, bool value) async {
     final String __pigeon_channelName =
         'dev.flutter.pigeon.mapbox_maps_flutter._MapInterface.setDebug$__pigeon_messageChannelSuffix';


### PR DESCRIPTION
### What does this pull request do?

Adds `@Deprecated` annotation to `MapDebugOptions` and it's accessors.

### What is the motivation and context behind this change?

Tailwork of https://github.com/mapbox/mapbox-maps-flutter/pull/630

### Pull request checklist:
 - [ ] Add a changelog entry.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
