### PR TITLE
Improve style image error reporting

### DIFF
--- a/ios/Classes/StyleController.swift
+++ b/ios/Classes/StyleController.swift
@@ -335,8 +335,8 @@ final class StyleController: StyleManager {
     }
 
     func hasStyleImage(imageId: String, completion: @escaping (Result<Bool, Error>) -> Void) {
-        let image = styleManager.image(withId: imageId)
-        completion(.success(image != nil))
+        let imageExists = styleManager.imageExists(withId: imageId)
+        completion(.success(imageExists))
     }
 
     func invalidateStyleCustomGeometrySourceTile(sourceId: String, tileId: CanonicalTileID, completion: @escaping (Result<Void, Error>) -> Void) {

--- a/ios/Classes/StyleController.swift
+++ b/ios/Classes/StyleController.swift
@@ -226,7 +226,10 @@ final class StyleController: StyleManager {
     }
 
     func updateStyleImageSourceImage(sourceId: String, image: MbxImage, completion: @escaping (Result<Void, Error>) -> Void) {
-        guard let image = UIImage(data: image.data.data, scale: UIScreen.main.scale) else { return }
+        guard let image = UIImage(data: image.data.data, scale: UIScreen.main.scale) else {
+            completion(.failure(FlutterError(code: StyleController.errorCode, message: "Could not initialize the image from the specified data.", details: nil)))
+            return
+        }
         do {
             try styleManager.updateImageSource(withId: sourceId, image: image)
             completion(.success(()))
@@ -295,7 +298,10 @@ final class StyleController: StyleManager {
     }
 
     func addStyleImage(imageId: String, scale: Double, image: MbxImage, sdf: Bool, stretchX: [ImageStretches?], stretchY: [ImageStretches?], content: ImageContent?, completion: @escaping (Result<Void, Error>) -> Void) {
-        guard let image = UIImage(data: image.data.data, scale: scale) else { return }
+        guard let image = UIImage(data: image.data.data, scale: scale) else {
+            completion(.failure(FlutterError(code: StyleController.errorCode, message: "Could not initialize the image from the specified data.", details: nil)))
+            return
+        }
         var imageContent: MapboxMaps.ImageContent?
         if let content {
             imageContent = MapboxMaps.ImageContent(left: Float(content.left),


### PR DESCRIPTION
### What does this pull request do?

This PR adds error throwing on iOS(Android is not susceptible to this) in case data -> UIImage conversion fails. Additionally, I changed `hasStyleImage` to use the dedicated method(`imageExists()`) from the platform side on iOS(Android already uses that).

### What is the motivation and context behind this change?



### Pull request checklist:
 - [ ] Add a changelog entry.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
