### PR TITLE
Bump Maps SDK to 11.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ final geometry = RenderedQueryGeometry(type: Type.SCREEN_COORDINATE, value jsonE
 // Using a typed constructor
 final geometry = RenderedQueryGeometry.fromScreenCoordinate(screenCoordinate);
 ```
+* Bump Maps SDK to 11.7.0.
 
 ### 2.3.0-rc.1
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -78,7 +78,7 @@ if (file("$rootDir/gradle/ktlint.gradle").exists() && file("$rootDir/gradle/lint
 }
 
 dependencies {
-    implementation "com.mapbox.maps:android:11.7.0-rc.1"
+    implementation "com.mapbox.maps:android:11.7.0"
 
     implementation "androidx.annotation:annotation:1.8.2"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.8.4"

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -4,14 +4,14 @@ PODS:
     - Flutter
   - mapbox_maps_flutter (2.3.0-rc.1):
     - Flutter
-    - MapboxMaps (~> 11.7.0-rc.1)
+    - MapboxMaps (~> 11.7.0)
     - Turf (= 3.0.0)
-  - MapboxCommon (24.7.0-rc.2)
-  - MapboxCoreMaps (11.7.0-rc.2):
-    - MapboxCommon (~> 24.7.0-rc)
-  - MapboxMaps (11.7.0-rc.1):
-    - MapboxCommon (= 24.7.0-rc.2)
-    - MapboxCoreMaps (= 11.7.0-rc.2)
+  - MapboxCommon (24.7.0)
+  - MapboxCoreMaps (11.7.0):
+    - MapboxCommon (~> 24.7)
+  - MapboxMaps (11.7.0):
+    - MapboxCommon (= 24.7.0)
+    - MapboxCoreMaps (= 11.7.0)
     - Turf (= 3.0.0)
   - path_provider_foundation (0.0.1):
     - Flutter
@@ -49,10 +49,10 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
-  mapbox_maps_flutter: d6122dadb872e294835dfcff372590693adcce35
-  MapboxCommon: 85c133c17aa073d6d57a14ee5676a2236d3df35a
-  MapboxCoreMaps: 35061f7cacdfc22accd89b2218bc66af1939f380
-  MapboxMaps: 1ab65689c868ac0c1065342ba840818087f1486b
+  mapbox_maps_flutter: 12c1065c77cc520a7f3bef0959be740902011069
+  MapboxCommon: fbc1138a831f4c1b728167c3f49701fe3a9aeed1
+  MapboxCoreMaps: 8946c9fa51e588d594ee6ebf192d9942368abb6a
+  MapboxMaps: bf9f775d921ed357ae642c379ebad90550cdb9de
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
   permission_handler_apple: e76247795d700c14ea09e3a2d8855d41ee80a2e6
   Turf: a1604e74adce15c58462c9ae2acdbf049d5be35e

--- a/ios/mapbox_maps_flutter.podspec
+++ b/ios/mapbox_maps_flutter.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.dependency 'Flutter'
   s.platform = :ios, '12.0'
 
-  s.dependency 'MapboxMaps', '~> 11.7.0-rc.1'
+  s.dependency 'MapboxMaps', '~> 11.7.0'
   s.dependency 'Turf', '3.0.0'
 
   # Flutter.framework does not contain a i386 slice.


### PR DESCRIPTION
### What does this pull request do?

Bumps Mapbox Maps SDK version to the latest stable 11.7.0.

### What is the motivation and context behind this change?



### Pull request checklist:
 - [x] Add a changelog entry.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
