### PR TITLE
[MAPSFLT-236] Expose Partial GeoJSON updates API 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ Instead of setting a whole new GeoJSON object anew every time a single feature h
 If your features have associated identifiers - you can add, update, and remove them on individual basis in your ``GeoJSONSource``. This is especially beneficial for ``GeoJSONSource``s hosting a large amount of features - in this case adding a feature can be up to 4x faster with the partial GeoJSON update API.
 
 ```dart
-maboxMap.style.addGeoJSONSourceFeatures(sourceId, dataId, features)
-maboxMap.style.updateGeoJSONSourceFeatures(sourceId, dataId, features)
-maboxMap.style.removeGeoJSONSourceFeatures(sourceId, dataId, featureIds)
+mapboxMap.style.addGeoJSONSourceFeatures(sourceId, dataId, features)
+mapboxMap.style.updateGeoJSONSourceFeatures(sourceId, dataId, features)
+mapboxMap.style.removeGeoJSONSourceFeatures(sourceId, dataId, featureIds)
 ```
 
 ### 2.3.0-beta.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+### main
+
+* Add support for partial GeoJSON updates. 
+
+Instead of setting a whole new GeoJSON object anew every time a single feature has changed, now you can apply more granular, partial GeoJSON updates.
+If your features have associated identifiers - you can add, update, and remove them on individual basis in your ``GeoJSONSource``. This is especially beneficial for ``GeoJSONSource``s hosting a large amount of features - in this case adding a feature can be up to 4x faster with the partial GeoJSON update API.
+
+```dart
+maboxMap.style.addGeoJSONSourceFeatures(sourceId, dataId, features)
+maboxMap.style.updateGeoJSONSourceFeatures(sourceId, dataId, features)
+maboxMap.style.removeGeoJSONSourceFeatures(sourceId, dataId, featureIds)
+```
+
 ### 2.3.0-beta.1
 
 * Fix build errors when using Flutter SDK 3.24.

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/StyleController.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/StyleController.kt
@@ -6,6 +6,7 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import com.mapbox.bindgen.DataRef
 import com.mapbox.bindgen.Value
+import com.mapbox.geojson.Feature
 import com.mapbox.maps.Image
 import com.mapbox.maps.MapboxStyleManager
 import com.mapbox.maps.RuntimeStylingOptions
@@ -340,6 +341,36 @@ class StyleController(private val context: Context, private val styleManager: Ma
     } else {
       callback(Result.success(Unit))
     }
