### PR TITLE
Exclude checked-in files from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,10 +55,8 @@ unlinked.ds
 unlinked_spec.ds
 
 # Android related
-**/android/**/gradle-wrapper.jar
 **/android/.gradle
 **/android/captures/
-**/android/gradlew
 **/android/gradlew.bat
 **/android/local.properties
 **/android/**/GeneratedPluginRegistrant.java
@@ -114,3 +112,5 @@ app.*.symbols
 !**/ios/**/default.perspectivev3
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
 !/dev/ci/**/Gemfile.lock
+!**/Podfile.lock
+!**/example/pubspec.lock

--- a/example/android/.gitignore
+++ b/example/android/.gitignore
@@ -1,7 +1,5 @@
-gradle-wrapper.jar
 /.gradle
 /captures/
-/gradlew
 /gradlew.bat
 /local.properties
 GeneratedPluginRegistrant.java


### PR DESCRIPTION
### What does this pull request do?

Inspired by warning cleanup by @pjleonard37, this PR addresses pub pre-publishing validation  warnings related to ignored files being checked in.

I checked and it seems there is a reason to keep these files checked in, so I just removed them from gitignore:
* pubspec.lock - is recommended to be kept for applications https://dart.dev/tools/pub/glossary#lockfile
* Gradle wrappers - https://docs.gradle.org/current/userguide/gradle_wrapper.html#sec:wrapper_generation
* Podfile.lock - https://guides.cocoapods.org/using/using-cocoapods.html

### What is the motivation and context behind this change?

<img width="231" alt="Screenshot 2024-09-19 at 14 57 09" src="https://github.com/user-attachments/assets/1d0b5228-cbc9-468c-b0ff-5188fb6394d6">


### Pull request checklist:
 - [ ] Add a changelog entry.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
