### PR TITLE
Virtual display hosting mode on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### main
 
-* Update Maps SDK to 11.8.0-rc.1
+* Updated the minimum required Flutter SDK to version 3.22.3 and Dart to version 3.4.4. With the fix for Virtual Display hosting mode on Android in Flutter 3.22, we’ve changed the default map view hosting mode to Virtual Display composition. This update should eliminate the brief visibility of the map after it has been dismissed.
+* Update Maps SDK to 11.8.0-rc.1.
 
 # 2.4.0-beta.1
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -487,5 +487,5 @@ packages:
     source: hosted
     version: "1.0.4"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  dart: ">=3.4.4 <4.0.0"
+  flutter: ">=3.22.3"

--- a/lib/src/map_widget.dart
+++ b/lib/src/map_widget.dart
@@ -48,7 +48,7 @@ class MapWidget extends StatefulWidget {
     // FIXME Flutter 3.x has memory leak on Android using in SurfaceView mode, see https://github.com/flutter/flutter/issues/118384
     // As a workaround default is true.
     this.textureView = true,
-    this.androidHostingMode = AndroidPlatformViewHostingMode.HC,
+    this.androidHostingMode = AndroidPlatformViewHostingMode.VD,
     this.styleUri = MapboxStyles.STANDARD,
     this.gestureRecognizers,
     this.onMapCreated,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,8 @@ version: 2.4.0-beta.1
 homepage: https://github.com/mapbox/mapbox-maps-flutter
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.10.0"
+  sdk: ">=3.4.4 <4.0.0"
+  flutter: ">=3.22.3"
 
 dependencies:
   flutter:


### PR DESCRIPTION
### What does this pull request do?

This PR sets the default display back to Virtual Display on Android. Set minimum supported Flutter version to `3.22.3` and Dart to `3.4.4`. 

### What is the motivation and context behind this change?

To address the issue map being visible for a brief moment after it has been dismissed.

https://mapbox.atlassian.net/browse/MAPSFLT-248

### Pull request checklist:
 - [x] Add a changelog entry.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
