### PR TITLE
[offline] add default pixelRatio for TilesetDescriptorOptions

### DIFF
--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/Extentions.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/Extentions.kt
@@ -611,12 +611,12 @@ fun com.mapbox.maps.StylePackLoadProgress.toFLTStylePackLoadProgress(): StylePac
   )
 }
 
-fun TilesetDescriptorOptions.toTilesetDescriptorOptions(): com.mapbox.maps.TilesetDescriptorOptions {
+fun TilesetDescriptorOptions.toTilesetDescriptorOptions(context: Context): com.mapbox.maps.TilesetDescriptorOptions {
   val builder = com.mapbox.maps.TilesetDescriptorOptions.Builder()
     .styleURI(styleURI)
     .minZoom(minZoom.toByte())
     .maxZoom(maxZoom.toByte())
-  pixelRatio?.let { builder.pixelRatio(it.toFloat()) }
+    .pixelRatio(pixelRatio?.toFloat() ?: context.resources.displayMetrics.density)
   tilesets?.let { builder.tilesets(it) }
   stylePackOptions?.let { builder.stylePackOptions(it.toStylePackLoadOptions()) }
   extraOptions?.let { builder.extraOptions(it.toValue()) }

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/offline/OfflineMapInstanceManager.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/offline/OfflineMapInstanceManager.kt
@@ -2,6 +2,7 @@ package com.mapbox.maps.mapbox_maps.offline
 
 import android.content.Context
 import com.mapbox.common.TileStore
+import com.mapbox.maps.MapboxMapsOptions
 import com.mapbox.maps.mapbox_maps.ProxyBinaryMessenger
 import com.mapbox.maps.mapbox_maps.pigeons.*
 import io.flutter.plugin.common.BinaryMessenger
@@ -27,6 +28,7 @@ class OfflineMapInstanceManager(
   override fun setupTileStore(channelSuffix: String, filePath: String?) {
     val proxy = ProxyBinaryMessenger(messenger, channelSuffix)
     val tileStore = filePath?.let { TileStore.create(it) } ?: TileStore.create()
+    MapboxMapsOptions.tileStore = tileStore
     val tileStoreController = TileStoreController(context, messenger, tileStore)
     _TileStore.setUp(proxy, tileStoreController)
     proxies["tilestore/$channelSuffix"] = proxy
@@ -35,5 +37,6 @@ class OfflineMapInstanceManager(
   override fun tearDownTileStore(channelSuffix: String) {
     val proxy = proxies["tilestore/$channelSuffix"] ?: return
     _TileStore.setUp(proxy, null)
+    MapboxMapsOptions.tileStore = null
   }
 }

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/offline/TileStoreController.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/offline/TileStoreController.kt
@@ -38,7 +38,7 @@ class TileStoreController(
     callback: (Result<TileRegion>) -> Unit
   ) {
     tileStore.loadTileRegion(
-      id, offlineManager.tileRegionLoadOptions(loadOptions),
+      id, offlineManager.tileRegionLoadOptions(loadOptions, context),
       { progress ->
         mainHandler.post {
           tileRegionLoadProgressHandlers[id]?.success(progress.toFLTTileRegionLoadProgress().toList())
@@ -75,7 +75,7 @@ class TileStoreController(
   ) {
     tileStore.estimateTileRegion(
       id,
-      offlineManager.tileRegionLoadOptions(loadOptions),
+      offlineManager.tileRegionLoadOptions(loadOptions, context),
       estimateOptions?.toTileRegionEstimateOptions() ?: com.mapbox.common.TileRegionEstimateOptions(null),
       { progress ->
         mainHandler.post {
@@ -116,7 +116,7 @@ class TileStoreController(
   }
 
   override fun tileRegionContainsDescriptor(id: String, options: List<TilesetDescriptorOptions>, callback: (Result<Boolean>) -> Unit) {
-    val descriptors = options.map { offlineManager.createTilesetDescriptor(it.toTilesetDescriptorOptions()) }
+    val descriptors = options.map { offlineManager.createTilesetDescriptor(it.toTilesetDescriptorOptions(context)) }
     tileStore.tileRegionContainsDescriptors(id, descriptors) { expected ->
       mainHandler.post {
         callback(expected.toResult { it })
@@ -152,7 +152,7 @@ class TileStoreController(
   }
 }
 
-private fun OfflineManager.tileRegionLoadOptions(fltValue: TileRegionLoadOptions): com.mapbox.common.TileRegionLoadOptions {
+private fun OfflineManager.tileRegionLoadOptions(fltValue: TileRegionLoadOptions, context: Context): com.mapbox.common.TileRegionLoadOptions {
   val builder = com.mapbox.common.TileRegionLoadOptions.Builder()
     .geometry(fltValue.geometry?.toGeometry())
     .metadata(fltValue.metadata?.toValue())
@@ -165,7 +165,7 @@ private fun OfflineManager.tileRegionLoadOptions(fltValue: TileRegionLoadOptions
   fltValue.descriptorsOptions?.let { options ->
     val descriptors: List<TilesetDescriptorOptions> = options.filterNotNull()
     builder.descriptors(
-      descriptors.map { createTilesetDescriptor(it.toTilesetDescriptorOptions()) }
+      descriptors.map { createTilesetDescriptor(it.toTilesetDescriptorOptions(context)) }
     )
   }
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -48,7 +48,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  integration_test: ce0a3ffa1de96d1a89ca0ac26fca7ea18a749ef4
+  integration_test: 13825b8a9334a850581300559b8839134b124670
   mapbox_maps_flutter: 4ad19682f43ffed50be9c1eb2364107e21725f1f
   MapboxCommon: 595dd030df6b2c88e73dd53cef95acc3f31cfa7e
   MapboxCoreMaps: f33e09b177988af18168b8717f5d79937c85908f

--- a/example/lib/offline_map.dart
+++ b/example/lib/offline_map.dart
@@ -32,12 +32,6 @@ class OfflineMapWidgetState extends State<OfflineMapWidget> {
   final StreamController<double> _tileRegionLoadProgress =
       StreamController.broadcast();
 
-  _onMapCreated(MapboxMap mapboxMap) async {
-    this.mapboxMap = mapboxMap;
-    await _downloadStylePack();
-    await _downloadTileRegion();
-  }
-
   _downloadStylePack() async {
     final offlineManager = await OfflineManager.create();
     final stylePackLoadOptions = StylePackLoadOptions(
@@ -45,7 +39,7 @@ class OfflineMapWidgetState extends State<OfflineMapWidget> {
             GlyphsRasterizationMode.IDEOGRAPHS_RASTERIZED_LOCALLY,
         metadata: {"tag": "test"},
         acceptExpired: false);
-    offlineManager.loadStylePack(MapboxStyles.OUTDOORS, stylePackLoadOptions,
+    offlineManager.loadStylePack(MapboxStyles.SATELLITE_STREETS, stylePackLoadOptions,
         (progress) {
       final percentage =
           progress.completedResourceCount / progress.requiredResourceCount;
@@ -59,13 +53,12 @@ class OfflineMapWidgetState extends State<OfflineMapWidget> {
   }
 
   _downloadTileRegion() async {
-    final tmpDir = await getTemporaryDirectory();
-    final tileStore = await TileStore.createAt(await tmpDir.uri);
+    final tileStore = await TileStore.createDefault();
     final tileRegionLoadOptions = TileRegionLoadOptions(
-        geometry: Point(coordinates: Position(-80.1263, 25.7845)).toJson(),
+        geometry: City.helsinki.toJson(),
         descriptorsOptions: [
           TilesetDescriptorOptions(
-              styleURI: MapboxStyles.OUTDOORS, minZoom: 0, maxZoom: 16)
+              styleURI: MapboxStyles.SATELLITE_STREETS, minZoom: 0, maxZoom: 16)
         ],
         acceptExpired: true,
         networkRestriction: NetworkRestriction.NONE);
@@ -85,18 +78,40 @@ class OfflineMapWidgetState extends State<OfflineMapWidget> {
 
   @override
   Widget build(BuildContext context) {
-    final mapWidget = MapWidget(
-      key: ValueKey("mapWidget"),
-      styleUri: MapboxStyles.OUTDOORS,
-      cameraOptions: CameraOptions(center: City.helsinki, zoom: 2.0),
-      onMapCreated: _onMapCreated,
-    );
+    String downloadButtonText = "Download Map";
+    final mapIsDownloaded = Future
+        .wait([_tileRegionLoadProgress.sink.done, _stylePackProgress.sink.done])
+        .whenComplete(() async {
+          await OfflineSwitch.shared.setMapboxStackConnected(false);
+        });
 
     return new Column(
       mainAxisSize: MainAxisSize.min,
       children: [
         Expanded(
-          child: mapWidget,
+          child: FutureBuilder(future: mapIsDownloaded, builder: (context, snapshot) {
+            if (snapshot.hasData) {
+              return MapWidget(
+                key: ValueKey("mapWidget"),
+                styleUri: MapboxStyles.SATELLITE_STREETS,
+                cameraOptions: CameraOptions(center: City.helsinki, zoom: 12.0),
+              );
+            } else {
+              return TextButton(
+                style: ButtonStyle(
+                  foregroundColor: MaterialStateProperty.all<Color>(Colors.blue),
+                ),
+                onPressed: () async {
+                  setState(() {
+                    downloadButtonText = "Downloading";
+                  });
+                  await _downloadStylePack();
+                  await _downloadTileRegion();
+                },
+                child: Text(downloadButtonText),
+              );
+            }
+          }),
         ),
         SizedBox(
             height: 100,

--- a/example/lib/offline_map.dart
+++ b/example/lib/offline_map.dart
@@ -53,10 +53,13 @@ class OfflineMapWidgetState extends State<OfflineMapWidget> {
   }
 
   _downloadTileRegion() async {
-    final tileStore = await TileStore.createDefault();
+    final path = await getTemporaryDirectory();
+    final tileStore = await TileStore.createAt(path.uri);
     final tileRegionLoadOptions = TileRegionLoadOptions(
         geometry: City.helsinki.toJson(),
         descriptorsOptions: [
+          // If you are using a raster tileset you may need to set a different pixelRatio.
+          // The default is UIScreen.main.scale on iOS and displayMetrics's density on Android.
           TilesetDescriptorOptions(
               styleURI: MapboxStyles.SATELLITE_STREETS, minZoom: 0, maxZoom: 16)
         ],

--- a/ios/Classes/Extensions.swift
+++ b/ios/Classes/Extensions.swift
@@ -917,25 +917,15 @@ extension MapboxCoreMaps.StylePackLoadProgress {
 
 extension MapboxCoreMaps.TilesetDescriptorOptions {
 
-    convenience init(fltValue: TilesetDescriptorOptions) {
-        if let pixelRatio = fltValue.pixelRatio {
-            self.init(
-                styleURI: fltValue.styleURI,
-                minZoom: UInt8(fltValue.minZoom),
-                maxZoom: UInt8(fltValue.maxZoom),
-                pixelRatio: Float(pixelRatio),
-                tilesets: fltValue.tilesets?.compacted(),
-                stylePack: fltValue.stylePackOptions.flatMap(MapboxCoreMaps.StylePackLoadOptions.init(fltValue:)),
-                extraOptions: fltValue.extraOptions)
-        } else {
-            self.init(
-                styleURI: fltValue.styleURI,
-                minZoom: UInt8(fltValue.minZoom),
-                maxZoom: UInt8(fltValue.maxZoom),
-                tilesets: fltValue.tilesets?.compacted(),
-                stylePack: fltValue.stylePackOptions.flatMap(MapboxCoreMaps.StylePackLoadOptions.init(fltValue:)),
-                extraOptions: fltValue.extraOptions)
-        }
+    convenience init?(fltValue: TilesetDescriptorOptions) {
+        guard let styleURI = StyleURI(rawValue: fltValue.styleURI) else { return nil }
+        self.init(
+            styleURI: styleURI,
+            zoomRange: UInt8(fltValue.minZoom)...UInt8(fltValue.maxZoom),
+            pixelRatio: fltValue.pixelRatio.map(Float.init),
+            tilesets: fltValue.tilesets?.compacted(),
+            stylePackOptions: fltValue.stylePackOptions.flatMap(MapboxCoreMaps.StylePackLoadOptions.init(fltValue:)),
+            extraOptions: fltValue.extraOptions)
     }
 }
 
@@ -993,6 +983,20 @@ extension MapboxCommon.TileRegionEstimateProgress {
             requiredResourceCount: Int64(requiredResourceCount),
             completedResourceCount: Int64(completedResourceCount),
             erroredResourceCount: Int64(erroredResourceCount))
+    }
+}
+
+extension MapboxCommon.NetworkRestriction {
+
+    init(fltValue: NetworkRestriction) {
+        switch fltValue {
+        case .nONE:
+            self = .none
+        case .dISALLOWEXPENSIVE:
+            self = .disallowExpensive
+        case .dISALLOWALL:
+            self = .disallowAll
+        }
     }
 }
 // MARK: Result

--- a/ios/Classes/Offline/TileStoreController.swift
+++ b/ios/Classes/Offline/TileStoreController.swift
@@ -75,7 +75,7 @@ final class TileStoreController: _TileStore {
 
     func tileRegionContainsDescriptor(id: String, options: [TilesetDescriptorOptions], completion: @escaping (Result<Bool, Swift.Error>) -> Void) {
         let descriptors = options
-            .map(MapboxCoreMaps.TilesetDescriptorOptions.init(fltValue:))
+            .compactMap(MapboxCoreMaps.TilesetDescriptorOptions.init(fltValue:))
             .map(offlineManager.createTilesetDescriptor(for:))
 
         tileStore.tileRegionContainsDescriptors(forId: id, descriptors: descriptors, completion: executeOnMainThread(completion))
@@ -110,11 +110,11 @@ extension OfflineManager {
             geometry: convertDictionaryToGeometry(dict: fltValue.geometry),
             descriptors: fltValue.descriptorsOptions?.compactMap { descriptorOptions in
                 guard let descriptorOptions else { return nil }
-                return createTilesetDescriptor(for: MapboxCoreMaps.TilesetDescriptorOptions(fltValue: descriptorOptions))
+                return MapboxCoreMaps.TilesetDescriptorOptions(fltValue: descriptorOptions).map(createTilesetDescriptor(for:))
             },
             metadata: fltValue.metadata,
             acceptExpired: fltValue.acceptExpired,
-            networkRestriction: MapboxCommon.NetworkRestriction(other: fltValue.networkRestriction) ?? .none,
+            networkRestriction: MapboxCommon.NetworkRestriction(fltValue: fltValue.networkRestriction),
             averageBytesPerSecond: fltValue.averageBytesPerSecond.map(Int.init),
             extraOptions: fltValue.extraOptions
         )


### PR DESCRIPTION
### What does this pull request do?

Add default `pixelRatio` for `TilesetDescriptorOptions`, so raster tileset can be loaded in offline mode. This also set `MapboxMapsOptions.tileStore` automatically on initialization of TileStore

Related PRs
- https://github.com/mapbox/mapbox-maps-android-internal/pull/2508
- https://github.com/mapbox/mapbox-maps-ios-internal/pull/2172 

### What is the motivation and context behind this change?



### Pull request checklist:
 - [ ] Add a changelog entry.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
