### PR TITLE
Fix crash after creating/destroying multiple `Snapshotter`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ onCameraChangeListener(CameraChangedEventData data) {
 ```
 * Print to console native Maps SDK logs in debug configuration.
 Logs are proxied only in debug configuration and can be disabled completely by passing environment flag `MAPBOX_LOG_DEBUG` with false value.
+* Fix rare crash in `Snapshotter`. The crash could happen when creating/destroying multiple instances of `Snapshotter` in succession.
 
 # 2.3.0
 

--- a/lib/src/snapshotter/snapshotter.dart
+++ b/lib/src/snapshotter/snapshotter.dart
@@ -79,7 +79,7 @@ final class Snapshotter {
         snapshotter._mapEvents.eventTypes.map((e) => e.index).toList(),
         options);
 
-    Snapshotter._finalizer.attach(snapshotter, snapshotter._suffix);
+    Snapshotter._finalizer.attach(snapshotter, snapshotter._suffix, detach: snapshotter);
     return snapshotter;
   }
 


### PR DESCRIPTION
### What does this pull request do?

I noticed that there's a crash when opening/closing the snapshotter example repeatedly.
Upon investigation it turns out that the finalizer we use to cleanup after an instance of `Snapshotter` has been disposed doesn't have a detach token thus it never detaches which causes new instances(of `Snapshotter`) to be cleaned up together with the instances that are going away.

### What is the motivation and context behind this change?

Fixing a rare crash in `Snapshotter`.

### Pull request checklist:
 - [x] Add a changelog entry.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
