### PR TITLE
Fix some map events not propagating to flutter side due to excessive re-subscriptions

### DIFF
--- a/lib/src/map_events.dart
+++ b/lib/src/map_events.dart
@@ -16,7 +16,7 @@ final class _MapEvents {
   OnStyleImageUnusedListener? _onStyleImageUnusedListener;
   OnResourceRequestListener? _onResourceRequestListener;
   late final MethodChannel _channel;
-  List<_MapEvent> _subscribedEventTypes = [];
+  List<_MapEvent> subscribedEventTypes = [];
 
   List<_MapEvent> get eventTypes {
     final listenersMap = {
@@ -54,7 +54,7 @@ final class _MapEvents {
   void updateSubscriptions() {
     final newEventTypes = eventTypes;
 
-    if (listEquals(newEventTypes, _subscribedEventTypes)) {
+    if (listEquals(newEventTypes, subscribedEventTypes)) {
       return;
     }
 
@@ -62,7 +62,7 @@ final class _MapEvents {
     _channel.invokeMethod(
         "subscribeToEvents", newEventTypes.map((e) => e.index).toList());
 
-    _subscribedEventTypes = newEventTypes;
+    subscribedEventTypes = newEventTypes;
   }
 
   void dispose() {

--- a/lib/src/map_widget.dart
+++ b/lib/src/map_widget.dart
@@ -206,6 +206,7 @@ class _MapWidgetState extends State<MapWidget> {
       'mapboxPluginVersion': '2.5.0-rc.1',
       'eventTypes': _events.eventTypes.map((e) => e.index).toList(),
     };
+    _events.subscribedEventTypes = _events.eventTypes;
 
     return _mapboxMapsPlatform.buildView(widget.androidHostingMode,
         creationParams, onPlatformViewCreated, widget.gestureRecognizers,


### PR DESCRIPTION
### What does this pull request do?

Because map widget would send event subscription request to the platform side two times during map widget initialization some events could be missed because of this. This PR fixed the issue by eliminating needless re-subscriptions.

### What is the motivation and context behind this change?



### Pull request checklist:
 - [ ] Add a changelog entry.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
