### PR TITLE
Ignore event subsription updates while platform view is creating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ onCameraChangeListener(CameraChangedEventData data) {
 * Print to console native Maps SDK logs in debug configuration.
 Logs are proxied only in debug configuration and can be disabled completely by passing environment flag `MAPBOX_LOG_DEBUG` with false value.
 * Fix rare crash in `Snapshotter`. The crash could happen when creating/destroying multiple instances of `Snapshotter` in succession.
+* Fix a crash that occurs when the widget state is updated before the platform view is created.
 
 # 2.3.0
 

--- a/lib/src/map_widget.dart
+++ b/lib/src/map_widget.dart
@@ -176,7 +176,7 @@ class _MapWidgetState extends State<MapWidget> {
   late final BinaryMessenger _binaryMessenger =
       ProxyBinaryMessenger(suffix: _suffix.toString());
   late final _MapEvents _events;
-
+  bool _platformViewCreated = false;
   MapboxMap? mapboxMap;
 
   @override
@@ -217,7 +217,10 @@ class _MapWidgetState extends State<MapWidget> {
     super.didUpdateWidget(oldWidget);
 
     _updateEventListeners();
-    _events.updateSubscriptions();
+
+    if (_platformViewCreated) {
+      _events.updateSubscriptions();
+    }
   }
 
   void _updateEventListeners() {
@@ -249,5 +252,8 @@ class _MapWidgetState extends State<MapWidget> {
       widget.onMapCreated!(controller);
     }
     mapboxMap = controller;
+
+    _events.updateSubscriptions();
+    _platformViewCreated = true;
   }
 }


### PR DESCRIPTION
### What does this pull request do?

Platform view creation is asynchronous and in case widget state updates before the view is created we can get an exception trying to send a message to subscribe for events.

The fix is to ignore event subsription updates while platform view is creating.

Addresses https://github.com/mapbox/mapbox-maps-flutter/issues/657. 

### What is the motivation and context behind this change?



### Pull request checklist:
 - [x] Add a changelog entry.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