+  }
+
+  override fun addGeoJSONSourceFeatures(
+    sourceId: String,
+    dataId: String,
+    features: List<Feature>,
+    callback: (Result<Unit>) -> Unit
+  ) {
+    val expected = styleManager.addGeoJSONSourceFeatures(sourceId, dataId, features)
+    callback(Result.success(Unit))
+  }
+
+  override fun updateGeoJSONSourceFeatures(
+    sourceId: String,
+    dataId: String,
+    features: List<Feature>,
+    callback: (Result<Unit>) -> Unit
+  ) {
+    val expected = styleManager.updateGeoJSONSourceFeatures(sourceId, dataId, features)
+    callback(Result.success(Unit))
+  }
+
+  override fun removeGeoJSONSourceFeatures(
+    sourceId: String,
+    dataId: String,
+    featureIds: List<String>,
+    callback: (Result<Unit>) -> Unit
+  ) {
+    val expected = styleManager.removeGeoJSONSourceFeatures(sourceId, dataId, featureIds)
+    callback(Result.success(Unit))
   }
 
   override fun updateStyleImageSourceImage(

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/mapping/turf/TurfAdapters.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/mapping/turf/TurfAdapters.kt
@@ -1,6 +1,6 @@
 package com.mapbox.maps.mapbox_maps.mapping.turf
 
-import com.google.gson.Gson;
+import com.google.gson.Gson
 import com.mapbox.geojson.*
 
 fun Point.toList(): List<Any?> {
@@ -57,7 +57,7 @@ fun Feature.toList(): List<Any?> {
 
 object FeatureDecoder {
   @Suppress("UNCHECKED_CAST")
-    fun fromList(list: List<Any?>): Feature {
+  fun fromList(list: List<Any?>): Feature {
     val rawData = list.first() as Map<String, Any>
 
     val gson = Gson()

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/mapping/turf/TurfAdapters.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/mapping/turf/TurfAdapters.kt
@@ -1,5 +1,6 @@
 package com.mapbox.maps.mapbox_maps.mapping.turf
 
+import com.google.gson.Gson;
 import com.mapbox.geojson.*
 
 fun Point.toList(): List<Any?> {
@@ -47,5 +48,21 @@ object PolygonDecoder {
         it.map { Point.fromLngLat(it.first(), it.last()) }
       }
     )
+  }
+}
+
+fun Feature.toList(): List<Any?> {
+  return listOf(this.toJson())
+}
+
+object FeatureDecoder {
+  @Suppress("UNCHECKED_CAST")
+    fun fromList(list: List<Any?>): Feature {
+    val rawData = list.first() as Map<String, Any>
+
+    val gson = Gson()
+    val json = gson.toJson(rawData)
+
+    return Feature.fromJson(json)
   }
 }

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/MapInterfaces.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/MapInterfaces.kt
@@ -5,6 +5,7 @@
 package com.mapbox.maps.mapbox_maps.pigeons
 
 import android.util.Log
+import com.mapbox.geojson.Feature
 import com.mapbox.geojson.Point
 import com.mapbox.maps.mapbox_maps.mapping.turf.*
 import io.flutter.plugin.common.BasicMessageChannel
@@ -4733,7 +4734,7 @@ interface StyleManager {
    *
    * @return A string describing an error if the operation was not successful, empty otherwise.
    */
-  fun addGeoJSONSourceFeatures(sourceId: String, dataID: String, features: List<Feature>, callback: (Result<Unit>) -> Unit)
+  fun addGeoJSONSourceFeatures(sourceId: String, dataId: String, features: List<Feature>, callback: (Result<Unit>) -> Unit)
   /**
    * Update existing features in a GeoJSON style source.
    *
@@ -4761,7 +4762,7 @@ interface StyleManager {
    *
    * @return A string describing an error if the operation was not successful, empty otherwise.
    */
-  fun updateGeoJSONSourceFeatures(sourceId: String, dataID: String, features: List<Feature>, callback: (Result<Unit>) -> Unit)
+  fun updateGeoJSONSourceFeatures(sourceId: String, dataId: String, features: List<Feature>, callback: (Result<Unit>) -> Unit)
   /**
    * Remove features from a GeoJSON style source.
    *
@@ -4789,7 +4790,7 @@ interface StyleManager {
    *
    * @return A string describing an error if the operation was not successful, empty otherwise.
    */
-  fun removeGeoJSONSourceFeatures(sourceId: String, dataID: String, featureIds: List<String>, callback: (Result<Unit>) -> Unit)
+  fun removeGeoJSONSourceFeatures(sourceId: String, dataId: String, featureIds: List<String>, callback: (Result<Unit>) -> Unit)
   /**
    * Updates the image of an [image style source](https://docs.mapbox.com/mapbox-gl-js/style-spec/#sources-image).
    *
@@ -5586,9 +5587,9 @@ interface StyleManager {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val sourceIdArg = args[0] as String
-            val dataIDArg = args[1] as String
+            val dataIdArg = args[1] as String
             val featuresArg = args[2] as List<Feature>
-            api.addGeoJSONSourceFeatures(sourceIdArg, dataIDArg, featuresArg) { result: Result<Unit> ->
+            api.addGeoJSONSourceFeatures(sourceIdArg, dataIdArg, featuresArg) { result: Result<Unit> ->
               val error = result.exceptionOrNull()
               if (error != null) {
                 reply.reply(wrapError(error))
@@ -5607,9 +5608,9 @@ interface StyleManager {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val sourceIdArg = args[0] as String
-            val dataIDArg = args[1] as String
+            val dataIdArg = args[1] as String
             val featuresArg = args[2] as List<Feature>
-            api.updateGeoJSONSourceFeatures(sourceIdArg, dataIDArg, featuresArg) { result: Result<Unit> ->
+            api.updateGeoJSONSourceFeatures(sourceIdArg, dataIdArg, featuresArg) { result: Result<Unit> ->
               val error = result.exceptionOrNull()
               if (error != null) {
                 reply.reply(wrapError(error))
@@ -5628,9 +5629,9 @@ interface StyleManager {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val sourceIdArg = args[0] as String
-            val dataIDArg = args[1] as String
+            val dataIdArg = args[1] as String
             val featureIdsArg = args[2] as List<String>
-            api.removeGeoJSONSourceFeatures(sourceIdArg, dataIDArg, featureIdsArg) { result: Result<Unit> ->
+            api.removeGeoJSONSourceFeatures(sourceIdArg, dataIdArg, featureIdsArg) { result: Result<Unit> ->
               val error = result.exceptionOrNull()
               if (error != null) {
                 reply.reply(wrapError(error))

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/MapInterfaces.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/MapInterfaces.kt
@@ -1892,310 +1892,315 @@ private object MapInterfacesPigeonCodec : StandardMessageCodec() {
       }
       130.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          GlyphsRasterizationOptions.fromList(it)
+          FeatureDecoder.fromList(it)
         }
       }
       131.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          TileCoverOptions.fromList(it)
+          GlyphsRasterizationOptions.fromList(it)
         }
       }
       132.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          MbxEdgeInsets.fromList(it)
+          TileCoverOptions.fromList(it)
         }
       }
       133.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          CameraOptions.fromList(it)
+          MbxEdgeInsets.fromList(it)
         }
       }
       134.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          CameraState.fromList(it)
+          CameraOptions.fromList(it)
         }
       }
       135.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          CameraBoundsOptions.fromList(it)
+          CameraState.fromList(it)
         }
       }
       136.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          CameraBounds.fromList(it)
+          CameraBoundsOptions.fromList(it)
         }
       }
       137.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          MapAnimationOptions.fromList(it)
+          CameraBounds.fromList(it)
         }
       }
       138.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          CoordinateBounds.fromList(it)
+          MapAnimationOptions.fromList(it)
         }
       }
       139.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          _MapWidgetDebugOptionsBox.fromList(it)
+          CoordinateBounds.fromList(it)
         }
       }
       140.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          MapDebugOptions.fromList(it)
+          _MapWidgetDebugOptionsBox.fromList(it)
         }
       }
       141.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          TileCacheBudgetInMegabytes.fromList(it)
+          MapDebugOptions.fromList(it)
         }
       }
       142.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          TileCacheBudgetInTiles.fromList(it)
+          TileCacheBudgetInMegabytes.fromList(it)
         }
       }
       143.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          MapOptions.fromList(it)
+          TileCacheBudgetInTiles.fromList(it)
         }
       }
       144.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          ScreenCoordinate.fromList(it)
+          MapOptions.fromList(it)
         }
       }
       145.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          ScreenBox.fromList(it)
+          ScreenCoordinate.fromList(it)
         }
       }
       146.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          CoordinateBoundsZoom.fromList(it)
+          ScreenBox.fromList(it)
         }
       }
       147.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          Size.fromList(it)
+          CoordinateBoundsZoom.fromList(it)
         }
       }
       148.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          RenderedQueryOptions.fromList(it)
+          Size.fromList(it)
         }
       }
       149.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          SourceQueryOptions.fromList(it)
+          RenderedQueryOptions.fromList(it)
         }
       }
       150.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          FeatureExtensionValue.fromList(it)
+          SourceQueryOptions.fromList(it)
         }
       }
       151.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          LayerPosition.fromList(it)
+          FeatureExtensionValue.fromList(it)
         }
       }
       152.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          QueriedRenderedFeature.fromList(it)
+          LayerPosition.fromList(it)
         }
       }
       153.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          QueriedSourceFeature.fromList(it)
+          QueriedRenderedFeature.fromList(it)
         }
       }
       154.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          QueriedFeature.fromList(it)
+          QueriedSourceFeature.fromList(it)
         }
       }
       155.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          RenderedQueryGeometry.fromList(it)
+          QueriedFeature.fromList(it)
         }
       }
       156.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          ProjectedMeters.fromList(it)
+          RenderedQueryGeometry.fromList(it)
         }
       }
       157.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          MercatorCoordinate.fromList(it)
+          ProjectedMeters.fromList(it)
         }
       }
       158.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          StyleObjectInfo.fromList(it)
+          MercatorCoordinate.fromList(it)
         }
       }
       159.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          StyleProjection.fromList(it)
+          StyleObjectInfo.fromList(it)
         }
       }
       160.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          FlatLight.fromList(it)
+          StyleProjection.fromList(it)
         }
       }
       161.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          DirectionalLight.fromList(it)
+          FlatLight.fromList(it)
         }
       }
       162.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          AmbientLight.fromList(it)
+          DirectionalLight.fromList(it)
         }
       }
       163.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          MbxImage.fromList(it)
+          AmbientLight.fromList(it)
         }
       }
       164.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          ImageStretches.fromList(it)
+          MbxImage.fromList(it)
         }
       }
       165.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          ImageContent.fromList(it)
+          ImageStretches.fromList(it)
         }
       }
       166.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          TransitionOptions.fromList(it)
+          ImageContent.fromList(it)
         }
       }
       167.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          CanonicalTileID.fromList(it)
+          TransitionOptions.fromList(it)
         }
       }
       168.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          StylePropertyValue.fromList(it)
+          CanonicalTileID.fromList(it)
         }
       }
       169.toByte() -> {
-        return (readValue(buffer) as Int?)?.let {
-          GlyphsRasterizationMode.ofRaw(it)
+        return (readValue(buffer) as? List<Any?>)?.let {
+          StylePropertyValue.fromList(it)
         }
       }
       170.toByte() -> {
         return (readValue(buffer) as Int?)?.let {
-          ContextMode.ofRaw(it)
+          GlyphsRasterizationMode.ofRaw(it)
         }
       }
       171.toByte() -> {
         return (readValue(buffer) as Int?)?.let {
-          ConstrainMode.ofRaw(it)
+          ContextMode.ofRaw(it)
         }
       }
       172.toByte() -> {
         return (readValue(buffer) as Int?)?.let {
-          ViewportMode.ofRaw(it)
+          ConstrainMode.ofRaw(it)
         }
       }
       173.toByte() -> {
         return (readValue(buffer) as Int?)?.let {
-          NorthOrientation.ofRaw(it)
+          ViewportMode.ofRaw(it)
         }
       }
       174.toByte() -> {
         return (readValue(buffer) as Int?)?.let {
-          _MapWidgetDebugOptions.ofRaw(it)
+          NorthOrientation.ofRaw(it)
         }
       }
       175.toByte() -> {
         return (readValue(buffer) as Int?)?.let {
-          MapDebugOptionsData.ofRaw(it)
+          _MapWidgetDebugOptions.ofRaw(it)
         }
       }
       176.toByte() -> {
         return (readValue(buffer) as Int?)?.let {
-          ViewAnnotationAnchor.ofRaw(it)
+          MapDebugOptionsData.ofRaw(it)
         }
       }
       177.toByte() -> {
         return (readValue(buffer) as Int?)?.let {
-          Type.ofRaw(it)
+          ViewAnnotationAnchor.ofRaw(it)
         }
       }
       178.toByte() -> {
         return (readValue(buffer) as Int?)?.let {
-          StylePackErrorType.ofRaw(it)
+          Type.ofRaw(it)
         }
       }
       179.toByte() -> {
         return (readValue(buffer) as Int?)?.let {
-          ResponseErrorReason.ofRaw(it)
+          StylePackErrorType.ofRaw(it)
         }
       }
       180.toByte() -> {
         return (readValue(buffer) as Int?)?.let {
-          OfflineRegionDownloadState.ofRaw(it)
+          ResponseErrorReason.ofRaw(it)
         }
       }
       181.toByte() -> {
         return (readValue(buffer) as Int?)?.let {
-          TileStoreUsageMode.ofRaw(it)
+          OfflineRegionDownloadState.ofRaw(it)
         }
       }
       182.toByte() -> {
         return (readValue(buffer) as Int?)?.let {
-          StylePropertyValueKind.ofRaw(it)
+          TileStoreUsageMode.ofRaw(it)
         }
       }
       183.toByte() -> {
         return (readValue(buffer) as Int?)?.let {
-          StyleProjectionName.ofRaw(it)
+          StylePropertyValueKind.ofRaw(it)
         }
       }
       184.toByte() -> {
         return (readValue(buffer) as Int?)?.let {
-          Anchor.ofRaw(it)
+          StyleProjectionName.ofRaw(it)
         }
       }
       185.toByte() -> {
         return (readValue(buffer) as Int?)?.let {
-          HttpMethod.ofRaw(it)
+          Anchor.ofRaw(it)
         }
       }
       186.toByte() -> {
         return (readValue(buffer) as Int?)?.let {
-          HttpRequestErrorType.ofRaw(it)
+          HttpMethod.ofRaw(it)
         }
       }
       187.toByte() -> {
         return (readValue(buffer) as Int?)?.let {
-          DownloadErrorCode.ofRaw(it)
+          HttpRequestErrorType.ofRaw(it)
         }
       }
       188.toByte() -> {
         return (readValue(buffer) as Int?)?.let {
-          DownloadState.ofRaw(it)
+          DownloadErrorCode.ofRaw(it)
         }
       }
       189.toByte() -> {
         return (readValue(buffer) as Int?)?.let {
-          TileDataDomain.ofRaw(it)
+          DownloadState.ofRaw(it)
         }
       }
       190.toByte() -> {
         return (readValue(buffer) as Int?)?.let {
-          TileRegionErrorType.ofRaw(it)
+          TileDataDomain.ofRaw(it)
         }
       }
       191.toByte() -> {
+        return (readValue(buffer) as Int?)?.let {
+          TileRegionErrorType.ofRaw(it)
+        }
+      }
+      192.toByte() -> {
         return (readValue(buffer) as Int?)?.let {
           _MapEvent.ofRaw(it)
         }
@@ -2209,252 +2214,256 @@ private object MapInterfacesPigeonCodec : StandardMessageCodec() {
         stream.write(129)
         writeValue(stream, value.toList())
       }
-      is GlyphsRasterizationOptions -> {
+      is Feature -> {
         stream.write(130)
         writeValue(stream, value.toList())
       }
-      is TileCoverOptions -> {
+      is GlyphsRasterizationOptions -> {
         stream.write(131)
         writeValue(stream, value.toList())
       }
-      is MbxEdgeInsets -> {
+      is TileCoverOptions -> {
         stream.write(132)
         writeValue(stream, value.toList())
       }
-      is CameraOptions -> {
+      is MbxEdgeInsets -> {
         stream.write(133)
         writeValue(stream, value.toList())
       }
-      is CameraState -> {
+      is CameraOptions -> {
         stream.write(134)
         writeValue(stream, value.toList())
       }
-      is CameraBoundsOptions -> {
+      is CameraState -> {
         stream.write(135)
         writeValue(stream, value.toList())
       }
-      is CameraBounds -> {
+      is CameraBoundsOptions -> {
         stream.write(136)
         writeValue(stream, value.toList())
       }
-      is MapAnimationOptions -> {
+      is CameraBounds -> {
         stream.write(137)
         writeValue(stream, value.toList())
       }
-      is CoordinateBounds -> {
+      is MapAnimationOptions -> {
         stream.write(138)
         writeValue(stream, value.toList())
       }
-      is _MapWidgetDebugOptionsBox -> {
+      is CoordinateBounds -> {
         stream.write(139)
         writeValue(stream, value.toList())
       }
-      is MapDebugOptions -> {
+      is _MapWidgetDebugOptionsBox -> {
         stream.write(140)
         writeValue(stream, value.toList())
       }
-      is TileCacheBudgetInMegabytes -> {
+      is MapDebugOptions -> {
         stream.write(141)
         writeValue(stream, value.toList())
       }
-      is TileCacheBudgetInTiles -> {
+      is TileCacheBudgetInMegabytes -> {
         stream.write(142)
         writeValue(stream, value.toList())
       }
-      is MapOptions -> {
+      is TileCacheBudgetInTiles -> {
         stream.write(143)
         writeValue(stream, value.toList())
       }
-      is ScreenCoordinate -> {
+      is MapOptions -> {
         stream.write(144)
         writeValue(stream, value.toList())
       }
-      is ScreenBox -> {
+      is ScreenCoordinate -> {
         stream.write(145)
         writeValue(stream, value.toList())
       }
-      is CoordinateBoundsZoom -> {
+      is ScreenBox -> {
         stream.write(146)
         writeValue(stream, value.toList())
       }
-      is Size -> {
+      is CoordinateBoundsZoom -> {
         stream.write(147)
         writeValue(stream, value.toList())
       }
-      is RenderedQueryOptions -> {
+      is Size -> {
         stream.write(148)
         writeValue(stream, value.toList())
       }
-      is SourceQueryOptions -> {
+      is RenderedQueryOptions -> {
         stream.write(149)
         writeValue(stream, value.toList())
       }
-      is FeatureExtensionValue -> {
+      is SourceQueryOptions -> {
         stream.write(150)
         writeValue(stream, value.toList())
       }
-      is LayerPosition -> {
+      is FeatureExtensionValue -> {
         stream.write(151)
         writeValue(stream, value.toList())
       }
-      is QueriedRenderedFeature -> {
+      is LayerPosition -> {
         stream.write(152)
         writeValue(stream, value.toList())
       }
-      is QueriedSourceFeature -> {
+      is QueriedRenderedFeature -> {
         stream.write(153)
         writeValue(stream, value.toList())
       }
-      is QueriedFeature -> {
+      is QueriedSourceFeature -> {
         stream.write(154)
         writeValue(stream, value.toList())
       }
-      is RenderedQueryGeometry -> {
+      is QueriedFeature -> {
         stream.write(155)
         writeValue(stream, value.toList())
       }
-      is ProjectedMeters -> {
+      is RenderedQueryGeometry -> {
         stream.write(156)
         writeValue(stream, value.toList())
       }
-      is MercatorCoordinate -> {
+      is ProjectedMeters -> {
         stream.write(157)
         writeValue(stream, value.toList())
       }
-      is StyleObjectInfo -> {
+      is MercatorCoordinate -> {
         stream.write(158)
         writeValue(stream, value.toList())
       }
-      is StyleProjection -> {
+      is StyleObjectInfo -> {
         stream.write(159)
         writeValue(stream, value.toList())
       }
-      is FlatLight -> {
+      is StyleProjection -> {
         stream.write(160)
         writeValue(stream, value.toList())
       }
-      is DirectionalLight -> {
+      is FlatLight -> {
         stream.write(161)
         writeValue(stream, value.toList())
       }
-      is AmbientLight -> {
+      is DirectionalLight -> {
         stream.write(162)
         writeValue(stream, value.toList())
       }
-      is MbxImage -> {
+      is AmbientLight -> {
         stream.write(163)
         writeValue(stream, value.toList())
       }
-      is ImageStretches -> {
+      is MbxImage -> {
         stream.write(164)
         writeValue(stream, value.toList())
       }
-      is ImageContent -> {
+      is ImageStretches -> {
         stream.write(165)
         writeValue(stream, value.toList())
       }
-      is TransitionOptions -> {
+      is ImageContent -> {
         stream.write(166)
         writeValue(stream, value.toList())
       }
-      is CanonicalTileID -> {
+      is TransitionOptions -> {
         stream.write(167)
         writeValue(stream, value.toList())
       }
-      is StylePropertyValue -> {
+      is CanonicalTileID -> {
         stream.write(168)
         writeValue(stream, value.toList())
       }
-      is GlyphsRasterizationMode -> {
+      is StylePropertyValue -> {
         stream.write(169)
-        writeValue(stream, value.raw)
+        writeValue(stream, value.toList())
       }
-      is ContextMode -> {
+      is GlyphsRasterizationMode -> {
         stream.write(170)
         writeValue(stream, value.raw)
       }
-      is ConstrainMode -> {
+      is ContextMode -> {
         stream.write(171)
         writeValue(stream, value.raw)
       }
-      is ViewportMode -> {
+      is ConstrainMode -> {
         stream.write(172)
         writeValue(stream, value.raw)
       }
-      is NorthOrientation -> {
+      is ViewportMode -> {
         stream.write(173)
         writeValue(stream, value.raw)
       }
-      is _MapWidgetDebugOptions -> {
+      is NorthOrientation -> {
         stream.write(174)
         writeValue(stream, value.raw)
       }
-      is MapDebugOptionsData -> {
+      is _MapWidgetDebugOptions -> {
         stream.write(175)
         writeValue(stream, value.raw)
       }
-      is ViewAnnotationAnchor -> {
+      is MapDebugOptionsData -> {
         stream.write(176)
         writeValue(stream, value.raw)
       }
-      is Type -> {
+      is ViewAnnotationAnchor -> {
         stream.write(177)
         writeValue(stream, value.raw)
       }
-      is StylePackErrorType -> {
+      is Type -> {
         stream.write(178)
         writeValue(stream, value.raw)
       }
-      is ResponseErrorReason -> {
+      is StylePackErrorType -> {
         stream.write(179)
         writeValue(stream, value.raw)
       }
-      is OfflineRegionDownloadState -> {
+      is ResponseErrorReason -> {
         stream.write(180)
         writeValue(stream, value.raw)
       }
-      is TileStoreUsageMode -> {
+      is OfflineRegionDownloadState -> {
         stream.write(181)
         writeValue(stream, value.raw)
       }
-      is StylePropertyValueKind -> {
+      is TileStoreUsageMode -> {
         stream.write(182)
         writeValue(stream, value.raw)
       }
-      is StyleProjectionName -> {
+      is StylePropertyValueKind -> {
         stream.write(183)
         writeValue(stream, value.raw)
       }
-      is Anchor -> {
+      is StyleProjectionName -> {
         stream.write(184)
         writeValue(stream, value.raw)
       }
-      is HttpMethod -> {
+      is Anchor -> {
         stream.write(185)
         writeValue(stream, value.raw)
       }
-      is HttpRequestErrorType -> {
+      is HttpMethod -> {
         stream.write(186)
         writeValue(stream, value.raw)
       }
-      is DownloadErrorCode -> {
+      is HttpRequestErrorType -> {
         stream.write(187)
         writeValue(stream, value.raw)
       }
-      is DownloadState -> {
+      is DownloadErrorCode -> {
         stream.write(188)
         writeValue(stream, value.raw)
       }
-      is TileDataDomain -> {
+      is DownloadState -> {
         stream.write(189)
         writeValue(stream, value.raw)
       }
-      is TileRegionErrorType -> {
+      is TileDataDomain -> {
         stream.write(190)
         writeValue(stream, value.raw)
       }
-      is _MapEvent -> {
+      is TileRegionErrorType -> {
         stream.write(191)
+        writeValue(stream, value.raw)
+      }
+      is _MapEvent -> {
+        stream.write(192)
         writeValue(stream, value.raw)
       }
       else -> super.writeValue(stream, value)
@@ -4698,6 +4707,90 @@ interface StyleManager {
    */
   fun setStyleSourceProperties(sourceId: String, properties: String, callback: (Result<Unit>) -> Unit)
   /**
+   * Add additional features to a GeoJSON style source.
+   *
+   * The add operation will be scheduled and applied on a GeoJSON serialization queue.
+   *
+   * In order to capture events when actual data is drawn on the map please refer to Events API
+   * and listen to `onSourceDataLoaded` (optionally pass the `dataId` parameter to filter the events)
+   * or `onMapLoadingError` with `type = metadata` if data parsing error has occurred.
+   *
+   * Partially updating a GeoJSON source is not compatible with using shared cache and generated IDs.
+   * It is important to ensure that every feature in the GeoJSON style source, as well as the newly added
+   * feature, has a unique ID (or a unique promote ID if in use). Failure to provide unique IDs will result
+   * in a `map-loading-error`.
+   *
+   * - Note: The method allows the user to provide a data ID, which will be returned as the `dataId` parameter in the
+   * `source-data-loaded` event. However, it's important to note that multiple partial updates can be queued
+   * for the same GeoJSON source when ongoing source parsing is taking place. In these cases, the partial
+   * updates will be applied to the source in batches. Only the data ID provided in the most recent call within
+   * each batch will be included in the `source-data-loaded` event. If no data ID is provided in the most recent
+   * call, the data ID in the `source-data-loaded`event will be null.
+   *
+   * @param sourceId The identifier of the style source.
+   * @param dataId An arbitrary string used to track the given GeoJSON data.
+   * @param features An array of GeoJSON features to be added to the source.
+   *
+   * @return A string describing an error if the operation was not successful, empty otherwise.
+   */
+  fun addGeoJSONSourceFeatures(sourceId: String, dataID: String, features: List<Feature>, callback: (Result<Unit>) -> Unit)
+  /**
+   * Update existing features in a GeoJSON style source.
+   *
+   * The update operation will be scheduled and applied on a GeoJSON serialization queue.
+   *
+   * In order to capture events when actual data is drawn on the map please refer to Events API
+   * and listen to `onSourceDataLoaded` (optionally pass the `dataId` parameter to filter the events)
+   * or `onMapLoadingError` with `type = metadata` if data parsing error has occurred.
+   *
+   * Partially updating a GeoJSON source is not compatible with using shared cache and generated IDs.
+   * It is important to ensure that every feature in the GeoJSON style source, as well as the newly added
+   * feature, has a unique ID (or a unique promote ID if in use). Failure to provide unique IDs will result
+   * in a `map-loading-error`.
+   *
+   * - Note: The method allows the user to provide a data ID, which will be returned as the `dataId` parameter in the
+   * `source-data-loaded` event. However, it's important to note that multiple partial updates can be queued
+   * for the same GeoJSON source when ongoing source parsing is taking place. In these cases, the partial
+   * updates will be applied to the source in batches. Only the data ID provided in the most recent call within
+   * each batch will be included in the `source-data-loaded` event. If no data ID is provided in the most recent
+   * call, the data ID in the `source-data-loaded`event will be null.
+   *
+   * @param sourceId A style source identifier.
+   * @param dataId An arbitrary string used to track the given GeoJSON data.
+   * @param features The GeoJSON features to be updated in the source.
+   *
+   * @return A string describing an error if the operation was not successful, empty otherwise.
+   */
+  fun updateGeoJSONSourceFeatures(sourceId: String, dataID: String, features: List<Feature>, callback: (Result<Unit>) -> Unit)
+  /**
+   * Remove features from a GeoJSON style source.
+   *
+   * The remove operation will be scheduled and applied on a GeoJSON serialization queue.
+   *
+   * In order to capture events when actual data is drawn on the map please refer to Events API
+   * and listen to `onSourceDataLoaded` (optionally pass the `dataId` parameter to filter the events)
+   * or `onMapLoadingError` with `type = metadata` if an error has occurred.
+   *
+   * Partially updating a GeoJSON source is not compatible with using shared cache and generated IDs.
+   * It is important to ensure that every feature in the GeoJSON style source, as well as the newly added
+   * feature, has a unique ID (or a unique promote ID if in use). Failure to provide unique IDs will result
+   * in a `map-loading-error`.
+   *
+   * - Note: The method allows the user to provide a data ID, which will be returned as the `dataId` parameter in the
+   * `source-data-loaded` event. However, it's important to note that multiple partial updates can be queued
+   * for the same GeoJSON source when ongoing source parsing is taking place. In these cases, the partial
+   * updates will be applied to the source in batches. Only the data ID provided in the most recent call within
+   * each batch will be included in the `source-data-loaded` event. If no data ID is provided in the most recent
+   * call, the data ID in the `source-data-loaded`event will be null.
+   *
+   * @param sourceId A style source identifier.
+   * @param dataId An arbitrary string used to track the given GeoJSON data.
+   * @param featureIds The Ids of the features that need to be removed from the source.
+   *
+   * @return A string describing an error if the operation was not successful, empty otherwise.
+   */
+  fun removeGeoJSONSourceFeatures(sourceId: String, dataID: String, featureIds: List<String>, callback: (Result<Unit>) -> Unit)
+  /**
    * Updates the image of an [image style source](https://docs.mapbox.com/mapbox-gl-js/style-spec/#sources-image).
    *
    * @param sourceId A style source identifier.
@@ -5475,6 +5568,69 @@ interface StyleManager {
             val sourceIdArg = args[0] as String
             val propertiesArg = args[1] as String
             api.setStyleSourceProperties(sourceIdArg, propertiesArg) { result: Result<Unit> ->
+              val error = result.exceptionOrNull()
+              if (error != null) {
+                reply.reply(wrapError(error))
+              } else {
+                reply.reply(wrapResult(null))
+              }
+            }
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.mapbox_maps_flutter.StyleManager.addGeoJSONSourceFeatures$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val sourceIdArg = args[0] as String
+            val dataIDArg = args[1] as String
+            val featuresArg = args[2] as List<Feature>
+            api.addGeoJSONSourceFeatures(sourceIdArg, dataIDArg, featuresArg) { result: Result<Unit> ->
+              val error = result.exceptionOrNull()
+              if (error != null) {
+                reply.reply(wrapError(error))
+              } else {
+                reply.reply(wrapResult(null))
+              }
+            }
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.mapbox_maps_flutter.StyleManager.updateGeoJSONSourceFeatures$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val sourceIdArg = args[0] as String
+            val dataIDArg = args[1] as String
+            val featuresArg = args[2] as List<Feature>
+            api.updateGeoJSONSourceFeatures(sourceIdArg, dataIDArg, featuresArg) { result: Result<Unit> ->
+              val error = result.exceptionOrNull()
+              if (error != null) {
+                reply.reply(wrapError(error))
+              } else {
+                reply.reply(wrapResult(null))
+              }
+            }
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.mapbox_maps_flutter.StyleManager.removeGeoJSONSourceFeatures$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val sourceIdArg = args[0] as String
+            val dataIDArg = args[1] as String
+            val featureIdsArg = args[2] as List<String>
+            api.removeGeoJSONSourceFeatures(sourceIdArg, dataIDArg, featureIdsArg) { result: Result<Unit> ->
               val error = result.exceptionOrNull()
               if (error != null) {
                 reply.reply(wrapError(error))

--- a/example/assets/from_crema_to_council_crest.geojson
+++ b/example/assets/from_crema_to_council_crest.geojson
@@ -3,7 +3,7 @@
   "features": [
     {
       "type": "Feature",
-      "id": "abc", 
+      "id": "featureID", 
       "properties": {
         "name": "Crema to Council Crest"
       },

--- a/example/assets/from_crema_to_council_crest.geojson
+++ b/example/assets/from_crema_to_council_crest.geojson
@@ -3,6 +3,7 @@
   "features": [
     {
       "type": "Feature",
+      "id": "abc", 
       "properties": {
         "name": "Crema to Council Crest"
       },

--- a/example/integration_test/camera_test.dart
+++ b/example/integration_test/camera_test.dart
@@ -149,109 +149,109 @@ void main() {
     expect(camera.anchor, isNull);
   });
 
-  testWidgets('coordinateBoundsForCamera', (WidgetTester tester) async {
-    final mapFuture = app.main();
-    await tester.pumpAndSettle();
-    final mapboxMap = await mapFuture;
-    var option = CameraOptions(
-        center: Point(
-            coordinates: Position(
-          1.0,
-          2.0,
-        )),
-        padding: MbxEdgeInsets(top: 1, left: 2, bottom: 3, right: 4),
-        anchor: ScreenCoordinate(x: 1, y: 1),
-        zoom: 10,
-        bearing: 20,
-        pitch: 30);
-    var camera = await mapboxMap.coordinateBoundsForCamera(option);
-    expect(camera.infiniteBounds, false);
-    final northeast = camera.northeast;
-    final southwest = camera.southwest;
-    expect((northeast.coordinates.lng as double).round(), 1);
-    expect((northeast.coordinates.lat as double).round(), 2);
-    expect((southwest.coordinates.lng as double).round(), 1);
-    expect((southwest.coordinates.lat as double).round(), 2);
-  });
+  // testWidgets('coordinateBoundsForCamera', (WidgetTester tester) async {
+  //   final mapFuture = app.main();
+  //   await tester.pumpAndSettle();
+  //   final mapboxMap = await mapFuture;
+  //   var option = CameraOptions(
+  //       center: Point(
+  //           coordinates: Position(
+  //         1.0,
+  //         2.0,
+  //       )),
+  //       padding: MbxEdgeInsets(top: 1, left: 2, bottom: 3, right: 4),
+  //       anchor: ScreenCoordinate(x: 1, y: 1),
+  //       zoom: 10,
+  //       bearing: 20,
+  //       pitch: 30);
+  //   var camera = await mapboxMap.coordinateBoundsForCamera(option);
+  //   expect(camera.infiniteBounds, false);
+  //   final northeast = camera.northeast;
+  //   final southwest = camera.southwest;
+  //   expect((northeast.coordinates.lng as double).round(), 1);
+  //   expect((northeast.coordinates.lat as double).round(), 2);
+  //   expect((southwest.coordinates.lng as double).round(), 1);
+  //   expect((southwest.coordinates.lat as double).round(), 2);
+  // });
 
-  testWidgets('coordinateBoundsForCameraUnwrapped',
-      (WidgetTester tester) async {
-    final mapFuture = app.main();
-    await tester.pumpAndSettle();
-    final mapboxMap = await mapFuture;
-    var option = CameraOptions(
-        center: Point(
-            coordinates: Position(
-          1.0,
-          2.0,
-        )),
-        padding: MbxEdgeInsets(top: 1, left: 2, bottom: 3, right: 4),
-        anchor: ScreenCoordinate(x: 1, y: 1),
-        zoom: 10,
-        bearing: 20,
-        pitch: 30);
-    var camera = await mapboxMap.coordinateBoundsForCameraUnwrapped(option);
-    expect(camera.infiniteBounds, false);
-    final northeast = camera.northeast;
-    final southwest = camera.southwest;
-    expect((northeast.coordinates.lng as double).round(), 1);
-    expect((northeast.coordinates.lat as double).round(), 2);
-    expect((southwest.coordinates.lng as double).round(), 1);
-    expect((southwest.coordinates.lat as double).round(), 2);
-  });
+  // testWidgets('coordinateBoundsForCameraUnwrapped',
+  //     (WidgetTester tester) async {
+  //   final mapFuture = app.main();
+  //   await tester.pumpAndSettle();
+  //   final mapboxMap = await mapFuture;
+  //   var option = CameraOptions(
+  //       center: Point(
+  //           coordinates: Position(
+  //         1.0,
+  //         2.0,
+  //       )),
+  //       padding: MbxEdgeInsets(top: 1, left: 2, bottom: 3, right: 4),
+  //       anchor: ScreenCoordinate(x: 1, y: 1),
+  //       zoom: 10,
+  //       bearing: 20,
+  //       pitch: 30);
+  //   var camera = await mapboxMap.coordinateBoundsForCameraUnwrapped(option);
+  //   expect(camera.infiniteBounds, false);
+  //   final northeast = camera.northeast;
+  //   final southwest = camera.southwest;
+  //   expect((northeast.coordinates.lng as double).round(), 1);
+  //   expect((northeast.coordinates.lat as double).round(), 2);
+  //   expect((southwest.coordinates.lng as double).round(), 1);
+  //   expect((southwest.coordinates.lat as double).round(), 2);
+  // });
 
-  testWidgets('coordinateBoundsZoomForCamera', (WidgetTester tester) async {
-    final mapFuture = app.main();
-    await tester.pumpAndSettle();
-    final mapboxMap = await mapFuture;
-    var option = CameraOptions(
-        center: Point(
-            coordinates: Position(
-          1.0,
-          2.0,
-        )),
-        padding: MbxEdgeInsets(top: 1, left: 2, bottom: 3, right: 4),
-        anchor: ScreenCoordinate(x: 1, y: 1),
-        zoom: 10,
-        bearing: 20,
-        pitch: 30);
-    var coordinate = await mapboxMap.coordinateBoundsZoomForCamera(option);
-    expect(coordinate.zoom, 10);
-    expect(coordinate.bounds.infiniteBounds, false);
-    final northeast = coordinate.bounds.northeast;
-    final southwest = coordinate.bounds.southwest;
-    expect((northeast.coordinates.lng as double).round(), 1);
-    expect((northeast.coordinates.lat as double).round(), 2);
-    expect((southwest.coordinates.lng as double).round(), 1);
-    expect((southwest.coordinates.lat as double).round(), 2);
-  });
-  testWidgets('coordinateBoundsZoomForCameraUnwrapped',
-      (WidgetTester tester) async {
-    final mapFuture = app.main();
-    await tester.pumpAndSettle();
-    final mapboxMap = await mapFuture;
-    var option = CameraOptions(
-        center: Point(
-            coordinates: Position(
-          1.0,
-          2.0,
-        )),
-        padding: MbxEdgeInsets(top: 1, left: 2, bottom: 3, right: 4),
-        anchor: ScreenCoordinate(x: 1, y: 1),
-        zoom: 10,
-        bearing: 20,
-        pitch: 30);
-    var coordinate =
-        await mapboxMap.coordinateBoundsZoomForCameraUnwrapped(option);
-    expect(coordinate.zoom, 10);
-    expect(coordinate.bounds.infiniteBounds, false);
-    final northeast = coordinate.bounds.northeast;
-    final southwest = coordinate.bounds.southwest;
-    expect((northeast.coordinates.lng as double).round(), 1);
-    expect((northeast.coordinates.lat as double).round(), 2);
-    expect((southwest.coordinates.lng as double).round(), 1);
-    expect((southwest.coordinates.lat as double).round(), 2);
-  });
+  // testWidgets('coordinateBoundsZoomForCamera', (WidgetTester tester) async {
+  //   final mapFuture = app.main();
+  //   await tester.pumpAndSettle();
+  //   final mapboxMap = await mapFuture;
+  //   var option = CameraOptions(
+  //       center: Point(
+  //           coordinates: Position(
+  //         1.0,
+  //         2.0,
+  //       )),
+  //       padding: MbxEdgeInsets(top: 1, left: 2, bottom: 3, right: 4),
+  //       anchor: ScreenCoordinate(x: 1, y: 1),
+  //       zoom: 10,
+  //       bearing: 20,
+  //       pitch: 30);
+  //   var coordinate = await mapboxMap.coordinateBoundsZoomForCamera(option);
+  //   expect(coordinate.zoom, 10);
+  //   expect(coordinate.bounds.infiniteBounds, false);
+  //   final northeast = coordinate.bounds.northeast;
+  //   final southwest = coordinate.bounds.southwest;
+  //   expect((northeast.coordinates.lng as double).round(), 1);
+  //   expect((northeast.coordinates.lat as double).round(), 2);
+  //   expect((southwest.coordinates.lng as double).round(), 1);
+  //   expect((southwest.coordinates.lat as double).round(), 2);
+  // });
+  // testWidgets('coordinateBoundsZoomForCameraUnwrapped',
+  //     (WidgetTester tester) async {
+  //   final mapFuture = app.main();
+  //   await tester.pumpAndSettle();
+  //   final mapboxMap = await mapFuture;
+  //   var option = CameraOptions(
+  //       center: Point(
+  //           coordinates: Position(
+  //         1.0,
+  //         2.0,
+  //       )),
+  //       padding: MbxEdgeInsets(top: 1, left: 2, bottom: 3, right: 4),
+  //       anchor: ScreenCoordinate(x: 1, y: 1),
+  //       zoom: 10,
+  //       bearing: 20,
+  //       pitch: 30);
+  //   var coordinate =
+  //       await mapboxMap.coordinateBoundsZoomForCameraUnwrapped(option);
+  //   expect(coordinate.zoom, 10);
+  //   expect(coordinate.bounds.infiniteBounds, false);
+  //   final northeast = coordinate.bounds.northeast;
+  //   final southwest = coordinate.bounds.southwest;
+  //   expect((northeast.coordinates.lng as double).round(), 1);
+  //   expect((northeast.coordinates.lat as double).round(), 2);
+  //   expect((southwest.coordinates.lng as double).round(), 1);
+  //   expect((southwest.coordinates.lat as double).round(), 2);
+  // });
   testWidgets('pixelForCoordinate', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();

--- a/example/integration_test/camera_test.dart
+++ b/example/integration_test/camera_test.dart
@@ -149,109 +149,109 @@ void main() {
     expect(camera.anchor, isNull);
   });
 
-  // testWidgets('coordinateBoundsForCamera', (WidgetTester tester) async {
-  //   final mapFuture = app.main();
-  //   await tester.pumpAndSettle();
-  //   final mapboxMap = await mapFuture;
-  //   var option = CameraOptions(
-  //       center: Point(
-  //           coordinates: Position(
-  //         1.0,
-  //         2.0,
-  //       )),
-  //       padding: MbxEdgeInsets(top: 1, left: 2, bottom: 3, right: 4),
-  //       anchor: ScreenCoordinate(x: 1, y: 1),
-  //       zoom: 10,
-  //       bearing: 20,
-  //       pitch: 30);
-  //   var camera = await mapboxMap.coordinateBoundsForCamera(option);
-  //   expect(camera.infiniteBounds, false);
-  //   final northeast = camera.northeast;
-  //   final southwest = camera.southwest;
-  //   expect((northeast.coordinates.lng as double).round(), 1);
-  //   expect((northeast.coordinates.lat as double).round(), 2);
-  //   expect((southwest.coordinates.lng as double).round(), 1);
-  //   expect((southwest.coordinates.lat as double).round(), 2);
-  // });
+  testWidgets('coordinateBoundsForCamera', (WidgetTester tester) async {
+    final mapFuture = app.main();
+    await tester.pumpAndSettle();
+    final mapboxMap = await mapFuture;
+    var option = CameraOptions(
+        center: Point(
+            coordinates: Position(
+          1.0,
+          2.0,
+        )),
+        padding: MbxEdgeInsets(top: 1, left: 2, bottom: 3, right: 4),
+        anchor: ScreenCoordinate(x: 1, y: 1),
+        zoom: 10,
+        bearing: 20,
+        pitch: 30);
+    var camera = await mapboxMap.coordinateBoundsForCamera(option);
+    expect(camera.infiniteBounds, false);
+    final northeast = camera.northeast;
+    final southwest = camera.southwest;
+    expect((northeast.coordinates.lng as double).round(), 1);
+    expect((northeast.coordinates.lat as double).round(), 2);
+    expect((southwest.coordinates.lng as double).round(), 1);
+    expect((southwest.coordinates.lat as double).round(), 2);
+  });
 
-  // testWidgets('coordinateBoundsForCameraUnwrapped',
-  //     (WidgetTester tester) async {
-  //   final mapFuture = app.main();
-  //   await tester.pumpAndSettle();
-  //   final mapboxMap = await mapFuture;
-  //   var option = CameraOptions(
-  //       center: Point(
-  //           coordinates: Position(
-  //         1.0,
-  //         2.0,
-  //       )),
-  //       padding: MbxEdgeInsets(top: 1, left: 2, bottom: 3, right: 4),
-  //       anchor: ScreenCoordinate(x: 1, y: 1),
-  //       zoom: 10,
-  //       bearing: 20,
-  //       pitch: 30);
-  //   var camera = await mapboxMap.coordinateBoundsForCameraUnwrapped(option);
-  //   expect(camera.infiniteBounds, false);
-  //   final northeast = camera.northeast;
-  //   final southwest = camera.southwest;
-  //   expect((northeast.coordinates.lng as double).round(), 1);
-  //   expect((northeast.coordinates.lat as double).round(), 2);
-  //   expect((southwest.coordinates.lng as double).round(), 1);
-  //   expect((southwest.coordinates.lat as double).round(), 2);
-  // });
+  testWidgets('coordinateBoundsForCameraUnwrapped',
+      (WidgetTester tester) async {
+    final mapFuture = app.main();
+    await tester.pumpAndSettle();
+    final mapboxMap = await mapFuture;
+    var option = CameraOptions(
+        center: Point(
+            coordinates: Position(
+          1.0,
+          2.0,
+        )),
+        padding: MbxEdgeInsets(top: 1, left: 2, bottom: 3, right: 4),
+        anchor: ScreenCoordinate(x: 1, y: 1),
+        zoom: 10,
+        bearing: 20,
+        pitch: 30);
+    var camera = await mapboxMap.coordinateBoundsForCameraUnwrapped(option);
+    expect(camera.infiniteBounds, false);
+    final northeast = camera.northeast;
+    final southwest = camera.southwest;
+    expect((northeast.coordinates.lng as double).round(), 1);
+    expect((northeast.coordinates.lat as double).round(), 2);
+    expect((southwest.coordinates.lng as double).round(), 1);
+    expect((southwest.coordinates.lat as double).round(), 2);
+  });
 
-  // testWidgets('coordinateBoundsZoomForCamera', (WidgetTester tester) async {
-  //   final mapFuture = app.main();
-  //   await tester.pumpAndSettle();
-  //   final mapboxMap = await mapFuture;
-  //   var option = CameraOptions(
-  //       center: Point(
-  //           coordinates: Position(
-  //         1.0,
-  //         2.0,
-  //       )),
-  //       padding: MbxEdgeInsets(top: 1, left: 2, bottom: 3, right: 4),
-  //       anchor: ScreenCoordinate(x: 1, y: 1),
-  //       zoom: 10,
-  //       bearing: 20,
-  //       pitch: 30);
-  //   var coordinate = await mapboxMap.coordinateBoundsZoomForCamera(option);
-  //   expect(coordinate.zoom, 10);
-  //   expect(coordinate.bounds.infiniteBounds, false);
-  //   final northeast = coordinate.bounds.northeast;
-  //   final southwest = coordinate.bounds.southwest;
-  //   expect((northeast.coordinates.lng as double).round(), 1);
-  //   expect((northeast.coordinates.lat as double).round(), 2);
-  //   expect((southwest.coordinates.lng as double).round(), 1);
-  //   expect((southwest.coordinates.lat as double).round(), 2);
-  // });
-  // testWidgets('coordinateBoundsZoomForCameraUnwrapped',
-  //     (WidgetTester tester) async {
-  //   final mapFuture = app.main();
-  //   await tester.pumpAndSettle();
-  //   final mapboxMap = await mapFuture;
-  //   var option = CameraOptions(
-  //       center: Point(
-  //           coordinates: Position(
-  //         1.0,
-  //         2.0,
-  //       )),
-  //       padding: MbxEdgeInsets(top: 1, left: 2, bottom: 3, right: 4),
-  //       anchor: ScreenCoordinate(x: 1, y: 1),
-  //       zoom: 10,
-  //       bearing: 20,
-  //       pitch: 30);
-  //   var coordinate =
-  //       await mapboxMap.coordinateBoundsZoomForCameraUnwrapped(option);
-  //   expect(coordinate.zoom, 10);
-  //   expect(coordinate.bounds.infiniteBounds, false);
-  //   final northeast = coordinate.bounds.northeast;
-  //   final southwest = coordinate.bounds.southwest;
-  //   expect((northeast.coordinates.lng as double).round(), 1);
-  //   expect((northeast.coordinates.lat as double).round(), 2);
-  //   expect((southwest.coordinates.lng as double).round(), 1);
-  //   expect((southwest.coordinates.lat as double).round(), 2);
-  // });
+  testWidgets('coordinateBoundsZoomForCamera', (WidgetTester tester) async {
+    final mapFuture = app.main();
+    await tester.pumpAndSettle();
+    final mapboxMap = await mapFuture;
+    var option = CameraOptions(
+        center: Point(
+            coordinates: Position(
+          1.0,
+          2.0,
+        )),
+        padding: MbxEdgeInsets(top: 1, left: 2, bottom: 3, right: 4),
+        anchor: ScreenCoordinate(x: 1, y: 1),
+        zoom: 10,
+        bearing: 20,
+        pitch: 30);
+    var coordinate = await mapboxMap.coordinateBoundsZoomForCamera(option);
+    expect(coordinate.zoom, 10);
+    expect(coordinate.bounds.infiniteBounds, false);
+    final northeast = coordinate.bounds.northeast;
+    final southwest = coordinate.bounds.southwest;
+    expect((northeast.coordinates.lng as double).round(), 1);
+    expect((northeast.coordinates.lat as double).round(), 2);
+    expect((southwest.coordinates.lng as double).round(), 1);
+    expect((southwest.coordinates.lat as double).round(), 2);
+  });
+  testWidgets('coordinateBoundsZoomForCameraUnwrapped',
+      (WidgetTester tester) async {
+    final mapFuture = app.main();
+    await tester.pumpAndSettle();
+    final mapboxMap = await mapFuture;
+    var option = CameraOptions(
+        center: Point(
+            coordinates: Position(
+          1.0,
+          2.0,
+        )),
+        padding: MbxEdgeInsets(top: 1, left: 2, bottom: 3, right: 4),
+        anchor: ScreenCoordinate(x: 1, y: 1),
+        zoom: 10,
+        bearing: 20,
+        pitch: 30);
+    var coordinate =
+        await mapboxMap.coordinateBoundsZoomForCameraUnwrapped(option);
+    expect(coordinate.zoom, 10);
+    expect(coordinate.bounds.infiniteBounds, false);
+    final northeast = coordinate.bounds.northeast;
+    final southwest = coordinate.bounds.southwest;
+    expect((northeast.coordinates.lng as double).round(), 1);
+    expect((northeast.coordinates.lat as double).round(), 2);
+    expect((southwest.coordinates.lng as double).round(), 1);
+    expect((southwest.coordinates.lat as double).round(), 2);
+  });
   testWidgets('pixelForCoordinate', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();

--- a/example/integration_test/style/source/geojson_source_test.dart
+++ b/example/integration_test/style/source/geojson_source_test.dart
@@ -102,12 +102,8 @@ void main() {
     var generateId = await source.generateId;
     expect(generateId, true);
 
-    // TODO: Investigate why this check is susceptible to fail on iOS
-    // https://mapbox.atlassian.net/browse/MAPSFLT-141
-    if (Platform.isAndroid) {
-      var prefetchZoomDelta = await source.prefetchZoomDelta;
-      expect(prefetchZoomDelta, 1.0);
-    }
+    var prefetchZoomDelta = await source.prefetchZoomDelta;
+    expect(prefetchZoomDelta, 1.0);
 
     var tileCacheBudget = await source.tileCacheBudget;
     expect(tileCacheBudget?.size,

--- a/example/integration_test/style/style_test.dart
+++ b/example/integration_test/style/style_test.dart
@@ -223,6 +223,29 @@ void main() {
         '<a href=\"https://www.mapbox.com/about/maps/\" target=\"_blank\" title=\"Mapbox\" aria-label=\"Mapbox\" role=\"listitem\">© Mapbox</a>');
   });
 
+  testWidgets('addGeoJSONSourceFeatures', (WidgetTester tester) async {
+    final mapFuture = app.main();
+    await tester.pumpAndSettle();
+    final mapboxMap = await mapFuture;
+    var data = await rootBundle
+        .loadString('assets/from_crema_to_council_crest.geojson');
+    var feature = Feature(
+        id: "addedFeature", geometry: Point(coordinates: Position(1, 1)));
+
+    // Add GeoJSONSourceFeature
+    await mapboxMap.style.addSource(GeoJsonSource(id: "line", data: data));
+    await mapboxMap.style.addGeoJSONSourceFeatures("line", "dataID", [feature]);
+    await mapboxMap.style
+        .addLayer(CircleLayer(id: "circle_layer", sourceId: "line"));
+
+    await Future.delayed(Duration(milliseconds: 100));
+    var returnedSourceFeatures = await mapboxMap.querySourceFeatures(
+        'line', SourceQueryOptions(filter: ''));
+    expect(returnedSourceFeatures.length, 1);
+    expect(returnedSourceFeatures.first?.queriedFeature.feature['id'],
+        "addedFeature");
+  });
+
   testWidgets('getStyleDefaultCamera', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();

--- a/example/integration_test/style/style_test.dart
+++ b/example/integration_test/style/style_test.dart
@@ -169,10 +169,10 @@ void main() {
     style.addStyleLayer(layer, null);
     await style.setStyleLayerProperties('custom', json.encode(properties));
     var styleLayerProperties = await style.getStyleLayerProperties('custom');
-    var formatedProperties =
+    var formattedProperties =
         json.decode(styleLayerProperties) as Map<String, dynamic>;
-    expect(formatedProperties['paint']['circle-radius'], 10);
-    expect(formatedProperties['paint']['circle-color'],
+    expect(formattedProperties['paint']['circle-radius'], 10);
+    expect(formattedProperties['paint']['circle-color'],
         ['rgba', 255, 255, 255, 1]);
   });
 
@@ -223,14 +223,20 @@ void main() {
         '<a href=\"https://www.mapbox.com/about/maps/\" target=\"_blank\" title=\"Mapbox\" aria-label=\"Mapbox\" role=\"listitem\">© Mapbox</a>');
   });
 
-  testWidgets('addGeoJSONSourceFeatures', (WidgetTester tester) async {
+  testWidgets('addAndRemoveGeoJSONSourceFeatures', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();
     final mapboxMap = await mapFuture;
     var data = await rootBundle
         .loadString('assets/from_crema_to_council_crest.geojson');
     var feature = Feature(
-        id: "addedFeature", geometry: Point(coordinates: Position(1, 1)));
+        id: "addedFeature",
+        geometry: Point(coordinates: Position(1, 1)),
+        properties: {"test": "data"});
+
+    // Reset map events
+    app.events.resetOnSourceDataLoaded();
+    app.events.resetOnMapIdle();
 
     // Add GeoJSONSourceFeature
     await mapboxMap.style.addSource(GeoJsonSource(id: "line", data: data));
@@ -238,12 +244,77 @@ void main() {
     await mapboxMap.style
         .addLayer(CircleLayer(id: "circle_layer", sourceId: "line"));
 
-    await Future.delayed(Duration(milliseconds: 100));
+    // Wait for map and source to finish
+    await app.events.onSourceDataLoaded.future;
+    await app.events.onMapIdle.future;
+
+    // Test dataId is returned
+    expect(app.events.sourceDataIDs.first, "dataID");
+
+    // Test added Features
     var returnedSourceFeatures = await mapboxMap.querySourceFeatures(
         'line', SourceQueryOptions(filter: ''));
     expect(returnedSourceFeatures.length, 1);
     expect(returnedSourceFeatures.first?.queriedFeature.feature['id'],
         "addedFeature");
+    expect(returnedSourceFeatures.first?.queriedFeature.feature['properties'],
+        {"test": "data"});
+
+    // Reset map events
+    app.events.resetOnSourceDataLoaded();
+    app.events.resetOnMapIdle();
+
+    await mapboxMap.style
+        .removeGeoJSONSourceFeatures("line", "dataID", ["addedFeature"]);
+
+    // Wait for map and source to finish
+    await app.events.onSourceDataLoaded.future;
+    await app.events.onMapIdle.future;
+
+    returnedSourceFeatures = await mapboxMap.querySourceFeatures(
+        'line', SourceQueryOptions(filter: ''));
+    expect(returnedSourceFeatures.length, 0);
+  });
+
+  testWidgets('updateGeoJSONSourceFeatures', (WidgetTester tester) async {
+    final mapFuture = app.main();
+    await tester.pumpAndSettle();
+    final mapboxMap = await mapFuture;
+    var data = await rootBundle
+        .loadString('assets/from_crema_to_council_crest.geojson');
+    var feature = Feature(
+        id: "addedFeature",
+        geometry: Point(coordinates: Position(1, 1)),
+        properties: {"test": "data"});
+
+    // Reset map events
+    app.events.resetOnSourceDataLoaded();
+    app.events.resetOnMapIdle();
+
+    // Add and update GeoJSONSourceFeature
+    await mapboxMap.style.addSource(GeoJsonSource(id: "line", data: data));
+    await mapboxMap.style.addGeoJSONSourceFeatures("line", "dataID", [feature]);
+    await mapboxMap.style
+        .addLayer(CircleLayer(id: "circle_layer", sourceId: "line"));
+    feature.properties = {"test": "newData"};
+    await mapboxMap.style
+        .updateGeoJSONSourceFeatures("line", "dataID", [feature]);
+
+    // Wait for map and source to finish
+    await app.events.onSourceDataLoaded.future;
+    await app.events.onMapIdle.future;
+
+    // Test dataId is returned
+    expect(app.events.sourceDataIDs.first, "dataID");
+
+    // Test query
+    var returnedSourceFeatures = await mapboxMap.querySourceFeatures(
+        'line', SourceQueryOptions(filter: ''));
+    expect(returnedSourceFeatures.length, 1);
+    expect(returnedSourceFeatures.first?.queriedFeature.feature['id'],
+        "addedFeature");
+    expect(returnedSourceFeatures.first?.queriedFeature.feature['properties'],
+        {"test": "newData"});
   });
 
   testWidgets('getStyleDefaultCamera', (WidgetTester tester) async {

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -48,7 +48,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  integration_test: 13825b8a9334a850581300559b8839134b124670
+  integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
   mapbox_maps_flutter: 82d43a200b28f66979d77c05f27fbeb39373097f
   MapboxCommon: ec5a4bc2cc197cd3d22ec2be8172b6715a51c62d
   MapboxCoreMaps: a1aa1e6529d74853898463e60bd230c0863c203e

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -2,7 +2,7 @@ import UIKit
 import mapbox_maps_flutter
 import Flutter
 
-@UIApplicationMain
+@main
 @objc class AppDelegate: FlutterAppDelegate {
   override func application(
     _ application: UIApplication,

--- a/example/lib/empty_map_widget.dart
+++ b/example/lib/empty_map_widget.dart
@@ -10,11 +10,13 @@ class Events {
   var onStyleDataLoaded = Completer();
   var onSourceDataLoaded = Completer();
   var onCameraChanged = Completer();
+  var sourceDataIDs = [""];
 
   void resetOnMapLoaded() => onMapLoaded = Completer();
   void resetOnStyleLoaded() => onStyleLoaded = Completer();
   void resetOnStyleDataLoaded() => onStyleDataLoaded = Completer();
-  void resetOnSourceDataLoaded() => onSourceDataLoaded = Completer();
+  void resetOnSourceDataLoaded() =>
+      {sourceDataIDs.clear(), onSourceDataLoaded = Completer()};
   void resetOnCameraChanged() => onCameraChanged = Completer();
   void resetOnMapIdle() => onMapIdle = Completer();
 }
@@ -50,6 +52,10 @@ Future<MapboxMap> main() {
       }
     },
     onSourceDataLoadedListener: (SourceDataLoadedEventData data) {
+      var dataID = data.dataId;
+      if (dataID != null) {
+        events.sourceDataIDs.add(dataID);
+      }
       if (!events.onSourceDataLoaded.isCompleted) {
         events.onSourceDataLoaded.complete();
       }

--- a/example/lib/geojson_line.dart
+++ b/example/lib/geojson_line.dart
@@ -26,28 +26,47 @@ class DrawGeoJsonLineWidgetState extends State<DrawGeoJsonLineWidget> {
 
   _onMapCreated(MapboxMap mapboxMap) async {
     this.mapboxMap = mapboxMap;
+  }
+
+  _onStyleLoadedCallback(StyleLoadedEventData data) async {
     var data = await rootBundle
         .loadString('assets/from_crema_to_council_crest.geojson');
-    await mapboxMap.style.addSource(GeoJsonSource(id: "line", data: data));
-    await mapboxMap.style.addLayer(LineLayer(
+
+    await mapboxMap?.style.addSource(GeoJsonSource(id: "line", data: data));
+    await mapboxMap?.style.addLayer(LineLayer(
         id: "line_layer",
         sourceId: "line",
         lineJoin: LineJoin.ROUND,
         lineCap: LineCap.ROUND,
         lineColor: Colors.red.value,
         lineWidth: 6.0));
+    
+    // Wait 5 seconds, then update the GeoJSONSource with the new line
+    await Future.delayed(Duration(seconds: 5));
+
+    var newFeature = Feature(
+      id: "featureID",
+      geometry: LineString(coordinates: [
+        Position(-122.483696, 37.833818),
+        Position(-122.4861, 37.828802),
+        Position(-122.493782, 37.833683),
+        Position(-122.48959, 37.8366109),
+        Position(-122.483696, 37.833818)
+    ]));
+    await mapboxMap?.style.updateGeoJSONSourceFeatures("line", "new_line", [newFeature]);
   }
 
   @override
   Widget build(BuildContext context) {
     return new Scaffold(
-        body: MapWidget(
+    body: MapWidget(
       key: ValueKey("mapWidget"),
       styleUri: MapboxStyles.MAPBOX_STREETS,
       cameraOptions: CameraOptions(
           center: Point(coordinates: Position(-122.486052, 37.830348)),
           zoom: 14.0),
       onMapCreated: _onMapCreated,
+      onStyleLoadedListener: _onStyleLoadedCallback,
     ));
   }
 }

--- a/example/lib/geojson_line.dart
+++ b/example/lib/geojson_line.dart
@@ -40,26 +40,27 @@ class DrawGeoJsonLineWidgetState extends State<DrawGeoJsonLineWidget> {
         lineCap: LineCap.ROUND,
         lineColor: Colors.red.value,
         lineWidth: 6.0));
-    
+
     // Wait 5 seconds, then update the GeoJSONSource with the new line
     await Future.delayed(Duration(seconds: 5));
 
     var newFeature = Feature(
-      id: "featureID",
-      geometry: LineString(coordinates: [
-        Position(-122.483696, 37.833818),
-        Position(-122.4861, 37.828802),
-        Position(-122.493782, 37.833683),
-        Position(-122.48959, 37.8366109),
-        Position(-122.483696, 37.833818)
-    ]));
-    await mapboxMap?.style.updateGeoJSONSourceFeatures("line", "new_line", [newFeature]);
+        id: "featureID",
+        geometry: LineString(coordinates: [
+          Position(-122.483696, 37.833818),
+          Position(-122.4861, 37.828802),
+          Position(-122.493782, 37.833683),
+          Position(-122.48959, 37.8366109),
+          Position(-122.483696, 37.833818)
+        ]));
+    await mapboxMap?.style
+        .updateGeoJSONSourceFeatures("line", "new_line", [newFeature]);
   }
 
   @override
   Widget build(BuildContext context) {
     return new Scaffold(
-    body: MapWidget(
+        body: MapWidget(
       key: ValueKey("mapWidget"),
       styleUri: MapboxStyles.MAPBOX_STREETS,
       cameraOptions: CameraOptions(

--- a/example/lib/offline_map.dart
+++ b/example/lib/offline_map.dart
@@ -39,8 +39,8 @@ class OfflineMapWidgetState extends State<OfflineMapWidget> {
             GlyphsRasterizationMode.IDEOGRAPHS_RASTERIZED_LOCALLY,
         metadata: {"tag": "test"},
         acceptExpired: false);
-    offlineManager.loadStylePack(MapboxStyles.SATELLITE_STREETS, stylePackLoadOptions,
-        (progress) {
+    offlineManager.loadStylePack(
+        MapboxStyles.SATELLITE_STREETS, stylePackLoadOptions, (progress) {
       final percentage =
           progress.completedResourceCount / progress.requiredResourceCount;
       if (!_stylePackProgress.isClosed) {
@@ -82,39 +82,43 @@ class OfflineMapWidgetState extends State<OfflineMapWidget> {
   @override
   Widget build(BuildContext context) {
     String downloadButtonText = "Download Map";
-    final mapIsDownloaded = Future
-        .wait([_tileRegionLoadProgress.sink.done, _stylePackProgress.sink.done])
+    final mapIsDownloaded = Future.wait(
+            [_tileRegionLoadProgress.sink.done, _stylePackProgress.sink.done])
         .whenComplete(() async {
-          await OfflineSwitch.shared.setMapboxStackConnected(false);
-        });
+      await OfflineSwitch.shared.setMapboxStackConnected(false);
+    });
 
     return new Column(
       mainAxisSize: MainAxisSize.min,
       children: [
         Expanded(
-          child: FutureBuilder(future: mapIsDownloaded, builder: (context, snapshot) {
-            if (snapshot.hasData) {
-              return MapWidget(
-                key: ValueKey("mapWidget"),
-                styleUri: MapboxStyles.SATELLITE_STREETS,
-                cameraOptions: CameraOptions(center: City.helsinki, zoom: 12.0),
-              );
-            } else {
-              return TextButton(
-                style: ButtonStyle(
-                  foregroundColor: MaterialStateProperty.all<Color>(Colors.blue),
-                ),
-                onPressed: () async {
-                  setState(() {
-                    downloadButtonText = "Downloading";
-                  });
-                  await _downloadStylePack();
-                  await _downloadTileRegion();
-                },
-                child: Text(downloadButtonText),
-              );
-            }
-          }),
+          child: FutureBuilder(
+              future: mapIsDownloaded,
+              builder: (context, snapshot) {
+                if (snapshot.hasData) {
+                  return MapWidget(
+                    key: ValueKey("mapWidget"),
+                    styleUri: MapboxStyles.SATELLITE_STREETS,
+                    cameraOptions:
+                        CameraOptions(center: City.helsinki, zoom: 12.0),
+                  );
+                } else {
+                  return TextButton(
+                    style: ButtonStyle(
+                      foregroundColor:
+                          MaterialStateProperty.all<Color>(Colors.blue),
+                    ),
+                    onPressed: () async {
+                      setState(() {
+                        downloadButtonText = "Downloading";
+                      });
+                      await _downloadStylePack();
+                      await _downloadTileRegion();
+                    },
+                    child: Text(downloadButtonText),
+                  );
+                }
+              }),
         ),
         SizedBox(
             height: 100,

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -174,26 +174,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   mapbox_maps_flutter:
     dependency: "direct main"
     description:
@@ -213,18 +213,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.15.0"
   path:
     dependency: transitive
     description:
@@ -325,10 +325,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "12220bb4b65720483f8fa9450b4332347737cf8213dd2840d8b2c823e47243ec"
+      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.4"
+    version: "3.1.5"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -418,10 +418,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.2"
   turf:
     dependency: "direct dev"
     description:
@@ -466,10 +466,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.5"
   webdriver:
     dependency: transitive
     description:
@@ -488,4 +488,4 @@ packages:
     version: "1.0.4"
 sdks:
   dart: ">=3.3.0 <4.0.0"
-  flutter: ">=3.16.6"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/ios/Classes/Generated/MapInterfaces.swift
+++ b/ios/Classes/Generated/MapInterfaces.swift
@@ -4371,7 +4371,7 @@ protocol StyleManager {
   /// @param features An array of GeoJSON features to be added to the source.
   ///
   /// @return A string describing an error if the operation was not successful, empty otherwise.
-  func addGeoJSONSourceFeatures(sourceId: String, dataID: String, features: [Feature], completion: @escaping (Result<Void, Error>) -> Void)
+  func addGeoJSONSourceFeatures(sourceId: String, dataId: String, features: [Feature], completion: @escaping (Result<Void, Error>) -> Void)
   /// Update existing features in a GeoJSON style source.
   ///
   /// The update operation will be scheduled and applied on a GeoJSON serialization queue.
@@ -4397,7 +4397,7 @@ protocol StyleManager {
   /// @param features The GeoJSON features to be updated in the source.
   /// 
   /// @return A string describing an error if the operation was not successful, empty otherwise.
-  func updateGeoJSONSourceFeatures(sourceId: String, dataID: String, features: [Feature], completion: @escaping (Result<Void, Error>) -> Void)
+  func updateGeoJSONSourceFeatures(sourceId: String, dataId: String, features: [Feature], completion: @escaping (Result<Void, Error>) -> Void)
   /// Remove features from a GeoJSON style source.
   ///
   /// The remove operation will be scheduled and applied on a GeoJSON serialization queue.
@@ -4423,7 +4423,7 @@ protocol StyleManager {
   /// @param featureIds The Ids of the features that need to be removed from the source.
   /// 
   /// @return A string describing an error if the operation was not successful, empty otherwise.
-  func removeGeoJSONSourceFeatures(sourceId: String, dataID: String, featureIds: [String], completion: @escaping (Result<Void, Error>) -> Void)
+  func removeGeoJSONSourceFeatures(sourceId: String, dataId: String, featureIds: [String], completion: @escaping (Result<Void, Error>) -> Void)
   /// Updates the image of an [image style source](https://docs.mapbox.com/mapbox-gl-js/style-spec/#sources-image).
   ///
   /// @param sourceId A style source identifier.
@@ -5297,9 +5297,9 @@ class StyleManagerSetup {
       addGeoJSONSourceFeaturesChannel.setMessageHandler { message, reply in
         let args = message as! [Any?]
         let sourceIdArg = args[0] as! String
-        let dataIDArg = args[1] as! String
+        let dataIdArg = args[1] as! String
         let featuresArg = args[2] as! [Feature]
-        api.addGeoJSONSourceFeatures(sourceId: sourceIdArg, dataID: dataIDArg, features: featuresArg) { result in
+        api.addGeoJSONSourceFeatures(sourceId: sourceIdArg, dataId: dataIdArg, features: featuresArg) { result in
           switch result {
           case .success:
             reply(wrapResult(nil))
@@ -5341,9 +5341,9 @@ class StyleManagerSetup {
       updateGeoJSONSourceFeaturesChannel.setMessageHandler { message, reply in
         let args = message as! [Any?]
         let sourceIdArg = args[0] as! String
-        let dataIDArg = args[1] as! String
+        let dataIdArg = args[1] as! String
         let featuresArg = args[2] as! [Feature]
-        api.updateGeoJSONSourceFeatures(sourceId: sourceIdArg, dataID: dataIDArg, features: featuresArg) { result in
+        api.updateGeoJSONSourceFeatures(sourceId: sourceIdArg, dataId: dataIdArg, features: featuresArg) { result in
           switch result {
           case .success:
             reply(wrapResult(nil))
@@ -5385,9 +5385,9 @@ class StyleManagerSetup {
       removeGeoJSONSourceFeaturesChannel.setMessageHandler { message, reply in
         let args = message as! [Any?]
         let sourceIdArg = args[0] as! String
-        let dataIDArg = args[1] as! String
+        let dataIdArg = args[1] as! String
         let featureIdsArg = args[2] as! [String]
-        api.removeGeoJSONSourceFeatures(sourceId: sourceIdArg, dataID: dataIDArg, featureIds: featureIdsArg) { result in
+        api.removeGeoJSONSourceFeatures(sourceId: sourceIdArg, dataId: dataIdArg, featureIds: featureIdsArg) { result in
           switch result {
           case .success:
             reply(wrapResult(nil))

--- a/ios/Classes/Generated/MapInterfaces.swift
+++ b/ios/Classes/Generated/MapInterfaces.swift
@@ -11,6 +11,7 @@ import Foundation
   #error("Unsupported platform.")
 #endif
 import struct Turf.Point
+import struct Turf.Feature
 
 /// Error class for passing custom error details to Dart side.
 final class MapInterfacesError: Error {
@@ -1709,238 +1710,240 @@ private class MapInterfacesPigeonCodecReader: FlutterStandardReader {
     case 129:
       return Point.fromList(self.readValue() as! [Any?])
     case 130:
-      return GlyphsRasterizationOptions.fromList(self.readValue() as! [Any?])
+      return Feature.fromList(self.readValue() as! [Any?])
     case 131:
-      return TileCoverOptions.fromList(self.readValue() as! [Any?])
+      return GlyphsRasterizationOptions.fromList(self.readValue() as! [Any?])
     case 132:
-      return MbxEdgeInsets.fromList(self.readValue() as! [Any?])
+      return TileCoverOptions.fromList(self.readValue() as! [Any?])
     case 133:
-      return CameraOptions.fromList(self.readValue() as! [Any?])
+      return MbxEdgeInsets.fromList(self.readValue() as! [Any?])
     case 134:
-      return CameraState.fromList(self.readValue() as! [Any?])
+      return CameraOptions.fromList(self.readValue() as! [Any?])
     case 135:
-      return CameraBoundsOptions.fromList(self.readValue() as! [Any?])
+      return CameraState.fromList(self.readValue() as! [Any?])
     case 136:
-      return CameraBounds.fromList(self.readValue() as! [Any?])
+      return CameraBoundsOptions.fromList(self.readValue() as! [Any?])
     case 137:
-      return MapAnimationOptions.fromList(self.readValue() as! [Any?])
+      return CameraBounds.fromList(self.readValue() as! [Any?])
     case 138:
-      return CoordinateBounds.fromList(self.readValue() as! [Any?])
+      return MapAnimationOptions.fromList(self.readValue() as! [Any?])
     case 139:
-      return _MapWidgetDebugOptionsBox.fromList(self.readValue() as! [Any?])
+      return CoordinateBounds.fromList(self.readValue() as! [Any?])
     case 140:
-      return MapDebugOptions.fromList(self.readValue() as! [Any?])
+      return _MapWidgetDebugOptionsBox.fromList(self.readValue() as! [Any?])
     case 141:
-      return TileCacheBudgetInMegabytes.fromList(self.readValue() as! [Any?])
+      return MapDebugOptions.fromList(self.readValue() as! [Any?])
     case 142:
-      return TileCacheBudgetInTiles.fromList(self.readValue() as! [Any?])
+      return TileCacheBudgetInMegabytes.fromList(self.readValue() as! [Any?])
     case 143:
-      return MapOptions.fromList(self.readValue() as! [Any?])
+      return TileCacheBudgetInTiles.fromList(self.readValue() as! [Any?])
     case 144:
-      return ScreenCoordinate.fromList(self.readValue() as! [Any?])
+      return MapOptions.fromList(self.readValue() as! [Any?])
     case 145:
-      return ScreenBox.fromList(self.readValue() as! [Any?])
+      return ScreenCoordinate.fromList(self.readValue() as! [Any?])
     case 146:
-      return CoordinateBoundsZoom.fromList(self.readValue() as! [Any?])
+      return ScreenBox.fromList(self.readValue() as! [Any?])
     case 147:
-      return Size.fromList(self.readValue() as! [Any?])
+      return CoordinateBoundsZoom.fromList(self.readValue() as! [Any?])
     case 148:
-      return RenderedQueryOptions.fromList(self.readValue() as! [Any?])
+      return Size.fromList(self.readValue() as! [Any?])
     case 149:
-      return SourceQueryOptions.fromList(self.readValue() as! [Any?])
+      return RenderedQueryOptions.fromList(self.readValue() as! [Any?])
     case 150:
-      return FeatureExtensionValue.fromList(self.readValue() as! [Any?])
+      return SourceQueryOptions.fromList(self.readValue() as! [Any?])
     case 151:
-      return LayerPosition.fromList(self.readValue() as! [Any?])
+      return FeatureExtensionValue.fromList(self.readValue() as! [Any?])
     case 152:
-      return QueriedRenderedFeature.fromList(self.readValue() as! [Any?])
+      return LayerPosition.fromList(self.readValue() as! [Any?])
     case 153:
-      return QueriedSourceFeature.fromList(self.readValue() as! [Any?])
+      return QueriedRenderedFeature.fromList(self.readValue() as! [Any?])
     case 154:
-      return QueriedFeature.fromList(self.readValue() as! [Any?])
+      return QueriedSourceFeature.fromList(self.readValue() as! [Any?])
     case 155:
-      return RenderedQueryGeometry.fromList(self.readValue() as! [Any?])
+      return QueriedFeature.fromList(self.readValue() as! [Any?])
     case 156:
-      return ProjectedMeters.fromList(self.readValue() as! [Any?])
+      return RenderedQueryGeometry.fromList(self.readValue() as! [Any?])
     case 157:
-      return MercatorCoordinate.fromList(self.readValue() as! [Any?])
+      return ProjectedMeters.fromList(self.readValue() as! [Any?])
     case 158:
-      return StyleObjectInfo.fromList(self.readValue() as! [Any?])
+      return MercatorCoordinate.fromList(self.readValue() as! [Any?])
     case 159:
-      return StyleProjection.fromList(self.readValue() as! [Any?])
+      return StyleObjectInfo.fromList(self.readValue() as! [Any?])
     case 160:
-      return FlatLight.fromList(self.readValue() as! [Any?])
+      return StyleProjection.fromList(self.readValue() as! [Any?])
     case 161:
-      return DirectionalLight.fromList(self.readValue() as! [Any?])
+      return FlatLight.fromList(self.readValue() as! [Any?])
     case 162:
-      return AmbientLight.fromList(self.readValue() as! [Any?])
+      return DirectionalLight.fromList(self.readValue() as! [Any?])
     case 163:
-      return MbxImage.fromList(self.readValue() as! [Any?])
+      return AmbientLight.fromList(self.readValue() as! [Any?])
     case 164:
-      return ImageStretches.fromList(self.readValue() as! [Any?])
+      return MbxImage.fromList(self.readValue() as! [Any?])
     case 165:
-      return ImageContent.fromList(self.readValue() as! [Any?])
+      return ImageStretches.fromList(self.readValue() as! [Any?])
     case 166:
-      return TransitionOptions.fromList(self.readValue() as! [Any?])
+      return ImageContent.fromList(self.readValue() as! [Any?])
     case 167:
-      return CanonicalTileID.fromList(self.readValue() as! [Any?])
+      return TransitionOptions.fromList(self.readValue() as! [Any?])
     case 168:
-      return StylePropertyValue.fromList(self.readValue() as! [Any?])
+      return CanonicalTileID.fromList(self.readValue() as! [Any?])
     case 169:
+      return StylePropertyValue.fromList(self.readValue() as! [Any?])
+    case 170:
       var enumResult: GlyphsRasterizationMode?
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
       if let enumResultAsInt = enumResultAsInt {
         enumResult = GlyphsRasterizationMode(rawValue: enumResultAsInt)
       }
       return enumResult
-    case 170:
+    case 171:
       var enumResult: ContextMode?
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
       if let enumResultAsInt = enumResultAsInt {
         enumResult = ContextMode(rawValue: enumResultAsInt)
       }
       return enumResult
-    case 171:
+    case 172:
       var enumResult: ConstrainMode?
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
       if let enumResultAsInt = enumResultAsInt {
         enumResult = ConstrainMode(rawValue: enumResultAsInt)
       }
       return enumResult
-    case 172:
+    case 173:
       var enumResult: ViewportMode?
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
       if let enumResultAsInt = enumResultAsInt {
         enumResult = ViewportMode(rawValue: enumResultAsInt)
       }
       return enumResult
-    case 173:
+    case 174:
       var enumResult: NorthOrientation?
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
       if let enumResultAsInt = enumResultAsInt {
         enumResult = NorthOrientation(rawValue: enumResultAsInt)
       }
       return enumResult
-    case 174:
+    case 175:
       var enumResult: _MapWidgetDebugOptions?
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
       if let enumResultAsInt = enumResultAsInt {
         enumResult = _MapWidgetDebugOptions(rawValue: enumResultAsInt)
       }
       return enumResult
-    case 175:
+    case 176:
       var enumResult: MapDebugOptionsData?
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
       if let enumResultAsInt = enumResultAsInt {
         enumResult = MapDebugOptionsData(rawValue: enumResultAsInt)
       }
       return enumResult
-    case 176:
+    case 177:
       var enumResult: ViewAnnotationAnchor?
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
       if let enumResultAsInt = enumResultAsInt {
         enumResult = ViewAnnotationAnchor(rawValue: enumResultAsInt)
       }
       return enumResult
-    case 177:
+    case 178:
       var enumResult: Type?
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
       if let enumResultAsInt = enumResultAsInt {
         enumResult = Type(rawValue: enumResultAsInt)
       }
       return enumResult
-    case 178:
+    case 179:
       var enumResult: StylePackErrorType?
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
       if let enumResultAsInt = enumResultAsInt {
         enumResult = StylePackErrorType(rawValue: enumResultAsInt)
       }
       return enumResult
-    case 179:
+    case 180:
       var enumResult: ResponseErrorReason?
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
       if let enumResultAsInt = enumResultAsInt {
         enumResult = ResponseErrorReason(rawValue: enumResultAsInt)
       }
       return enumResult
-    case 180:
+    case 181:
       var enumResult: OfflineRegionDownloadState?
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
       if let enumResultAsInt = enumResultAsInt {
         enumResult = OfflineRegionDownloadState(rawValue: enumResultAsInt)
       }
       return enumResult
-    case 181:
+    case 182:
       var enumResult: TileStoreUsageMode?
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
       if let enumResultAsInt = enumResultAsInt {
         enumResult = TileStoreUsageMode(rawValue: enumResultAsInt)
       }
       return enumResult
-    case 182:
+    case 183:
       var enumResult: StylePropertyValueKind?
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
       if let enumResultAsInt = enumResultAsInt {
         enumResult = StylePropertyValueKind(rawValue: enumResultAsInt)
       }
       return enumResult
-    case 183:
+    case 184:
       var enumResult: StyleProjectionName?
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
       if let enumResultAsInt = enumResultAsInt {
         enumResult = StyleProjectionName(rawValue: enumResultAsInt)
       }
       return enumResult
-    case 184:
+    case 185:
       var enumResult: Anchor?
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
       if let enumResultAsInt = enumResultAsInt {
         enumResult = Anchor(rawValue: enumResultAsInt)
       }
       return enumResult
-    case 185:
+    case 186:
       var enumResult: HttpMethod?
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
       if let enumResultAsInt = enumResultAsInt {
         enumResult = HttpMethod(rawValue: enumResultAsInt)
       }
       return enumResult
-    case 186:
+    case 187:
       var enumResult: HttpRequestErrorType?
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
       if let enumResultAsInt = enumResultAsInt {
         enumResult = HttpRequestErrorType(rawValue: enumResultAsInt)
       }
       return enumResult
-    case 187:
+    case 188:
       var enumResult: DownloadErrorCode?
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
       if let enumResultAsInt = enumResultAsInt {
         enumResult = DownloadErrorCode(rawValue: enumResultAsInt)
       }
       return enumResult
-    case 188:
+    case 189:
       var enumResult: DownloadState?
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
       if let enumResultAsInt = enumResultAsInt {
         enumResult = DownloadState(rawValue: enumResultAsInt)
       }
       return enumResult
-    case 189:
+    case 190:
       var enumResult: TileDataDomain?
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
       if let enumResultAsInt = enumResultAsInt {
         enumResult = TileDataDomain(rawValue: enumResultAsInt)
       }
       return enumResult
-    case 190:
+    case 191:
       var enumResult: TileRegionErrorType?
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
       if let enumResultAsInt = enumResultAsInt {
         enumResult = TileRegionErrorType(rawValue: enumResultAsInt)
       }
       return enumResult
-    case 191:
+    case 192:
       var enumResult: _MapEvent?
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
       if let enumResultAsInt = enumResultAsInt {
@@ -1958,191 +1961,194 @@ private class MapInterfacesPigeonCodecWriter: FlutterStandardWriter {
     if let value = value as? Point {
       super.writeByte(129)
       super.writeValue(value.toList())
-    } else if let value = value as? GlyphsRasterizationOptions {
+    } else if let value = value as? Feature {
       super.writeByte(130)
       super.writeValue(value.toList())
-    } else if let value = value as? TileCoverOptions {
+    } else if let value = value as? GlyphsRasterizationOptions {
       super.writeByte(131)
       super.writeValue(value.toList())
-    } else if let value = value as? MbxEdgeInsets {
+    } else if let value = value as? TileCoverOptions {
       super.writeByte(132)
       super.writeValue(value.toList())
-    } else if let value = value as? CameraOptions {
+    } else if let value = value as? MbxEdgeInsets {
       super.writeByte(133)
       super.writeValue(value.toList())
-    } else if let value = value as? CameraState {
+    } else if let value = value as? CameraOptions {
       super.writeByte(134)
       super.writeValue(value.toList())
-    } else if let value = value as? CameraBoundsOptions {
+    } else if let value = value as? CameraState {
       super.writeByte(135)
       super.writeValue(value.toList())
-    } else if let value = value as? CameraBounds {
+    } else if let value = value as? CameraBoundsOptions {
       super.writeByte(136)
       super.writeValue(value.toList())
-    } else if let value = value as? MapAnimationOptions {
+    } else if let value = value as? CameraBounds {
       super.writeByte(137)
       super.writeValue(value.toList())
-    } else if let value = value as? CoordinateBounds {
+    } else if let value = value as? MapAnimationOptions {
       super.writeByte(138)
       super.writeValue(value.toList())
-    } else if let value = value as? _MapWidgetDebugOptionsBox {
+    } else if let value = value as? CoordinateBounds {
       super.writeByte(139)
       super.writeValue(value.toList())
-    } else if let value = value as? MapDebugOptions {
+    } else if let value = value as? _MapWidgetDebugOptionsBox {
       super.writeByte(140)
       super.writeValue(value.toList())
-    } else if let value = value as? TileCacheBudgetInMegabytes {
+    } else if let value = value as? MapDebugOptions {
       super.writeByte(141)
       super.writeValue(value.toList())
-    } else if let value = value as? TileCacheBudgetInTiles {
+    } else if let value = value as? TileCacheBudgetInMegabytes {
       super.writeByte(142)
       super.writeValue(value.toList())
-    } else if let value = value as? MapOptions {
+    } else if let value = value as? TileCacheBudgetInTiles {
       super.writeByte(143)
       super.writeValue(value.toList())
-    } else if let value = value as? ScreenCoordinate {
+    } else if let value = value as? MapOptions {
       super.writeByte(144)
       super.writeValue(value.toList())
-    } else if let value = value as? ScreenBox {
+    } else if let value = value as? ScreenCoordinate {
       super.writeByte(145)
       super.writeValue(value.toList())
-    } else if let value = value as? CoordinateBoundsZoom {
+    } else if let value = value as? ScreenBox {
       super.writeByte(146)
       super.writeValue(value.toList())
-    } else if let value = value as? Size {
+    } else if let value = value as? CoordinateBoundsZoom {
       super.writeByte(147)
       super.writeValue(value.toList())
-    } else if let value = value as? RenderedQueryOptions {
+    } else if let value = value as? Size {
       super.writeByte(148)
       super.writeValue(value.toList())
-    } else if let value = value as? SourceQueryOptions {
+    } else if let value = value as? RenderedQueryOptions {
       super.writeByte(149)
       super.writeValue(value.toList())
-    } else if let value = value as? FeatureExtensionValue {
+    } else if let value = value as? SourceQueryOptions {
       super.writeByte(150)
       super.writeValue(value.toList())
-    } else if let value = value as? LayerPosition {
+    } else if let value = value as? FeatureExtensionValue {
       super.writeByte(151)
       super.writeValue(value.toList())
-    } else if let value = value as? QueriedRenderedFeature {
+    } else if let value = value as? LayerPosition {
       super.writeByte(152)
       super.writeValue(value.toList())
-    } else if let value = value as? QueriedSourceFeature {
+    } else if let value = value as? QueriedRenderedFeature {
       super.writeByte(153)
       super.writeValue(value.toList())
-    } else if let value = value as? QueriedFeature {
+    } else if let value = value as? QueriedSourceFeature {
       super.writeByte(154)
       super.writeValue(value.toList())
-    } else if let value = value as? RenderedQueryGeometry {
+    } else if let value = value as? QueriedFeature {
       super.writeByte(155)
       super.writeValue(value.toList())
-    } else if let value = value as? ProjectedMeters {
+    } else if let value = value as? RenderedQueryGeometry {
       super.writeByte(156)
       super.writeValue(value.toList())
-    } else if let value = value as? MercatorCoordinate {
+    } else if let value = value as? ProjectedMeters {
       super.writeByte(157)
       super.writeValue(value.toList())
-    } else if let value = value as? StyleObjectInfo {
+    } else if let value = value as? MercatorCoordinate {
       super.writeByte(158)
       super.writeValue(value.toList())
-    } else if let value = value as? StyleProjection {
+    } else if let value = value as? StyleObjectInfo {
       super.writeByte(159)
       super.writeValue(value.toList())
-    } else if let value = value as? FlatLight {
+    } else if let value = value as? StyleProjection {
       super.writeByte(160)
       super.writeValue(value.toList())
-    } else if let value = value as? DirectionalLight {
+    } else if let value = value as? FlatLight {
       super.writeByte(161)
       super.writeValue(value.toList())
-    } else if let value = value as? AmbientLight {
+    } else if let value = value as? DirectionalLight {
       super.writeByte(162)
       super.writeValue(value.toList())
-    } else if let value = value as? MbxImage {
+    } else if let value = value as? AmbientLight {
       super.writeByte(163)
       super.writeValue(value.toList())
-    } else if let value = value as? ImageStretches {
+    } else if let value = value as? MbxImage {
       super.writeByte(164)
       super.writeValue(value.toList())
-    } else if let value = value as? ImageContent {
+    } else if let value = value as? ImageStretches {
       super.writeByte(165)
       super.writeValue(value.toList())
-    } else if let value = value as? TransitionOptions {
+    } else if let value = value as? ImageContent {
       super.writeByte(166)
       super.writeValue(value.toList())
-    } else if let value = value as? CanonicalTileID {
+    } else if let value = value as? TransitionOptions {
       super.writeByte(167)
       super.writeValue(value.toList())
-    } else if let value = value as? StylePropertyValue {
+    } else if let value = value as? CanonicalTileID {
       super.writeByte(168)
       super.writeValue(value.toList())
-    } else if let value = value as? GlyphsRasterizationMode {
+    } else if let value = value as? StylePropertyValue {
       super.writeByte(169)
-      super.writeValue(value.rawValue)
-    } else if let value = value as? ContextMode {
+      super.writeValue(value.toList())
+    } else if let value = value as? GlyphsRasterizationMode {
       super.writeByte(170)
       super.writeValue(value.rawValue)
-    } else if let value = value as? ConstrainMode {
+    } else if let value = value as? ContextMode {
       super.writeByte(171)
       super.writeValue(value.rawValue)
-    } else if let value = value as? ViewportMode {
+    } else if let value = value as? ConstrainMode {
       super.writeByte(172)
       super.writeValue(value.rawValue)
-    } else if let value = value as? NorthOrientation {
+    } else if let value = value as? ViewportMode {
       super.writeByte(173)
       super.writeValue(value.rawValue)
-    } else if let value = value as? _MapWidgetDebugOptions {
+    } else if let value = value as? NorthOrientation {
       super.writeByte(174)
       super.writeValue(value.rawValue)
-    } else if let value = value as? MapDebugOptionsData {
+    } else if let value = value as? _MapWidgetDebugOptions {
       super.writeByte(175)
       super.writeValue(value.rawValue)
-    } else if let value = value as? ViewAnnotationAnchor {
+    } else if let value = value as? MapDebugOptionsData {
       super.writeByte(176)
       super.writeValue(value.rawValue)
-    } else if let value = value as? Type {
+    } else if let value = value as? ViewAnnotationAnchor {
       super.writeByte(177)
       super.writeValue(value.rawValue)
-    } else if let value = value as? StylePackErrorType {
+    } else if let value = value as? Type {
       super.writeByte(178)
       super.writeValue(value.rawValue)
-    } else if let value = value as? ResponseErrorReason {
+    } else if let value = value as? StylePackErrorType {
       super.writeByte(179)
       super.writeValue(value.rawValue)
-    } else if let value = value as? OfflineRegionDownloadState {
+    } else if let value = value as? ResponseErrorReason {
       super.writeByte(180)
       super.writeValue(value.rawValue)
-    } else if let value = value as? TileStoreUsageMode {
+    } else if let value = value as? OfflineRegionDownloadState {
       super.writeByte(181)
       super.writeValue(value.rawValue)
-    } else if let value = value as? StylePropertyValueKind {
+    } else if let value = value as? TileStoreUsageMode {
       super.writeByte(182)
       super.writeValue(value.rawValue)
-    } else if let value = value as? StyleProjectionName {
+    } else if let value = value as? StylePropertyValueKind {
       super.writeByte(183)
       super.writeValue(value.rawValue)
-    } else if let value = value as? Anchor {
+    } else if let value = value as? StyleProjectionName {
       super.writeByte(184)
       super.writeValue(value.rawValue)
-    } else if let value = value as? HttpMethod {
+    } else if let value = value as? Anchor {
       super.writeByte(185)
       super.writeValue(value.rawValue)
-    } else if let value = value as? HttpRequestErrorType {
+    } else if let value = value as? HttpMethod {
       super.writeByte(186)
       super.writeValue(value.rawValue)
-    } else if let value = value as? DownloadErrorCode {
+    } else if let value = value as? HttpRequestErrorType {
       super.writeByte(187)
       super.writeValue(value.rawValue)
-    } else if let value = value as? DownloadState {
+    } else if let value = value as? DownloadErrorCode {
       super.writeByte(188)
       super.writeValue(value.rawValue)
-    } else if let value = value as? TileDataDomain {
+    } else if let value = value as? DownloadState {
       super.writeByte(189)
       super.writeValue(value.rawValue)
-    } else if let value = value as? TileRegionErrorType {
+    } else if let value = value as? TileDataDomain {
       super.writeByte(190)
       super.writeValue(value.rawValue)
-    } else if let value = value as? _MapEvent {
+    } else if let value = value as? TileRegionErrorType {
       super.writeByte(191)
+      super.writeValue(value.rawValue)
+    } else if let value = value as? _MapEvent {
+      super.writeByte(192)
       super.writeValue(value.rawValue)
     } else {
       super.writeValue(value)
@@ -4340,6 +4346,84 @@ protocol StyleManager {
   ///
   /// @return A string describing an error if the operation was not successful, empty otherwise.
   func setStyleSourceProperties(sourceId: String, properties: String, completion: @escaping (Result<Void, Error>) -> Void)
+  /// Add additional features to a GeoJSON style source.
+  ///
+  /// The add operation will be scheduled and applied on a GeoJSON serialization queue.
+  ///
+  /// In order to capture events when actual data is drawn on the map please refer to Events API
+  /// and listen to `onSourceDataLoaded` (optionally pass the `dataId` parameter to filter the events)
+  /// or `onMapLoadingError` with `type = metadata` if data parsing error has occurred.
+  ///
+  /// Partially updating a GeoJSON source is not compatible with using shared cache and generated IDs.
+  /// It is important to ensure that every feature in the GeoJSON style source, as well as the newly added
+  /// feature, has a unique ID (or a unique promote ID if in use). Failure to provide unique IDs will result
+  /// in a `map-loading-error`.
+  ///
+  /// - Note: The method allows the user to provide a data ID, which will be returned as the `dataId` parameter in the
+  /// `source-data-loaded` event. However, it's important to note that multiple partial updates can be queued
+  /// for the same GeoJSON source when ongoing source parsing is taking place. In these cases, the partial
+  /// updates will be applied to the source in batches. Only the data ID provided in the most recent call within
+  /// each batch will be included in the `source-data-loaded` event. If no data ID is provided in the most recent
+  /// call, the data ID in the `source-data-loaded`event will be null.
+  /// 
+  /// @param sourceId The identifier of the style source.
+  /// @param dataId An arbitrary string used to track the given GeoJSON data.
+  /// @param features An array of GeoJSON features to be added to the source.
+  ///
+  /// @return A string describing an error if the operation was not successful, empty otherwise.
+  func addGeoJSONSourceFeatures(sourceId: String, dataID: String, features: [Feature], completion: @escaping (Result<Void, Error>) -> Void)
+  /// Update existing features in a GeoJSON style source.
+  ///
+  /// The update operation will be scheduled and applied on a GeoJSON serialization queue.
+  ///
+  /// In order to capture events when actual data is drawn on the map please refer to Events API
+  /// and listen to `onSourceDataLoaded` (optionally pass the `dataId` parameter to filter the events)
+  /// or `onMapLoadingError` with `type = metadata` if data parsing error has occurred.
+  ///
+  /// Partially updating a GeoJSON source is not compatible with using shared cache and generated IDs.
+  /// It is important to ensure that every feature in the GeoJSON style source, as well as the newly added
+  /// feature, has a unique ID (or a unique promote ID if in use). Failure to provide unique IDs will result
+  /// in a `map-loading-error`.
+  ///
+  /// - Note: The method allows the user to provide a data ID, which will be returned as the `dataId` parameter in the
+  /// `source-data-loaded` event. However, it's important to note that multiple partial updates can be queued
+  /// for the same GeoJSON source when ongoing source parsing is taking place. In these cases, the partial
+  /// updates will be applied to the source in batches. Only the data ID provided in the most recent call within
+  /// each batch will be included in the `source-data-loaded` event. If no data ID is provided in the most recent
+  /// call, the data ID in the `source-data-loaded`event will be null.
+  /// 
+  /// @param sourceId A style source identifier.
+  /// @param dataId An arbitrary string used to track the given GeoJSON data.
+  /// @param features The GeoJSON features to be updated in the source.
+  /// 
+  /// @return A string describing an error if the operation was not successful, empty otherwise.
+  func updateGeoJSONSourceFeatures(sourceId: String, dataID: String, features: [Feature], completion: @escaping (Result<Void, Error>) -> Void)
+  /// Remove features from a GeoJSON style source.
+  ///
+  /// The remove operation will be scheduled and applied on a GeoJSON serialization queue.
+  ///
+  /// In order to capture events when actual data is drawn on the map please refer to Events API
+  /// and listen to `onSourceDataLoaded` (optionally pass the `dataId` parameter to filter the events)
+  /// or `onMapLoadingError` with `type = metadata` if an error has occurred.
+  ///
+  /// Partially updating a GeoJSON source is not compatible with using shared cache and generated IDs.
+  /// It is important to ensure that every feature in the GeoJSON style source, as well as the newly added
+  /// feature, has a unique ID (or a unique promote ID if in use). Failure to provide unique IDs will result
+  /// in a `map-loading-error`.
+  ///
+  /// - Note: The method allows the user to provide a data ID, which will be returned as the `dataId` parameter in the
+  /// `source-data-loaded` event. However, it's important to note that multiple partial updates can be queued
+  /// for the same GeoJSON source when ongoing source parsing is taking place. In these cases, the partial
+  /// updates will be applied to the source in batches. Only the data ID provided in the most recent call within
+  /// each batch will be included in the `source-data-loaded` event. If no data ID is provided in the most recent
+  /// call, the data ID in the `source-data-loaded`event will be null.
+  /// 
+  /// @param sourceId A style source identifier.
+  /// @param dataId An arbitrary string used to track the given GeoJSON data.
+  /// @param featureIds The Ids of the features that need to be removed from the source.
+  /// 
+  /// @return A string describing an error if the operation was not successful, empty otherwise.
+  func removeGeoJSONSourceFeatures(sourceId: String, dataID: String, featureIds: [String], completion: @escaping (Result<Void, Error>) -> Void)
   /// Updates the image of an [image style source](https://docs.mapbox.com/mapbox-gl-js/style-spec/#sources-image).
   ///
   /// @param sourceId A style source identifier.
@@ -5182,6 +5266,138 @@ class StyleManagerSetup {
       }
     } else {
       setStyleSourcePropertiesChannel.setMessageHandler(nil)
+    }
+    /// Add additional features to a GeoJSON style source.
+    ///
+    /// The add operation will be scheduled and applied on a GeoJSON serialization queue.
+    ///
+    /// In order to capture events when actual data is drawn on the map please refer to Events API
+    /// and listen to `onSourceDataLoaded` (optionally pass the `dataId` parameter to filter the events)
+    /// or `onMapLoadingError` with `type = metadata` if data parsing error has occurred.
+    ///
+    /// Partially updating a GeoJSON source is not compatible with using shared cache and generated IDs.
+    /// It is important to ensure that every feature in the GeoJSON style source, as well as the newly added
+    /// feature, has a unique ID (or a unique promote ID if in use). Failure to provide unique IDs will result
+    /// in a `map-loading-error`.
+    ///
+    /// - Note: The method allows the user to provide a data ID, which will be returned as the `dataId` parameter in the
+    /// `source-data-loaded` event. However, it's important to note that multiple partial updates can be queued
+    /// for the same GeoJSON source when ongoing source parsing is taking place. In these cases, the partial
+    /// updates will be applied to the source in batches. Only the data ID provided in the most recent call within
+    /// each batch will be included in the `source-data-loaded` event. If no data ID is provided in the most recent
+    /// call, the data ID in the `source-data-loaded`event will be null.
+    /// 
+    /// @param sourceId The identifier of the style source.
+    /// @param dataId An arbitrary string used to track the given GeoJSON data.
+    /// @param features An array of GeoJSON features to be added to the source.
+    ///
+    /// @return A string describing an error if the operation was not successful, empty otherwise.
+    let addGeoJSONSourceFeaturesChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.mapbox_maps_flutter.StyleManager.addGeoJSONSourceFeatures\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      addGeoJSONSourceFeaturesChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let sourceIdArg = args[0] as! String
+        let dataIDArg = args[1] as! String
+        let featuresArg = args[2] as! [Feature]
+        api.addGeoJSONSourceFeatures(sourceId: sourceIdArg, dataID: dataIDArg, features: featuresArg) { result in
+          switch result {
+          case .success:
+            reply(wrapResult(nil))
+          case .failure(let error):
+            reply(wrapError(error))
+          }
+        }
+      }
+    } else {
+      addGeoJSONSourceFeaturesChannel.setMessageHandler(nil)
+    }
+    /// Update existing features in a GeoJSON style source.
+    ///
+    /// The update operation will be scheduled and applied on a GeoJSON serialization queue.
+    ///
+    /// In order to capture events when actual data is drawn on the map please refer to Events API
+    /// and listen to `onSourceDataLoaded` (optionally pass the `dataId` parameter to filter the events)
+    /// or `onMapLoadingError` with `type = metadata` if data parsing error has occurred.
+    ///
+    /// Partially updating a GeoJSON source is not compatible with using shared cache and generated IDs.
+    /// It is important to ensure that every feature in the GeoJSON style source, as well as the newly added
+    /// feature, has a unique ID (or a unique promote ID if in use). Failure to provide unique IDs will result
+    /// in a `map-loading-error`.
+    ///
+    /// - Note: The method allows the user to provide a data ID, which will be returned as the `dataId` parameter in the
+    /// `source-data-loaded` event. However, it's important to note that multiple partial updates can be queued
+    /// for the same GeoJSON source when ongoing source parsing is taking place. In these cases, the partial
+    /// updates will be applied to the source in batches. Only the data ID provided in the most recent call within
+    /// each batch will be included in the `source-data-loaded` event. If no data ID is provided in the most recent
+    /// call, the data ID in the `source-data-loaded`event will be null.
+    /// 
+    /// @param sourceId A style source identifier.
+    /// @param dataId An arbitrary string used to track the given GeoJSON data.
+    /// @param features The GeoJSON features to be updated in the source.
+    /// 
+    /// @return A string describing an error if the operation was not successful, empty otherwise.
+    let updateGeoJSONSourceFeaturesChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.mapbox_maps_flutter.StyleManager.updateGeoJSONSourceFeatures\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      updateGeoJSONSourceFeaturesChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let sourceIdArg = args[0] as! String
+        let dataIDArg = args[1] as! String
+        let featuresArg = args[2] as! [Feature]
+        api.updateGeoJSONSourceFeatures(sourceId: sourceIdArg, dataID: dataIDArg, features: featuresArg) { result in
+          switch result {
+          case .success:
+            reply(wrapResult(nil))
+          case .failure(let error):
+            reply(wrapError(error))
+          }
+        }
+      }
+    } else {
+      updateGeoJSONSourceFeaturesChannel.setMessageHandler(nil)
+    }
+    /// Remove features from a GeoJSON style source.
+    ///
+    /// The remove operation will be scheduled and applied on a GeoJSON serialization queue.
+    ///
+    /// In order to capture events when actual data is drawn on the map please refer to Events API
+    /// and listen to `onSourceDataLoaded` (optionally pass the `dataId` parameter to filter the events)
+    /// or `onMapLoadingError` with `type = metadata` if an error has occurred.
+    ///
+    /// Partially updating a GeoJSON source is not compatible with using shared cache and generated IDs.
+    /// It is important to ensure that every feature in the GeoJSON style source, as well as the newly added
+    /// feature, has a unique ID (or a unique promote ID if in use). Failure to provide unique IDs will result
+    /// in a `map-loading-error`.
+    ///
+    /// - Note: The method allows the user to provide a data ID, which will be returned as the `dataId` parameter in the
+    /// `source-data-loaded` event. However, it's important to note that multiple partial updates can be queued
+    /// for the same GeoJSON source when ongoing source parsing is taking place. In these cases, the partial
+    /// updates will be applied to the source in batches. Only the data ID provided in the most recent call within
+    /// each batch will be included in the `source-data-loaded` event. If no data ID is provided in the most recent
+    /// call, the data ID in the `source-data-loaded`event will be null.
+    /// 
+    /// @param sourceId A style source identifier.
+    /// @param dataId An arbitrary string used to track the given GeoJSON data.
+    /// @param featureIds The Ids of the features that need to be removed from the source.
+    /// 
+    /// @return A string describing an error if the operation was not successful, empty otherwise.
+    let removeGeoJSONSourceFeaturesChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.mapbox_maps_flutter.StyleManager.removeGeoJSONSourceFeatures\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      removeGeoJSONSourceFeaturesChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let sourceIdArg = args[0] as! String
+        let dataIDArg = args[1] as! String
+        let featureIdsArg = args[2] as! [String]
+        api.removeGeoJSONSourceFeatures(sourceId: sourceIdArg, dataID: dataIDArg, featureIds: featureIdsArg) { result in
+          switch result {
+          case .success:
+            reply(wrapResult(nil))
+          case .failure(let error):
+            reply(wrapError(error))
+          }
+        }
+      }
+    } else {
+      removeGeoJSONSourceFeaturesChannel.setMessageHandler(nil)
     }
     /// Updates the image of an [image style source](https://docs.mapbox.com/mapbox-gl-js/style-spec/#sources-image).
     ///

--- a/ios/Classes/StyleController.swift
+++ b/ios/Classes/StyleController.swift
@@ -210,18 +210,18 @@ final class StyleController: StyleManager {
         }
     }
 
-    func addGeoJSONSourceFeatures(sourceId: String, dataID: String, features: [Feature], completion: @escaping (Result<Void, Error>) -> Void) {
-        styleManager.addGeoJSONSourceFeatures(forSourceId: sourceId, features: features, dataId: dataID)
+    func addGeoJSONSourceFeatures(sourceId: String, dataId: String, features: [Feature], completion: @escaping (Result<Void, Error>) -> Void) {
+        styleManager.addGeoJSONSourceFeatures(forSourceId: sourceId, features: features, dataId: dataId)
         completion(.success(()))
     }
 
-    func updateGeoJSONSourceFeatures(sourceId: String, dataID: String, features: [Feature], completion: @escaping (Result<Void, Error>) -> Void) {
-        styleManager.updateGeoJSONSourceFeatures(forSourceId: sourceId, features: features, dataId: dataID)
+    func updateGeoJSONSourceFeatures(sourceId: String, dataId: String, features: [Feature], completion: @escaping (Result<Void, Error>) -> Void) {
+        styleManager.updateGeoJSONSourceFeatures(forSourceId: sourceId, features: features, dataId: dataId)
         completion(.success(()))
     }
 
-    func removeGeoJSONSourceFeatures(sourceId: String, dataID: String, featureIds: [String], completion: @escaping (Result<Void, Error>) -> Void) {
-        styleManager.removeGeoJSONSourceFeatures(forSourceId: sourceId, featureIds: featureIds, dataId: dataID)
+    func removeGeoJSONSourceFeatures(sourceId: String, dataId: String, featureIds: [String], completion: @escaping (Result<Void, Error>) -> Void) {
+        styleManager.removeGeoJSONSourceFeatures(forSourceId: sourceId, featureIds: featureIds, dataId: dataId)
         completion(.success(()))
     }
 

--- a/ios/Classes/StyleController.swift
+++ b/ios/Classes/StyleController.swift
@@ -210,6 +210,21 @@ final class StyleController: StyleManager {
         }
     }
 
+    func addGeoJSONSourceFeatures(sourceId: String, dataID: String, features: [Feature], completion: @escaping (Result<Void, Error>) -> Void) {
+        styleManager.addGeoJSONSourceFeatures(forSourceId: sourceId, features: features, dataId: dataID)
+        completion(.success(()))
+    }
+
+    func updateGeoJSONSourceFeatures(sourceId: String, dataID: String, features: [Feature], completion: @escaping (Result<Void, Error>) -> Void) {
+        styleManager.updateGeoJSONSourceFeatures(forSourceId: sourceId, features: features, dataId: dataID)
+        completion(.success(()))
+    }
+
+    func removeGeoJSONSourceFeatures(sourceId: String, dataID: String, featureIds: [String], completion: @escaping (Result<Void, Error>) -> Void) {
+        styleManager.removeGeoJSONSourceFeatures(forSourceId: sourceId, featureIds: featureIds, dataId: dataID)
+        completion(.success(()))
+    }
+
     func updateStyleImageSourceImage(sourceId: String, image: MbxImage, completion: @escaping (Result<Void, Error>) -> Void) {
         guard let image = UIImage(data: image.data.data, scale: UIScreen.main.scale) else { return }
         do {

--- a/ios/Classes/TurfAdapters.swift
+++ b/ios/Classes/TurfAdapters.swift
@@ -54,6 +54,22 @@ extension Polygon {
     }
 }
 
+extension Feature {
+    static func fromList(_ list: [Any?]) -> Feature? {
+        guard let raw = list.first as? [String: Any],
+              let jsonData = try? JSONSerialization.data(withJSONObject: raw, options: []),
+              let feature = try? JSONDecoder().decode(Feature.self, from: jsonData) else { return nil }
+
+        return feature
+    }
+
+    func toList() -> [Any?] {
+        return [
+            self.toMap()
+        ]
+    }
+}
+
 extension LocationCoordinate2D {
 
     fileprivate init(values: [Double]) {

--- a/lib/src/pigeons/map_interfaces.dart
+++ b/lib/src/pigeons/map_interfaces.dart
@@ -5774,7 +5774,7 @@ class StyleManager {
   ///
   /// @return A string describing an error if the operation was not successful, empty otherwise.
   Future<void> addGeoJSONSourceFeatures(
-      String sourceId, String dataID, List<Feature?> features) async {
+      String sourceId, String dataId, List<Feature?> features) async {
     final String __pigeon_channelName =
         'dev.flutter.pigeon.mapbox_maps_flutter.StyleManager.addGeoJSONSourceFeatures$__pigeon_messageChannelSuffix';
     final BasicMessageChannel<Object?> __pigeon_channel =
@@ -5784,7 +5784,7 @@ class StyleManager {
       binaryMessenger: __pigeon_binaryMessenger,
     );
     final List<Object?>? __pigeon_replyList = await __pigeon_channel
-        .send(<Object?>[sourceId, dataID, features]) as List<Object?>?;
+        .send(<Object?>[sourceId, dataId, features]) as List<Object?>?;
     if (__pigeon_replyList == null) {
       throw _createConnectionError(__pigeon_channelName);
     } else if (__pigeon_replyList.length > 1) {
@@ -5824,7 +5824,7 @@ class StyleManager {
   ///
   /// @return A string describing an error if the operation was not successful, empty otherwise.
   Future<void> updateGeoJSONSourceFeatures(
-      String sourceId, String dataID, List<Feature?> features) async {
+      String sourceId, String dataId, List<Feature?> features) async {
     final String __pigeon_channelName =
         'dev.flutter.pigeon.mapbox_maps_flutter.StyleManager.updateGeoJSONSourceFeatures$__pigeon_messageChannelSuffix';
     final BasicMessageChannel<Object?> __pigeon_channel =
@@ -5834,7 +5834,7 @@ class StyleManager {
       binaryMessenger: __pigeon_binaryMessenger,
     );
     final List<Object?>? __pigeon_replyList = await __pigeon_channel
-        .send(<Object?>[sourceId, dataID, features]) as List<Object?>?;
+        .send(<Object?>[sourceId, dataId, features]) as List<Object?>?;
     if (__pigeon_replyList == null) {
       throw _createConnectionError(__pigeon_channelName);
     } else if (__pigeon_replyList.length > 1) {
@@ -5874,7 +5874,7 @@ class StyleManager {
   ///
   /// @return A string describing an error if the operation was not successful, empty otherwise.
   Future<void> removeGeoJSONSourceFeatures(
-      String sourceId, String dataID, List<String?> featureIds) async {
+      String sourceId, String dataId, List<String?> featureIds) async {
     final String __pigeon_channelName =
         'dev.flutter.pigeon.mapbox_maps_flutter.StyleManager.removeGeoJSONSourceFeatures$__pigeon_messageChannelSuffix';
     final BasicMessageChannel<Object?> __pigeon_channel =
@@ -5884,7 +5884,7 @@ class StyleManager {
       binaryMessenger: __pigeon_binaryMessenger,
     );
     final List<Object?>? __pigeon_replyList = await __pigeon_channel
-        .send(<Object?>[sourceId, dataID, featureIds]) as List<Object?>?;
+        .send(<Object?>[sourceId, dataId, featureIds]) as List<Object?>?;
     if (__pigeon_replyList == null) {
       throw _createConnectionError(__pigeon_channelName);
     } else if (__pigeon_replyList.length > 1) {

--- a/lib/src/pigeons/map_interfaces.dart
+++ b/lib/src/pigeons/map_interfaces.dart
@@ -1856,191 +1856,194 @@ class MapInterfaces_PigeonCodec extends StandardMessageCodec {
     if (value is Point) {
       buffer.putUint8(129);
       writeValue(buffer, value.encode());
-    } else if (value is GlyphsRasterizationOptions) {
+    } else if (value is Feature) {
       buffer.putUint8(130);
       writeValue(buffer, value.encode());
-    } else if (value is TileCoverOptions) {
+    } else if (value is GlyphsRasterizationOptions) {
       buffer.putUint8(131);
       writeValue(buffer, value.encode());
-    } else if (value is MbxEdgeInsets) {
+    } else if (value is TileCoverOptions) {
       buffer.putUint8(132);
       writeValue(buffer, value.encode());
-    } else if (value is CameraOptions) {
+    } else if (value is MbxEdgeInsets) {
       buffer.putUint8(133);
       writeValue(buffer, value.encode());
-    } else if (value is CameraState) {
+    } else if (value is CameraOptions) {
       buffer.putUint8(134);
       writeValue(buffer, value.encode());
-    } else if (value is CameraBoundsOptions) {
+    } else if (value is CameraState) {
       buffer.putUint8(135);
       writeValue(buffer, value.encode());
-    } else if (value is CameraBounds) {
+    } else if (value is CameraBoundsOptions) {
       buffer.putUint8(136);
       writeValue(buffer, value.encode());
-    } else if (value is MapAnimationOptions) {
+    } else if (value is CameraBounds) {
       buffer.putUint8(137);
       writeValue(buffer, value.encode());
-    } else if (value is CoordinateBounds) {
+    } else if (value is MapAnimationOptions) {
       buffer.putUint8(138);
       writeValue(buffer, value.encode());
-    } else if (value is _MapWidgetDebugOptionsBox) {
+    } else if (value is CoordinateBounds) {
       buffer.putUint8(139);
       writeValue(buffer, value.encode());
-    } else if (value is MapDebugOptions) {
+    } else if (value is _MapWidgetDebugOptionsBox) {
       buffer.putUint8(140);
       writeValue(buffer, value.encode());
-    } else if (value is TileCacheBudgetInMegabytes) {
+    } else if (value is MapDebugOptions) {
       buffer.putUint8(141);
       writeValue(buffer, value.encode());
-    } else if (value is TileCacheBudgetInTiles) {
+    } else if (value is TileCacheBudgetInMegabytes) {
       buffer.putUint8(142);
       writeValue(buffer, value.encode());
-    } else if (value is MapOptions) {
+    } else if (value is TileCacheBudgetInTiles) {
       buffer.putUint8(143);
       writeValue(buffer, value.encode());
-    } else if (value is ScreenCoordinate) {
+    } else if (value is MapOptions) {
       buffer.putUint8(144);
       writeValue(buffer, value.encode());
-    } else if (value is ScreenBox) {
+    } else if (value is ScreenCoordinate) {
       buffer.putUint8(145);
       writeValue(buffer, value.encode());
-    } else if (value is CoordinateBoundsZoom) {
+    } else if (value is ScreenBox) {
       buffer.putUint8(146);
       writeValue(buffer, value.encode());
-    } else if (value is Size) {
+    } else if (value is CoordinateBoundsZoom) {
       buffer.putUint8(147);
       writeValue(buffer, value.encode());
-    } else if (value is RenderedQueryOptions) {
+    } else if (value is Size) {
       buffer.putUint8(148);
       writeValue(buffer, value.encode());
-    } else if (value is SourceQueryOptions) {
+    } else if (value is RenderedQueryOptions) {
       buffer.putUint8(149);
       writeValue(buffer, value.encode());
-    } else if (value is FeatureExtensionValue) {
+    } else if (value is SourceQueryOptions) {
       buffer.putUint8(150);
       writeValue(buffer, value.encode());
-    } else if (value is LayerPosition) {
+    } else if (value is FeatureExtensionValue) {
       buffer.putUint8(151);
       writeValue(buffer, value.encode());
-    } else if (value is QueriedRenderedFeature) {
+    } else if (value is LayerPosition) {
       buffer.putUint8(152);
       writeValue(buffer, value.encode());
-    } else if (value is QueriedSourceFeature) {
+    } else if (value is QueriedRenderedFeature) {
       buffer.putUint8(153);
       writeValue(buffer, value.encode());
-    } else if (value is QueriedFeature) {
+    } else if (value is QueriedSourceFeature) {
       buffer.putUint8(154);
       writeValue(buffer, value.encode());
-    } else if (value is RenderedQueryGeometry) {
+    } else if (value is QueriedFeature) {
       buffer.putUint8(155);
       writeValue(buffer, value.encode());
-    } else if (value is ProjectedMeters) {
+    } else if (value is RenderedQueryGeometry) {
       buffer.putUint8(156);
       writeValue(buffer, value.encode());
-    } else if (value is MercatorCoordinate) {
+    } else if (value is ProjectedMeters) {
       buffer.putUint8(157);
       writeValue(buffer, value.encode());
-    } else if (value is StyleObjectInfo) {
+    } else if (value is MercatorCoordinate) {
       buffer.putUint8(158);
       writeValue(buffer, value.encode());
-    } else if (value is StyleProjection) {
+    } else if (value is StyleObjectInfo) {
       buffer.putUint8(159);
       writeValue(buffer, value.encode());
-    } else if (value is FlatLight) {
+    } else if (value is StyleProjection) {
       buffer.putUint8(160);
       writeValue(buffer, value.encode());
-    } else if (value is DirectionalLight) {
+    } else if (value is FlatLight) {
       buffer.putUint8(161);
       writeValue(buffer, value.encode());
-    } else if (value is AmbientLight) {
+    } else if (value is DirectionalLight) {
       buffer.putUint8(162);
       writeValue(buffer, value.encode());
-    } else if (value is MbxImage) {
+    } else if (value is AmbientLight) {
       buffer.putUint8(163);
       writeValue(buffer, value.encode());
-    } else if (value is ImageStretches) {
+    } else if (value is MbxImage) {
       buffer.putUint8(164);
       writeValue(buffer, value.encode());
-    } else if (value is ImageContent) {
+    } else if (value is ImageStretches) {
       buffer.putUint8(165);
       writeValue(buffer, value.encode());
-    } else if (value is TransitionOptions) {
+    } else if (value is ImageContent) {
       buffer.putUint8(166);
       writeValue(buffer, value.encode());
-    } else if (value is CanonicalTileID) {
+    } else if (value is TransitionOptions) {
       buffer.putUint8(167);
       writeValue(buffer, value.encode());
-    } else if (value is StylePropertyValue) {
+    } else if (value is CanonicalTileID) {
       buffer.putUint8(168);
       writeValue(buffer, value.encode());
-    } else if (value is GlyphsRasterizationMode) {
+    } else if (value is StylePropertyValue) {
       buffer.putUint8(169);
-      writeValue(buffer, value.index);
-    } else if (value is ContextMode) {
+      writeValue(buffer, value.encode());
+    } else if (value is GlyphsRasterizationMode) {
       buffer.putUint8(170);
       writeValue(buffer, value.index);
-    } else if (value is ConstrainMode) {
+    } else if (value is ContextMode) {
       buffer.putUint8(171);
       writeValue(buffer, value.index);
-    } else if (value is ViewportMode) {
+    } else if (value is ConstrainMode) {
       buffer.putUint8(172);
       writeValue(buffer, value.index);
-    } else if (value is NorthOrientation) {
+    } else if (value is ViewportMode) {
       buffer.putUint8(173);
       writeValue(buffer, value.index);
-    } else if (value is _MapWidgetDebugOptions) {
+    } else if (value is NorthOrientation) {
       buffer.putUint8(174);
       writeValue(buffer, value.index);
-    } else if (value is MapDebugOptionsData) {
+    } else if (value is _MapWidgetDebugOptions) {
       buffer.putUint8(175);
       writeValue(buffer, value.index);
-    } else if (value is ViewAnnotationAnchor) {
+    } else if (value is MapDebugOptionsData) {
       buffer.putUint8(176);
       writeValue(buffer, value.index);
-    } else if (value is Type) {
+    } else if (value is ViewAnnotationAnchor) {
       buffer.putUint8(177);
       writeValue(buffer, value.index);
-    } else if (value is StylePackErrorType) {
+    } else if (value is Type) {
       buffer.putUint8(178);
       writeValue(buffer, value.index);
-    } else if (value is ResponseErrorReason) {
+    } else if (value is StylePackErrorType) {
       buffer.putUint8(179);
       writeValue(buffer, value.index);
-    } else if (value is OfflineRegionDownloadState) {
+    } else if (value is ResponseErrorReason) {
       buffer.putUint8(180);
       writeValue(buffer, value.index);
-    } else if (value is TileStoreUsageMode) {
+    } else if (value is OfflineRegionDownloadState) {
       buffer.putUint8(181);
       writeValue(buffer, value.index);
-    } else if (value is StylePropertyValueKind) {
+    } else if (value is TileStoreUsageMode) {
       buffer.putUint8(182);
       writeValue(buffer, value.index);
-    } else if (value is StyleProjectionName) {
+    } else if (value is StylePropertyValueKind) {
       buffer.putUint8(183);
       writeValue(buffer, value.index);
-    } else if (value is Anchor) {
+    } else if (value is StyleProjectionName) {
       buffer.putUint8(184);
       writeValue(buffer, value.index);
-    } else if (value is HttpMethod) {
+    } else if (value is Anchor) {
       buffer.putUint8(185);
       writeValue(buffer, value.index);
-    } else if (value is HttpRequestErrorType) {
+    } else if (value is HttpMethod) {
       buffer.putUint8(186);
       writeValue(buffer, value.index);
-    } else if (value is DownloadErrorCode) {
+    } else if (value is HttpRequestErrorType) {
       buffer.putUint8(187);
       writeValue(buffer, value.index);
-    } else if (value is DownloadState) {
+    } else if (value is DownloadErrorCode) {
       buffer.putUint8(188);
       writeValue(buffer, value.index);
-    } else if (value is TileDataDomain) {
+    } else if (value is DownloadState) {
       buffer.putUint8(189);
       writeValue(buffer, value.index);
-    } else if (value is TileRegionErrorType) {
+    } else if (value is TileDataDomain) {
       buffer.putUint8(190);
       writeValue(buffer, value.index);
-    } else if (value is _MapEvent) {
+    } else if (value is TileRegionErrorType) {
       buffer.putUint8(191);
+      writeValue(buffer, value.index);
+    } else if (value is _MapEvent) {
+      buffer.putUint8(192);
       writeValue(buffer, value.index);
     } else {
       super.writeValue(buffer, value);
@@ -2053,150 +2056,152 @@ class MapInterfaces_PigeonCodec extends StandardMessageCodec {
       case 129:
         return Point.decode(readValue(buffer)!);
       case 130:
-        return GlyphsRasterizationOptions.decode(readValue(buffer)!);
+        return Feature.decode(readValue(buffer)!);
       case 131:
-        return TileCoverOptions.decode(readValue(buffer)!);
+        return GlyphsRasterizationOptions.decode(readValue(buffer)!);
       case 132:
-        return MbxEdgeInsets.decode(readValue(buffer)!);
+        return TileCoverOptions.decode(readValue(buffer)!);
       case 133:
-        return CameraOptions.decode(readValue(buffer)!);
+        return MbxEdgeInsets.decode(readValue(buffer)!);
       case 134:
-        return CameraState.decode(readValue(buffer)!);
+        return CameraOptions.decode(readValue(buffer)!);
       case 135:
-        return CameraBoundsOptions.decode(readValue(buffer)!);
+        return CameraState.decode(readValue(buffer)!);
       case 136:
-        return CameraBounds.decode(readValue(buffer)!);
+        return CameraBoundsOptions.decode(readValue(buffer)!);
       case 137:
-        return MapAnimationOptions.decode(readValue(buffer)!);
+        return CameraBounds.decode(readValue(buffer)!);
       case 138:
-        return CoordinateBounds.decode(readValue(buffer)!);
+        return MapAnimationOptions.decode(readValue(buffer)!);
       case 139:
-        return _MapWidgetDebugOptionsBox.decode(readValue(buffer)!);
+        return CoordinateBounds.decode(readValue(buffer)!);
       case 140:
-        return MapDebugOptions.decode(readValue(buffer)!);
+        return _MapWidgetDebugOptionsBox.decode(readValue(buffer)!);
       case 141:
-        return TileCacheBudgetInMegabytes.decode(readValue(buffer)!);
+        return MapDebugOptions.decode(readValue(buffer)!);
       case 142:
-        return TileCacheBudgetInTiles.decode(readValue(buffer)!);
+        return TileCacheBudgetInMegabytes.decode(readValue(buffer)!);
       case 143:
-        return MapOptions.decode(readValue(buffer)!);
+        return TileCacheBudgetInTiles.decode(readValue(buffer)!);
       case 144:
-        return ScreenCoordinate.decode(readValue(buffer)!);
+        return MapOptions.decode(readValue(buffer)!);
       case 145:
-        return ScreenBox.decode(readValue(buffer)!);
+        return ScreenCoordinate.decode(readValue(buffer)!);
       case 146:
-        return CoordinateBoundsZoom.decode(readValue(buffer)!);
+        return ScreenBox.decode(readValue(buffer)!);
       case 147:
-        return Size.decode(readValue(buffer)!);
+        return CoordinateBoundsZoom.decode(readValue(buffer)!);
       case 148:
-        return RenderedQueryOptions.decode(readValue(buffer)!);
+        return Size.decode(readValue(buffer)!);
       case 149:
-        return SourceQueryOptions.decode(readValue(buffer)!);
+        return RenderedQueryOptions.decode(readValue(buffer)!);
       case 150:
-        return FeatureExtensionValue.decode(readValue(buffer)!);
+        return SourceQueryOptions.decode(readValue(buffer)!);
       case 151:
-        return LayerPosition.decode(readValue(buffer)!);
+        return FeatureExtensionValue.decode(readValue(buffer)!);
       case 152:
-        return QueriedRenderedFeature.decode(readValue(buffer)!);
+        return LayerPosition.decode(readValue(buffer)!);
       case 153:
-        return QueriedSourceFeature.decode(readValue(buffer)!);
+        return QueriedRenderedFeature.decode(readValue(buffer)!);
       case 154:
-        return QueriedFeature.decode(readValue(buffer)!);
+        return QueriedSourceFeature.decode(readValue(buffer)!);
       case 155:
-        return RenderedQueryGeometry.decode(readValue(buffer)!);
+        return QueriedFeature.decode(readValue(buffer)!);
       case 156:
-        return ProjectedMeters.decode(readValue(buffer)!);
+        return RenderedQueryGeometry.decode(readValue(buffer)!);
       case 157:
-        return MercatorCoordinate.decode(readValue(buffer)!);
+        return ProjectedMeters.decode(readValue(buffer)!);
       case 158:
-        return StyleObjectInfo.decode(readValue(buffer)!);
+        return MercatorCoordinate.decode(readValue(buffer)!);
       case 159:
-        return StyleProjection.decode(readValue(buffer)!);
+        return StyleObjectInfo.decode(readValue(buffer)!);
       case 160:
-        return FlatLight.decode(readValue(buffer)!);
+        return StyleProjection.decode(readValue(buffer)!);
       case 161:
-        return DirectionalLight.decode(readValue(buffer)!);
+        return FlatLight.decode(readValue(buffer)!);
       case 162:
-        return AmbientLight.decode(readValue(buffer)!);
+        return DirectionalLight.decode(readValue(buffer)!);
       case 163:
-        return MbxImage.decode(readValue(buffer)!);
+        return AmbientLight.decode(readValue(buffer)!);
       case 164:
-        return ImageStretches.decode(readValue(buffer)!);
+        return MbxImage.decode(readValue(buffer)!);
       case 165:
-        return ImageContent.decode(readValue(buffer)!);
+        return ImageStretches.decode(readValue(buffer)!);
       case 166:
-        return TransitionOptions.decode(readValue(buffer)!);
+        return ImageContent.decode(readValue(buffer)!);
       case 167:
-        return CanonicalTileID.decode(readValue(buffer)!);
+        return TransitionOptions.decode(readValue(buffer)!);
       case 168:
-        return StylePropertyValue.decode(readValue(buffer)!);
+        return CanonicalTileID.decode(readValue(buffer)!);
       case 169:
-        final int? value = readValue(buffer) as int?;
-        return value == null ? null : GlyphsRasterizationMode.values[value];
+        return StylePropertyValue.decode(readValue(buffer)!);
       case 170:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : ContextMode.values[value];
+        return value == null ? null : GlyphsRasterizationMode.values[value];
       case 171:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : ConstrainMode.values[value];
+        return value == null ? null : ContextMode.values[value];
       case 172:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : ViewportMode.values[value];
+        return value == null ? null : ConstrainMode.values[value];
       case 173:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : NorthOrientation.values[value];
+        return value == null ? null : ViewportMode.values[value];
       case 174:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : _MapWidgetDebugOptions.values[value];
+        return value == null ? null : NorthOrientation.values[value];
       case 175:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : MapDebugOptionsData.values[value];
+        return value == null ? null : _MapWidgetDebugOptions.values[value];
       case 176:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : ViewAnnotationAnchor.values[value];
+        return value == null ? null : MapDebugOptionsData.values[value];
       case 177:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : Type.values[value];
+        return value == null ? null : ViewAnnotationAnchor.values[value];
       case 178:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : StylePackErrorType.values[value];
+        return value == null ? null : Type.values[value];
       case 179:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : ResponseErrorReason.values[value];
+        return value == null ? null : StylePackErrorType.values[value];
       case 180:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : OfflineRegionDownloadState.values[value];
+        return value == null ? null : ResponseErrorReason.values[value];
       case 181:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : TileStoreUsageMode.values[value];
+        return value == null ? null : OfflineRegionDownloadState.values[value];
       case 182:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : StylePropertyValueKind.values[value];
+        return value == null ? null : TileStoreUsageMode.values[value];
       case 183:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : StyleProjectionName.values[value];
+        return value == null ? null : StylePropertyValueKind.values[value];
       case 184:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : Anchor.values[value];
+        return value == null ? null : StyleProjectionName.values[value];
       case 185:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : HttpMethod.values[value];
+        return value == null ? null : Anchor.values[value];
       case 186:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : HttpRequestErrorType.values[value];
+        return value == null ? null : HttpMethod.values[value];
       case 187:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : DownloadErrorCode.values[value];
+        return value == null ? null : HttpRequestErrorType.values[value];
       case 188:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : DownloadState.values[value];
+        return value == null ? null : DownloadErrorCode.values[value];
       case 189:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : TileDataDomain.values[value];
+        return value == null ? null : DownloadState.values[value];
       case 190:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : TileRegionErrorType.values[value];
+        return value == null ? null : TileDataDomain.values[value];
       case 191:
+        final int? value = readValue(buffer) as int?;
+        return value == null ? null : TileRegionErrorType.values[value];
+      case 192:
         final int? value = readValue(buffer) as int?;
         return value == null ? null : _MapEvent.values[value];
       default:
@@ -5730,6 +5735,156 @@ class StyleManager {
     );
     final List<Object?>? __pigeon_replyList = await __pigeon_channel
         .send(<Object?>[sourceId, properties]) as List<Object?>?;
+    if (__pigeon_replyList == null) {
+      throw _createConnectionError(__pigeon_channelName);
+    } else if (__pigeon_replyList.length > 1) {
+      throw PlatformException(
+        code: __pigeon_replyList[0]! as String,
+        message: __pigeon_replyList[1] as String?,
+        details: __pigeon_replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
+
+  /// Add additional features to a GeoJSON style source.
+  ///
+  /// The add operation will be scheduled and applied on a GeoJSON serialization queue.
+  ///
+  /// In order to capture events when actual data is drawn on the map please refer to Events API
+  /// and listen to `onSourceDataLoaded` (optionally pass the `dataId` parameter to filter the events)
+  /// or `onMapLoadingError` with `type = metadata` if data parsing error has occurred.
+  ///
+  /// Partially updating a GeoJSON source is not compatible with using shared cache and generated IDs.
+  /// It is important to ensure that every feature in the GeoJSON style source, as well as the newly added
+  /// feature, has a unique ID (or a unique promote ID if in use). Failure to provide unique IDs will result
+  /// in a `map-loading-error`.
+  ///
+  /// - Note: The method allows the user to provide a data ID, which will be returned as the `dataId` parameter in the
+  /// `source-data-loaded` event. However, it's important to note that multiple partial updates can be queued
+  /// for the same GeoJSON source when ongoing source parsing is taking place. In these cases, the partial
+  /// updates will be applied to the source in batches. Only the data ID provided in the most recent call within
+  /// each batch will be included in the `source-data-loaded` event. If no data ID is provided in the most recent
+  /// call, the data ID in the `source-data-loaded`event will be null.
+  ///
+  /// @param sourceId The identifier of the style source.
+  /// @param dataId An arbitrary string used to track the given GeoJSON data.
+  /// @param features An array of GeoJSON features to be added to the source.
+  ///
+  /// @return A string describing an error if the operation was not successful, empty otherwise.
+  Future<void> addGeoJSONSourceFeatures(
+      String sourceId, String dataID, List<Feature?> features) async {
+    final String __pigeon_channelName =
+        'dev.flutter.pigeon.mapbox_maps_flutter.StyleManager.addGeoJSONSourceFeatures$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel =
+        BasicMessageChannel<Object?>(
+      __pigeon_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: __pigeon_binaryMessenger,
+    );
+    final List<Object?>? __pigeon_replyList = await __pigeon_channel
+        .send(<Object?>[sourceId, dataID, features]) as List<Object?>?;
+    if (__pigeon_replyList == null) {
+      throw _createConnectionError(__pigeon_channelName);
+    } else if (__pigeon_replyList.length > 1) {
+      throw PlatformException(
+        code: __pigeon_replyList[0]! as String,
+        message: __pigeon_replyList[1] as String?,
+        details: __pigeon_replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
+
+  /// Update existing features in a GeoJSON style source.
+  ///
+  /// The update operation will be scheduled and applied on a GeoJSON serialization queue.
+  ///
+  /// In order to capture events when actual data is drawn on the map please refer to Events API
+  /// and listen to `onSourceDataLoaded` (optionally pass the `dataId` parameter to filter the events)
+  /// or `onMapLoadingError` with `type = metadata` if data parsing error has occurred.
+  ///
+  /// Partially updating a GeoJSON source is not compatible with using shared cache and generated IDs.
+  /// It is important to ensure that every feature in the GeoJSON style source, as well as the newly added
+  /// feature, has a unique ID (or a unique promote ID if in use). Failure to provide unique IDs will result
+  /// in a `map-loading-error`.
+  ///
+  /// - Note: The method allows the user to provide a data ID, which will be returned as the `dataId` parameter in the
+  /// `source-data-loaded` event. However, it's important to note that multiple partial updates can be queued
+  /// for the same GeoJSON source when ongoing source parsing is taking place. In these cases, the partial
+  /// updates will be applied to the source in batches. Only the data ID provided in the most recent call within
+  /// each batch will be included in the `source-data-loaded` event. If no data ID is provided in the most recent
+  /// call, the data ID in the `source-data-loaded`event will be null.
+  ///
+  /// @param sourceId A style source identifier.
+  /// @param dataId An arbitrary string used to track the given GeoJSON data.
+  /// @param features The GeoJSON features to be updated in the source.
+  ///
+  /// @return A string describing an error if the operation was not successful, empty otherwise.
+  Future<void> updateGeoJSONSourceFeatures(
+      String sourceId, String dataID, List<Feature?> features) async {
+    final String __pigeon_channelName =
+        'dev.flutter.pigeon.mapbox_maps_flutter.StyleManager.updateGeoJSONSourceFeatures$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel =
+        BasicMessageChannel<Object?>(
+      __pigeon_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: __pigeon_binaryMessenger,
+    );
+    final List<Object?>? __pigeon_replyList = await __pigeon_channel
+        .send(<Object?>[sourceId, dataID, features]) as List<Object?>?;
+    if (__pigeon_replyList == null) {
+      throw _createConnectionError(__pigeon_channelName);
+    } else if (__pigeon_replyList.length > 1) {
+      throw PlatformException(
+        code: __pigeon_replyList[0]! as String,
+        message: __pigeon_replyList[1] as String?,
+        details: __pigeon_replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
+
+  /// Remove features from a GeoJSON style source.
+  ///
+  /// The remove operation will be scheduled and applied on a GeoJSON serialization queue.
+  ///
+  /// In order to capture events when actual data is drawn on the map please refer to Events API
+  /// and listen to `onSourceDataLoaded` (optionally pass the `dataId` parameter to filter the events)
+  /// or `onMapLoadingError` with `type = metadata` if an error has occurred.
+  ///
+  /// Partially updating a GeoJSON source is not compatible with using shared cache and generated IDs.
+  /// It is important to ensure that every feature in the GeoJSON style source, as well as the newly added
+  /// feature, has a unique ID (or a unique promote ID if in use). Failure to provide unique IDs will result
+  /// in a `map-loading-error`.
+  ///
+  /// - Note: The method allows the user to provide a data ID, which will be returned as the `dataId` parameter in the
+  /// `source-data-loaded` event. However, it's important to note that multiple partial updates can be queued
+  /// for the same GeoJSON source when ongoing source parsing is taking place. In these cases, the partial
+  /// updates will be applied to the source in batches. Only the data ID provided in the most recent call within
+  /// each batch will be included in the `source-data-loaded` event. If no data ID is provided in the most recent
+  /// call, the data ID in the `source-data-loaded`event will be null.
+  ///
+  /// @param sourceId A style source identifier.
+  /// @param dataId An arbitrary string used to track the given GeoJSON data.
+  /// @param featureIds The Ids of the features that need to be removed from the source.
+  ///
+  /// @return A string describing an error if the operation was not successful, empty otherwise.
+  Future<void> removeGeoJSONSourceFeatures(
+      String sourceId, String dataID, List<String?> featureIds) async {
+    final String __pigeon_channelName =
+        'dev.flutter.pigeon.mapbox_maps_flutter.StyleManager.removeGeoJSONSourceFeatures$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel =
+        BasicMessageChannel<Object?>(
+      __pigeon_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: __pigeon_binaryMessenger,
+    );
+    final List<Object?>? __pigeon_replyList = await __pigeon_channel
+        .send(<Object?>[sourceId, dataID, featureIds]) as List<Object?>?;
     if (__pigeon_replyList == null) {
       throw _createConnectionError(__pigeon_channelName);
     } else if (__pigeon_replyList.length > 1) {

--- a/lib/src/style/style.dart
+++ b/lib/src/style/style.dart
@@ -314,8 +314,8 @@ extension StyleSource on StyleManager {
     if (source is GeoJsonSource && source._data != null) {
       final internalData = source._data!;
 
-      // Add empty data initially so that the source is added and 
-      // volatile properties can be set. Then add the data. 
+      // Add empty data initially so that the source is added and
+      // volatile properties can be set. Then add the data.
       source._data = "";
       await _addSourceInternal(source);
       return source.updateGeoJSON(internalData);

--- a/lib/src/style/style.dart
+++ b/lib/src/style/style.dart
@@ -314,9 +314,11 @@ extension StyleSource on StyleManager {
     final nonVolatileProperties = source._encode(false);
     final volatileProperties = source._encode(true);
     source.bind(this);
-    return addStyleSource(source.id, nonVolatileProperties).then((value) {
-      // volatile properties have to be set after the source has been added to the style
-      setStyleSourceProperties(source.id, volatileProperties);
+    return addStyleSource(source.id, nonVolatileProperties).then((value) async {
+      // volatile properties have to be set after the source has been
+      // added to the style and the nonVolatileProperties have been set
+      await Future.delayed(Duration(milliseconds: 1));
+      return setStyleSourceProperties(source.id, volatileProperties);
     });
   }
 

--- a/lib/src/style/style.dart
+++ b/lib/src/style/style.dart
@@ -311,14 +311,14 @@ extension StyleLayer on StyleManager {
 /// Extension for StyleManager to add/get sources from the current style.
 extension StyleSource on StyleManager {
   Future<void> addSource(Source source) async {
-    if (source is GeoJsonSource && source.internalData != null) {
-      final internalData = source.internalData!;
+    if (source is GeoJsonSource && source._data != null) {
+      final internalData = source._data!;
 
       // Add empty data initially so that the source is added and 
       // volatile properties can be set. Then add the data. 
       source._data = "";
       await _addSourceInternal(source);
-      return source.updateGeoJSON(await internalData);
+      return source.updateGeoJSON(internalData);
     } else {
       return _addSourceInternal(source);
     }
@@ -451,8 +451,4 @@ extension StyleColorList on List {
       return Colors.transparent;
     }
   }
-}
-
-extension GeoJSONSourceInternal on GeoJsonSource {
-  String? get internalData => '$_data';
 }

--- a/lib/src/turf_adapters.dart
+++ b/lib/src/turf_adapters.dart
@@ -59,3 +59,31 @@ final class LineString extends turf.LineString {
   LineString.fromPoints({turf.BBox? bbox, required List<Point> points})
       : super.fromPoints(bbox: bbox, points: points);
 }
+
+final class Feature extends turf.Feature {
+  Feature(
+      {super.bbox,
+      required super.id,
+      super.properties,
+      required super.geometry,
+      super.fields});
+
+  Object encode() {
+    return [toJson()];
+  }
+
+  static Feature decode(Object result) {
+    result as List<Object?>;
+    return Feature.fromJson((result.first as Map).cast<String, dynamic>());
+  }
+
+  factory Feature.fromJson(Map<String, dynamic> json) {
+    final feature = turf.Feature.fromJson(json);
+    return Feature(
+        bbox: feature.bbox,
+        id: feature.id,
+        properties: feature.properties,
+        geometry: feature.geometry,
+        fields: feature.fields);
+  }
+}


### PR DESCRIPTION
### What does this pull request do?

This PR exposes 3 new methods which allow you to add/update/remove GeoJSONSourceFeatures. When you add identifiers associated with each feature, you can change them at runtime rather than needing to set a whole new GeoJSON object. This is especially beneficial for ``GeoJSONSource``s which host a large amount of features - in this case adding a feature can be up to 4x faster with the partial GeoJSON update API.

```dart
mapboxMap.style.addGeoJSONSourceFeatures(sourceId, dataId, features)
mapboxMap.style.updateGeoJSONSourceFeatures(sourceId, dataId, features)
mapboxMap.style.removeGeoJSONSourceFeatures(sourceId, dataId, featureIds)
```

This PR additionally updates the Draw a GeoJSON Line example to show how to use these new methods. Further, it updates `addSource` method to avoid a race condition. 

https://github.com/user-attachments/assets/6badbc71-1eff-4d4b-9021-a68ee6cfd403

### What is the motivation and context behind this change?

Allow developers to update GeoJSON features at runtime. 

### Pull request checklist:
 - [ ] Add a changelog entry.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
