### PR TITLE
Remove internal debug options boxing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,7 +182,7 @@ executors:
   macos-xcode-latest:
     resource_class: macos.m1.medium.gen1
     macos:
-      xcode: 15.2.0
+      xcode: 16.0.0
   firebase-test-runner:
     resource_class: small
     docker:

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/MapInterfaceController.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/MapInterfaceController.kt
@@ -25,7 +25,7 @@ import com.mapbox.maps.mapbox_maps.pigeons.TileCacheBudgetInTiles
 import com.mapbox.maps.mapbox_maps.pigeons.TileCoverOptions
 import com.mapbox.maps.mapbox_maps.pigeons.ViewportMode
 import com.mapbox.maps.mapbox_maps.pigeons._MapInterface
-import com.mapbox.maps.mapbox_maps.pigeons._MapWidgetDebugOptionsBox
+import com.mapbox.maps.mapbox_maps.pigeons._MapWidgetDebugOptions
 import com.mapbox.maps.plugin.delegates.listeners.OnMapLoadErrorListener
 
 class MapInterfaceController(
@@ -123,14 +123,14 @@ class MapInterfaceController(
     return mapboxMap.getMapOptions().toFLTMapOptions(context)
   }
 
-  override fun getDebugOptions(): List<_MapWidgetDebugOptionsBox?> {
+  override fun getDebugOptions(): List<_MapWidgetDebugOptions> {
     return mapView.debugOptions.mapNotNull { nativeOption ->
-      nativeOption.toFLTDebugOptions()?.let { _MapWidgetDebugOptionsBox(it) }
+      nativeOption.toFLTDebugOptions()
     }
   }
 
-  override fun setDebugOptions(debugOptions: List<_MapWidgetDebugOptionsBox>) {
-    mapView.debugOptions = debugOptions.map { it.option.toMapViewDebugOptions() }.toSet()
+  override fun setDebugOptions(debugOptions: List<_MapWidgetDebugOptions>) {
+    mapView.debugOptions = debugOptions.map { it.toMapViewDebugOptions() }.toSet()
   }
 
   override fun getDebug(): List<MapDebugOptions> {

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/MapInterfaces.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/MapInterfaces.kt
@@ -860,27 +860,6 @@ data class CoordinateBounds(
 }
 
 /**
- * This class is needed because Pigeon does not encode properly arrays of enums.
- *
- * Generated class from Pigeon that represents data sent in messages.
- */
-data class _MapWidgetDebugOptionsBox(
-  val option: _MapWidgetDebugOptions
-) {
-  companion object {
-    fun fromList(pigeonVar_list: List<Any?>): _MapWidgetDebugOptionsBox {
-      val option = pigeonVar_list[0] as _MapWidgetDebugOptions
-      return _MapWidgetDebugOptionsBox(option)
-    }
-  }
-  fun toList(): List<Any?> {
-    return listOf(
-      option,
-    )
-  }
-}
-
-/**
  * Options for enabling debugging features in a map.
  *
  * Generated class from Pigeon that represents data sent in messages.
@@ -1957,150 +1936,145 @@ private open class MapInterfacesPigeonCodec : StandardMessageCodec() {
       }
       162.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          _MapWidgetDebugOptionsBox.fromList(it)
+          MapDebugOptions.fromList(it)
         }
       }
       163.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          MapDebugOptions.fromList(it)
+          TileCacheBudgetInMegabytes.fromList(it)
         }
       }
       164.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          TileCacheBudgetInMegabytes.fromList(it)
+          TileCacheBudgetInTiles.fromList(it)
         }
       }
       165.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          TileCacheBudgetInTiles.fromList(it)
+          MapOptions.fromList(it)
         }
       }
       166.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          MapOptions.fromList(it)
+          ScreenCoordinate.fromList(it)
         }
       }
       167.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          ScreenCoordinate.fromList(it)
+          ScreenBox.fromList(it)
         }
       }
       168.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          ScreenBox.fromList(it)
+          CoordinateBoundsZoom.fromList(it)
         }
       }
       169.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          CoordinateBoundsZoom.fromList(it)
+          Size.fromList(it)
         }
       }
       170.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          Size.fromList(it)
+          RenderedQueryOptions.fromList(it)
         }
       }
       171.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          RenderedQueryOptions.fromList(it)
+          SourceQueryOptions.fromList(it)
         }
       }
       172.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          SourceQueryOptions.fromList(it)
+          FeatureExtensionValue.fromList(it)
         }
       }
       173.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          FeatureExtensionValue.fromList(it)
+          LayerPosition.fromList(it)
         }
       }
       174.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          LayerPosition.fromList(it)
+          QueriedRenderedFeature.fromList(it)
         }
       }
       175.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          QueriedRenderedFeature.fromList(it)
+          QueriedSourceFeature.fromList(it)
         }
       }
       176.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          QueriedSourceFeature.fromList(it)
+          QueriedFeature.fromList(it)
         }
       }
       177.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          QueriedFeature.fromList(it)
+          RenderedQueryGeometry.fromList(it)
         }
       }
       178.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          RenderedQueryGeometry.fromList(it)
+          ProjectedMeters.fromList(it)
         }
       }
       179.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          ProjectedMeters.fromList(it)
+          MercatorCoordinate.fromList(it)
         }
       }
       180.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          MercatorCoordinate.fromList(it)
+          StyleObjectInfo.fromList(it)
         }
       }
       181.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          StyleObjectInfo.fromList(it)
+          StyleProjection.fromList(it)
         }
       }
       182.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          StyleProjection.fromList(it)
+          FlatLight.fromList(it)
         }
       }
       183.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          FlatLight.fromList(it)
+          DirectionalLight.fromList(it)
         }
       }
       184.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          DirectionalLight.fromList(it)
+          AmbientLight.fromList(it)
         }
       }
       185.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          AmbientLight.fromList(it)
+          MbxImage.fromList(it)
         }
       }
       186.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          MbxImage.fromList(it)
+          ImageStretches.fromList(it)
         }
       }
       187.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          ImageStretches.fromList(it)
+          ImageContent.fromList(it)
         }
       }
       188.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          ImageContent.fromList(it)
+          TransitionOptions.fromList(it)
         }
       }
       189.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          TransitionOptions.fromList(it)
-        }
-      }
-      190.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let {
           CanonicalTileID.fromList(it)
         }
       }
-      191.toByte() -> {
+      190.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
           StylePropertyValue.fromList(it)
         }
@@ -2242,124 +2216,120 @@ private open class MapInterfacesPigeonCodec : StandardMessageCodec() {
         stream.write(161)
         writeValue(stream, value.toList())
       }
-      is _MapWidgetDebugOptionsBox -> {
+      is MapDebugOptions -> {
         stream.write(162)
         writeValue(stream, value.toList())
       }
-      is MapDebugOptions -> {
+      is TileCacheBudgetInMegabytes -> {
         stream.write(163)
         writeValue(stream, value.toList())
       }
-      is TileCacheBudgetInMegabytes -> {
+      is TileCacheBudgetInTiles -> {
         stream.write(164)
         writeValue(stream, value.toList())
       }
-      is TileCacheBudgetInTiles -> {
+      is MapOptions -> {
         stream.write(165)
         writeValue(stream, value.toList())
       }
-      is MapOptions -> {
+      is ScreenCoordinate -> {
         stream.write(166)
         writeValue(stream, value.toList())
       }
-      is ScreenCoordinate -> {
+      is ScreenBox -> {
         stream.write(167)
         writeValue(stream, value.toList())
       }
-      is ScreenBox -> {
+      is CoordinateBoundsZoom -> {
         stream.write(168)
         writeValue(stream, value.toList())
       }
-      is CoordinateBoundsZoom -> {
+      is Size -> {
         stream.write(169)
         writeValue(stream, value.toList())
       }
-      is Size -> {
+      is RenderedQueryOptions -> {
         stream.write(170)
         writeValue(stream, value.toList())
       }
-      is RenderedQueryOptions -> {
+      is SourceQueryOptions -> {
         stream.write(171)
         writeValue(stream, value.toList())
       }
-      is SourceQueryOptions -> {
+      is FeatureExtensionValue -> {
         stream.write(172)
         writeValue(stream, value.toList())
       }
-      is FeatureExtensionValue -> {
+      is LayerPosition -> {
         stream.write(173)
         writeValue(stream, value.toList())
       }
-      is LayerPosition -> {
+      is QueriedRenderedFeature -> {
         stream.write(174)
         writeValue(stream, value.toList())
       }
-      is QueriedRenderedFeature -> {
+      is QueriedSourceFeature -> {
         stream.write(175)
         writeValue(stream, value.toList())
       }
-      is QueriedSourceFeature -> {
+      is QueriedFeature -> {
         stream.write(176)
         writeValue(stream, value.toList())
       }
-      is QueriedFeature -> {
+      is RenderedQueryGeometry -> {
         stream.write(177)
         writeValue(stream, value.toList())
       }
-      is RenderedQueryGeometry -> {
+      is ProjectedMeters -> {
         stream.write(178)
         writeValue(stream, value.toList())
       }
-      is ProjectedMeters -> {
+      is MercatorCoordinate -> {
         stream.write(179)
         writeValue(stream, value.toList())
       }
-      is MercatorCoordinate -> {
+      is StyleObjectInfo -> {
         stream.write(180)
         writeValue(stream, value.toList())
       }
-      is StyleObjectInfo -> {
+      is StyleProjection -> {
         stream.write(181)
         writeValue(stream, value.toList())
       }
-      is StyleProjection -> {
+      is FlatLight -> {
         stream.write(182)
         writeValue(stream, value.toList())
       }
-      is FlatLight -> {
+      is DirectionalLight -> {
         stream.write(183)
         writeValue(stream, value.toList())
       }
-      is DirectionalLight -> {
+      is AmbientLight -> {
         stream.write(184)
         writeValue(stream, value.toList())
       }
-      is AmbientLight -> {
+      is MbxImage -> {
         stream.write(185)
         writeValue(stream, value.toList())
       }
-      is MbxImage -> {
+      is ImageStretches -> {
         stream.write(186)
         writeValue(stream, value.toList())
       }
-      is ImageStretches -> {
+      is ImageContent -> {
         stream.write(187)
         writeValue(stream, value.toList())
       }
-      is ImageContent -> {
+      is TransitionOptions -> {
         stream.write(188)
         writeValue(stream, value.toList())
       }
-      is TransitionOptions -> {
+      is CanonicalTileID -> {
         stream.write(189)
         writeValue(stream, value.toList())
       }
-      is CanonicalTileID -> {
-        stream.write(190)
-        writeValue(stream, value.toList())
-      }
       is StylePropertyValue -> {
-        stream.write(191)
+        stream.write(190)
         writeValue(stream, value.toList())
       }
       else -> super.writeValue(stream, value)
@@ -3109,8 +3079,8 @@ interface _MapInterface {
    * @return The map's `map options`.
    */
   fun getMapOptions(): MapOptions
-  fun getDebugOptions(): List<_MapWidgetDebugOptionsBox?>
-  fun setDebugOptions(debugOptions: List<_MapWidgetDebugOptionsBox>)
+  fun getDebugOptions(): List<_MapWidgetDebugOptions>
+  fun setDebugOptions(debugOptions: List<_MapWidgetDebugOptions>)
   /**
    * Returns the `map debug options`.
    *
@@ -3548,7 +3518,7 @@ interface _MapInterface {
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
-            val debugOptionsArg = args[0] as List<_MapWidgetDebugOptionsBox>
+            val debugOptionsArg = args[0] as List<_MapWidgetDebugOptions>
             val wrapped: List<Any?> = try {
               api.setDebugOptions(debugOptionsArg)
               listOf(null)

--- a/ios/Classes/Extensions.swift
+++ b/ios/Classes/Extensions.swift
@@ -5,7 +5,7 @@ import Flutter
 
 let COORDINATES = "coordinates"
 
-extension FlutterError: Error { }
+extension FlutterError: @retroactive Error { }
 
 // FLT to Mapbox
 
@@ -610,6 +610,7 @@ func convertDictionaryToString(dict: [String?: Any?]?) -> String {
 }
 
 func convertDictionaryToGeometry(dict: [String?: Any?]?) -> Geometry? {
+    guard let dict else { return nil }
     do {
         let jsonData = try JSONSerialization.data(withJSONObject: dict, options: JSONSerialization.WritingOptions.init(rawValue: 0))
         let geometry = try JSONDecoder().decode(Geometry.self, from: jsonData)

--- a/ios/Classes/Generated/MapInterfaces.swift
+++ b/ios/Classes/Generated/MapInterfaces.swift
@@ -727,27 +727,6 @@ struct CoordinateBounds {
   }
 }
 
-/// This class is needed because Pigeon does not encode properly arrays of enums.
-///
-/// Generated class from Pigeon that represents data sent in messages.
-struct _MapWidgetDebugOptionsBox {
-  var option: _MapWidgetDebugOptions
-
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ pigeonVar_list: [Any?]) -> _MapWidgetDebugOptionsBox? {
-    let option = pigeonVar_list[0] as! _MapWidgetDebugOptions
-
-    return _MapWidgetDebugOptionsBox(
-      option: option
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      option
-    ]
-  }
-}
-
 /// Options for enabling debugging features in a map.
 ///
 /// Generated class from Pigeon that represents data sent in messages.
@@ -1851,64 +1830,62 @@ private class MapInterfacesPigeonCodecReader: FlutterStandardReader {
     case 161:
       return CoordinateBounds.fromList(self.readValue() as! [Any?])
     case 162:
-      return _MapWidgetDebugOptionsBox.fromList(self.readValue() as! [Any?])
-    case 163:
       return MapDebugOptions.fromList(self.readValue() as! [Any?])
-    case 164:
+    case 163:
       return TileCacheBudgetInMegabytes.fromList(self.readValue() as! [Any?])
-    case 165:
+    case 164:
       return TileCacheBudgetInTiles.fromList(self.readValue() as! [Any?])
-    case 166:
+    case 165:
       return MapOptions.fromList(self.readValue() as! [Any?])
-    case 167:
+    case 166:
       return ScreenCoordinate.fromList(self.readValue() as! [Any?])
-    case 168:
+    case 167:
       return ScreenBox.fromList(self.readValue() as! [Any?])
-    case 169:
+    case 168:
       return CoordinateBoundsZoom.fromList(self.readValue() as! [Any?])
-    case 170:
+    case 169:
       return Size.fromList(self.readValue() as! [Any?])
-    case 171:
+    case 170:
       return RenderedQueryOptions.fromList(self.readValue() as! [Any?])
-    case 172:
+    case 171:
       return SourceQueryOptions.fromList(self.readValue() as! [Any?])
-    case 173:
+    case 172:
       return FeatureExtensionValue.fromList(self.readValue() as! [Any?])
-    case 174:
+    case 173:
       return LayerPosition.fromList(self.readValue() as! [Any?])
-    case 175:
+    case 174:
       return QueriedRenderedFeature.fromList(self.readValue() as! [Any?])
-    case 176:
+    case 175:
       return QueriedSourceFeature.fromList(self.readValue() as! [Any?])
-    case 177:
+    case 176:
       return QueriedFeature.fromList(self.readValue() as! [Any?])
-    case 178:
+    case 177:
       return RenderedQueryGeometry.fromList(self.readValue() as! [Any?])
-    case 179:
+    case 178:
       return ProjectedMeters.fromList(self.readValue() as! [Any?])
-    case 180:
+    case 179:
       return MercatorCoordinate.fromList(self.readValue() as! [Any?])
-    case 181:
+    case 180:
       return StyleObjectInfo.fromList(self.readValue() as! [Any?])
-    case 182:
+    case 181:
       return StyleProjection.fromList(self.readValue() as! [Any?])
-    case 183:
+    case 182:
       return FlatLight.fromList(self.readValue() as! [Any?])
-    case 184:
+    case 183:
       return DirectionalLight.fromList(self.readValue() as! [Any?])
-    case 185:
+    case 184:
       return AmbientLight.fromList(self.readValue() as! [Any?])
-    case 186:
+    case 185:
       return MbxImage.fromList(self.readValue() as! [Any?])
-    case 187:
+    case 186:
       return ImageStretches.fromList(self.readValue() as! [Any?])
-    case 188:
+    case 187:
       return ImageContent.fromList(self.readValue() as! [Any?])
-    case 189:
+    case 188:
       return TransitionOptions.fromList(self.readValue() as! [Any?])
-    case 190:
+    case 189:
       return CanonicalTileID.fromList(self.readValue() as! [Any?])
-    case 191:
+    case 190:
       return StylePropertyValue.fromList(self.readValue() as! [Any?])
     default:
       return super.readValue(ofType: type)
@@ -2017,95 +1994,92 @@ private class MapInterfacesPigeonCodecWriter: FlutterStandardWriter {
     } else if let value = value as? CoordinateBounds {
       super.writeByte(161)
       super.writeValue(value.toList())
-    } else if let value = value as? _MapWidgetDebugOptionsBox {
+    } else if let value = value as? MapDebugOptions {
       super.writeByte(162)
       super.writeValue(value.toList())
-    } else if let value = value as? MapDebugOptions {
+    } else if let value = value as? TileCacheBudgetInMegabytes {
       super.writeByte(163)
       super.writeValue(value.toList())
-    } else if let value = value as? TileCacheBudgetInMegabytes {
+    } else if let value = value as? TileCacheBudgetInTiles {
       super.writeByte(164)
       super.writeValue(value.toList())
-    } else if let value = value as? TileCacheBudgetInTiles {
+    } else if let value = value as? MapOptions {
       super.writeByte(165)
       super.writeValue(value.toList())
-    } else if let value = value as? MapOptions {
+    } else if let value = value as? ScreenCoordinate {
       super.writeByte(166)
       super.writeValue(value.toList())
-    } else if let value = value as? ScreenCoordinate {
+    } else if let value = value as? ScreenBox {
       super.writeByte(167)
       super.writeValue(value.toList())
-    } else if let value = value as? ScreenBox {
+    } else if let value = value as? CoordinateBoundsZoom {
       super.writeByte(168)
       super.writeValue(value.toList())
-    } else if let value = value as? CoordinateBoundsZoom {
+    } else if let value = value as? Size {
       super.writeByte(169)
       super.writeValue(value.toList())
-    } else if let value = value as? Size {
+    } else if let value = value as? RenderedQueryOptions {
       super.writeByte(170)
       super.writeValue(value.toList())
-    } else if let value = value as? RenderedQueryOptions {
+    } else if let value = value as? SourceQueryOptions {
       super.writeByte(171)
       super.writeValue(value.toList())
-    } else if let value = value as? SourceQueryOptions {
+    } else if let value = value as? FeatureExtensionValue {
       super.writeByte(172)
       super.writeValue(value.toList())
-    } else if let value = value as? FeatureExtensionValue {
+    } else if let value = value as? LayerPosition {
       super.writeByte(173)
       super.writeValue(value.toList())
-    } else if let value = value as? LayerPosition {
+    } else if let value = value as? QueriedRenderedFeature {
       super.writeByte(174)
       super.writeValue(value.toList())
-    } else if let value = value as? QueriedRenderedFeature {
+    } else if let value = value as? QueriedSourceFeature {
       super.writeByte(175)
       super.writeValue(value.toList())
-    } else if let value = value as? QueriedSourceFeature {
+    } else if let value = value as? QueriedFeature {
       super.writeByte(176)
       super.writeValue(value.toList())
-    } else if let value = value as? QueriedFeature {
+    } else if let value = value as? RenderedQueryGeometry {
       super.writeByte(177)
       super.writeValue(value.toList())
-    } else if let value = value as? RenderedQueryGeometry {
+    } else if let value = value as? ProjectedMeters {
       super.writeByte(178)
       super.writeValue(value.toList())
-    } else if let value = value as? ProjectedMeters {
+    } else if let value = value as? MercatorCoordinate {
       super.writeByte(179)
       super.writeValue(value.toList())
-    } else if let value = value as? MercatorCoordinate {
+    } else if let value = value as? StyleObjectInfo {
       super.writeByte(180)
       super.writeValue(value.toList())
-    } else if let value = value as? StyleObjectInfo {
+    } else if let value = value as? StyleProjection {
       super.writeByte(181)
       super.writeValue(value.toList())
-    } else if let value = value as? StyleProjection {
+    } else if let value = value as? FlatLight {
       super.writeByte(182)
       super.writeValue(value.toList())
-    } else if let value = value as? FlatLight {
+    } else if let value = value as? DirectionalLight {
       super.writeByte(183)
       super.writeValue(value.toList())
-    } else if let value = value as? DirectionalLight {
+    } else if let value = value as? AmbientLight {
       super.writeByte(184)
       super.writeValue(value.toList())
-    } else if let value = value as? AmbientLight {
+    } else if let value = value as? MbxImage {
       super.writeByte(185)
       super.writeValue(value.toList())
-    } else if let value = value as? MbxImage {
+    } else if let value = value as? ImageStretches {
       super.writeByte(186)
       super.writeValue(value.toList())
-    } else if let value = value as? ImageStretches {
+    } else if let value = value as? ImageContent {
       super.writeByte(187)
       super.writeValue(value.toList())
-    } else if let value = value as? ImageContent {
+    } else if let value = value as? TransitionOptions {
       super.writeByte(188)
       super.writeValue(value.toList())
-    } else if let value = value as? TransitionOptions {
+    } else if let value = value as? CanonicalTileID {
       super.writeByte(189)
       super.writeValue(value.toList())
-    } else if let value = value as? CanonicalTileID {
-      super.writeByte(190)
-      super.writeValue(value.toList())
     } else if let value = value as? StylePropertyValue {
-      super.writeByte(191)
+      super.writeByte(190)
       super.writeValue(value.toList())
     } else {
       super.writeValue(value)
@@ -2887,8 +2861,8 @@ protocol _MapInterface {
   ///
   /// @return The map's `map options`.
   func getMapOptions() throws -> MapOptions
-  func getDebugOptions() throws -> [_MapWidgetDebugOptionsBox?]
-  func setDebugOptions(debugOptions: [_MapWidgetDebugOptionsBox]) throws
+  func getDebugOptions() throws -> [_MapWidgetDebugOptions]
+  func setDebugOptions(debugOptions: [_MapWidgetDebugOptions]) throws
   /// Returns the `map debug options`.
   ///
   /// @return An array of `map debug options` flags currently set to the map.
@@ -3291,7 +3265,7 @@ class _MapInterfaceSetup {
     if let api = api {
       setDebugOptionsChannel.setMessageHandler { message, reply in
         let args = message as! [Any?]
-        let debugOptionsArg = args[0] as! [_MapWidgetDebugOptionsBox]
+        let debugOptionsArg = args[0] as! [_MapWidgetDebugOptions]
         do {
           try api.setDebugOptions(debugOptions: debugOptionsArg)
           reply(wrapResult(nil))

--- a/ios/Classes/MapInterfaceController.swift
+++ b/ios/Classes/MapInterfaceController.swift
@@ -124,12 +124,12 @@ final class MapInterfaceController: _MapInterface {
         return self.mapboxMap.options.toFLTMapOptions()
     }
 
-    func getDebugOptions() throws -> [_MapWidgetDebugOptionsBox?] {
-        return mapView.debugOptions.toFLTDebugOptions().map(_MapWidgetDebugOptionsBox.init)
+    func getDebugOptions() throws -> [_MapWidgetDebugOptions] {
+        return mapView.debugOptions.toFLTDebugOptions()
     }
 
-    func setDebugOptions(debugOptions: [_MapWidgetDebugOptionsBox]) throws {
-        mapView.debugOptions = debugOptions.map(\.option).toDebugOptions()
+    func setDebugOptions(debugOptions: [_MapWidgetDebugOptions]) throws {
+        mapView.debugOptions = debugOptions.toDebugOptions()
     }
 
     func getDebug() throws -> [MapDebugOptions?] {

--- a/ios/Classes/StyleController.swift
+++ b/ios/Classes/StyleController.swift
@@ -376,7 +376,7 @@ final class StyleController: StyleManager {
 
     func removeStyleImport(importId: String) throws {
         do {
-            try styleManager.removeStyleImport(for: importId)
+            try styleManager.removeStyleImport(withId: importId)
         } catch let styleError {
             throw FlutterError(code: StyleController.errorCode, message: styleError.localizedDescription, details: nil)
         }

--- a/lib/src/mapbox_map.dart
+++ b/lib/src/mapbox_map.dart
@@ -363,15 +363,14 @@ class MapboxMap extends ChangeNotifier {
   /// Debug options for the widget associated with the map.
   Future<List<MapWidgetDebugOptions>> getDebugOptions() async {
     return _mapInterface.getDebugOptions().then((value) {
-      return value.map((e) => e?.option.widgetDebugOptions).nonNulls.toList();
+      return value.map((e) => e.widgetDebugOptions).toList();
     });
   }
 
   /// Set debug options for the widget associated with the map.
   Future<void> setDebugOptions(List<MapWidgetDebugOptions> debugOptions) {
-    return _mapInterface.setDebugOptions(debugOptions
-        .map((e) => _MapWidgetDebugOptionsBox(option: e.option))
-        .toList());
+    return _mapInterface
+        .setDebugOptions(debugOptions.map((e) => e.option).toList());
   }
 
   /// Returns the `map debug options`.

--- a/lib/src/pigeons/map_interfaces.dart
+++ b/lib/src/pigeons/map_interfaces.dart
@@ -778,28 +778,6 @@ class CoordinateBounds {
   }
 }
 
-/// This class is needed because Pigeon does not encode properly arrays of enums.
-class _MapWidgetDebugOptionsBox {
-  _MapWidgetDebugOptionsBox({
-    required this.option,
-  });
-
-  _MapWidgetDebugOptions option;
-
-  Object encode() {
-    return <Object?>[
-      option,
-    ];
-  }
-
-  static _MapWidgetDebugOptionsBox decode(Object result) {
-    result as List<Object?>;
-    return _MapWidgetDebugOptionsBox(
-      option: result[0]! as _MapWidgetDebugOptions,
-    );
-  }
-}
-
 /// Options for enabling debugging features in a map.
 @Deprecated("Use 'MapWidgetDebugOptions' instead")
 class MapDebugOptions {
@@ -1940,95 +1918,92 @@ class MapInterfaces_PigeonCodec extends StandardMessageCodec {
     } else if (value is CoordinateBounds) {
       buffer.putUint8(161);
       writeValue(buffer, value.encode());
-    } else if (value is _MapWidgetDebugOptionsBox) {
+    } else if (value is MapDebugOptions) {
       buffer.putUint8(162);
       writeValue(buffer, value.encode());
-    } else if (value is MapDebugOptions) {
+    } else if (value is TileCacheBudgetInMegabytes) {
       buffer.putUint8(163);
       writeValue(buffer, value.encode());
-    } else if (value is TileCacheBudgetInMegabytes) {
+    } else if (value is TileCacheBudgetInTiles) {
       buffer.putUint8(164);
       writeValue(buffer, value.encode());
-    } else if (value is TileCacheBudgetInTiles) {
+    } else if (value is MapOptions) {
       buffer.putUint8(165);
       writeValue(buffer, value.encode());
-    } else if (value is MapOptions) {
+    } else if (value is ScreenCoordinate) {
       buffer.putUint8(166);
       writeValue(buffer, value.encode());
-    } else if (value is ScreenCoordinate) {
+    } else if (value is ScreenBox) {
       buffer.putUint8(167);
       writeValue(buffer, value.encode());
-    } else if (value is ScreenBox) {
+    } else if (value is CoordinateBoundsZoom) {
       buffer.putUint8(168);
       writeValue(buffer, value.encode());
-    } else if (value is CoordinateBoundsZoom) {
+    } else if (value is Size) {
       buffer.putUint8(169);
       writeValue(buffer, value.encode());
-    } else if (value is Size) {
+    } else if (value is RenderedQueryOptions) {
       buffer.putUint8(170);
       writeValue(buffer, value.encode());
-    } else if (value is RenderedQueryOptions) {
+    } else if (value is SourceQueryOptions) {
       buffer.putUint8(171);
       writeValue(buffer, value.encode());
-    } else if (value is SourceQueryOptions) {
+    } else if (value is FeatureExtensionValue) {
       buffer.putUint8(172);
       writeValue(buffer, value.encode());
-    } else if (value is FeatureExtensionValue) {
+    } else if (value is LayerPosition) {
       buffer.putUint8(173);
       writeValue(buffer, value.encode());
-    } else if (value is LayerPosition) {
+    } else if (value is QueriedRenderedFeature) {
       buffer.putUint8(174);
       writeValue(buffer, value.encode());
-    } else if (value is QueriedRenderedFeature) {
+    } else if (value is QueriedSourceFeature) {
       buffer.putUint8(175);
       writeValue(buffer, value.encode());
-    } else if (value is QueriedSourceFeature) {
+    } else if (value is QueriedFeature) {
       buffer.putUint8(176);
       writeValue(buffer, value.encode());
-    } else if (value is QueriedFeature) {
+    } else if (value is RenderedQueryGeometry) {
       buffer.putUint8(177);
       writeValue(buffer, value.encode());
-    } else if (value is RenderedQueryGeometry) {
+    } else if (value is ProjectedMeters) {
       buffer.putUint8(178);
       writeValue(buffer, value.encode());
-    } else if (value is ProjectedMeters) {
+    } else if (value is MercatorCoordinate) {
       buffer.putUint8(179);
       writeValue(buffer, value.encode());
-    } else if (value is MercatorCoordinate) {
+    } else if (value is StyleObjectInfo) {
       buffer.putUint8(180);
       writeValue(buffer, value.encode());
-    } else if (value is StyleObjectInfo) {
+    } else if (value is StyleProjection) {
       buffer.putUint8(181);
       writeValue(buffer, value.encode());
-    } else if (value is StyleProjection) {
+    } else if (value is FlatLight) {
       buffer.putUint8(182);
       writeValue(buffer, value.encode());
-    } else if (value is FlatLight) {
+    } else if (value is DirectionalLight) {
       buffer.putUint8(183);
       writeValue(buffer, value.encode());
-    } else if (value is DirectionalLight) {
+    } else if (value is AmbientLight) {
       buffer.putUint8(184);
       writeValue(buffer, value.encode());
-    } else if (value is AmbientLight) {
+    } else if (value is MbxImage) {
       buffer.putUint8(185);
       writeValue(buffer, value.encode());
-    } else if (value is MbxImage) {
+    } else if (value is ImageStretches) {
       buffer.putUint8(186);
       writeValue(buffer, value.encode());
-    } else if (value is ImageStretches) {
+    } else if (value is ImageContent) {
       buffer.putUint8(187);
       writeValue(buffer, value.encode());
-    } else if (value is ImageContent) {
+    } else if (value is TransitionOptions) {
       buffer.putUint8(188);
       writeValue(buffer, value.encode());
-    } else if (value is TransitionOptions) {
+    } else if (value is CanonicalTileID) {
       buffer.putUint8(189);
       writeValue(buffer, value.encode());
-    } else if (value is CanonicalTileID) {
-      buffer.putUint8(190);
-      writeValue(buffer, value.encode());
     } else if (value is StylePropertyValue) {
-      buffer.putUint8(191);
+      buffer.putUint8(190);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -2127,64 +2102,62 @@ class MapInterfaces_PigeonCodec extends StandardMessageCodec {
       case 161:
         return CoordinateBounds.decode(readValue(buffer)!);
       case 162:
-        return _MapWidgetDebugOptionsBox.decode(readValue(buffer)!);
-      case 163:
         return MapDebugOptions.decode(readValue(buffer)!);
-      case 164:
+      case 163:
         return TileCacheBudgetInMegabytes.decode(readValue(buffer)!);
-      case 165:
+      case 164:
         return TileCacheBudgetInTiles.decode(readValue(buffer)!);
-      case 166:
+      case 165:
         return MapOptions.decode(readValue(buffer)!);
-      case 167:
+      case 166:
         return ScreenCoordinate.decode(readValue(buffer)!);
-      case 168:
+      case 167:
         return ScreenBox.decode(readValue(buffer)!);
-      case 169:
+      case 168:
         return CoordinateBoundsZoom.decode(readValue(buffer)!);
-      case 170:
+      case 169:
         return Size.decode(readValue(buffer)!);
-      case 171:
+      case 170:
         return RenderedQueryOptions.decode(readValue(buffer)!);
-      case 172:
+      case 171:
         return SourceQueryOptions.decode(readValue(buffer)!);
-      case 173:
+      case 172:
         return FeatureExtensionValue.decode(readValue(buffer)!);
-      case 174:
+      case 173:
         return LayerPosition.decode(readValue(buffer)!);
-      case 175:
+      case 174:
         return QueriedRenderedFeature.decode(readValue(buffer)!);
-      case 176:
+      case 175:
         return QueriedSourceFeature.decode(readValue(buffer)!);
-      case 177:
+      case 176:
         return QueriedFeature.decode(readValue(buffer)!);
-      case 178:
+      case 177:
         return RenderedQueryGeometry.decode(readValue(buffer)!);
-      case 179:
+      case 178:
         return ProjectedMeters.decode(readValue(buffer)!);
-      case 180:
+      case 179:
         return MercatorCoordinate.decode(readValue(buffer)!);
-      case 181:
+      case 180:
         return StyleObjectInfo.decode(readValue(buffer)!);
-      case 182:
+      case 181:
         return StyleProjection.decode(readValue(buffer)!);
-      case 183:
+      case 182:
         return FlatLight.decode(readValue(buffer)!);
-      case 184:
+      case 183:
         return DirectionalLight.decode(readValue(buffer)!);
-      case 185:
+      case 184:
         return AmbientLight.decode(readValue(buffer)!);
-      case 186:
+      case 185:
         return MbxImage.decode(readValue(buffer)!);
-      case 187:
+      case 186:
         return ImageStretches.decode(readValue(buffer)!);
-      case 188:
+      case 187:
         return ImageContent.decode(readValue(buffer)!);
-      case 189:
+      case 188:
         return TransitionOptions.decode(readValue(buffer)!);
-      case 190:
+      case 189:
         return CanonicalTileID.decode(readValue(buffer)!);
-      case 191:
+      case 190:
         return StylePropertyValue.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
@@ -3512,7 +3485,7 @@ class _MapInterface {
     }
   }
 
-  Future<List<_MapWidgetDebugOptionsBox?>> getDebugOptions() async {
+  Future<List<_MapWidgetDebugOptions>> getDebugOptions() async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.mapbox_maps_flutter._MapInterface.getDebugOptions$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =
@@ -3538,12 +3511,12 @@ class _MapInterface {
       );
     } else {
       return (pigeonVar_replyList[0] as List<Object?>?)!
-          .cast<_MapWidgetDebugOptionsBox?>();
+          .cast<_MapWidgetDebugOptions>();
     }
   }
 
   Future<void> setDebugOptions(
-      List<_MapWidgetDebugOptionsBox> debugOptions) async {
+      List<_MapWidgetDebugOptions> debugOptions) async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.mapbox_maps_flutter._MapInterface.setDebugOptions$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel =


### PR DESCRIPTION
### What does this pull request do?

This PR removes `_MapWidgetDebugOptionsBox` that became useless after Pigeon started supporting collections of enums directly, so there is no need for boxing now.
Plus, fixes two minor warnings on iOS side.

### What is the motivation and context behind this change?



### Pull request checklist:
 - [ ] Add a changelog entry.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
