### PR TITLE
Fix featureState update/query in map_interface_example

### DIFF
--- a/example/lib/map_interface_example.dart
+++ b/example/lib/map_interface_example.dart
@@ -91,7 +91,7 @@ class MapInterfaceExampleState extends State<MapInterfaceExample> {
       child: Text('setFeatureState'),
       onPressed: () {
         mapboxMap?.setFeatureState(
-            'source', 'custom', 'point', json.encode({'choose': true}));
+            'source', null, 'point', json.encode({'choose': true}));
       },
     );
   }
@@ -100,7 +100,7 @@ class MapInterfaceExampleState extends State<MapInterfaceExample> {
     return TextButton(
       child: Text('getFeatureState'),
       onPressed: () {
-        mapboxMap?.getFeatureState('source', 'custom', 'point').then(
+        mapboxMap?.getFeatureState('source', null, 'point').then(
             (value) => ScaffoldMessenger.of(context).showSnackBar(SnackBar(
                   content: Text("FeatureState: ${value}"),
                   backgroundColor: Theme.of(context).primaryColor,


### PR DESCRIPTION
### What does this pull request do?

Fixes `get/setFeatureState` actions in the map_interface_example. Source layer id was erroneously set to be the circle layer id referencing the source, while the source in question(id: `source`) is a GeoJson source that doesn't support source layering.
https://docs.mapbox.com/style-spec/reference/layers/#source-layer

Kudos to @jnorkus for uncovering this!

### What is the motivation and context behind this change?



### Pull request checklist:
 - [ ] Add a changelog entry.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
