### PR TITLE
Viewport Android exception fix

### DIFF
--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/ViewportController.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/ViewportController.kt
@@ -54,8 +54,10 @@ class ViewportController(
         return
       }
       val transition = viewportPlugin.transitionFromFLTTransition(transitionStorage, cameraPlugin)
+      var callbackCopy: ((Result<Boolean>) -> Unit)? = callback
       viewportPlugin.transitionTo(state, transition) { success ->
-        callback(Result.success(success))
+        callbackCopy?.invoke(Result.success(success))
+        callbackCopy = null
       }
     } catch (error: Exception) {
       logE("Viewport", "Could not create viewport state ouf of options: $stateStorage")


### PR DESCRIPTION
### What does this pull request do?

Addresses "Reply already submitted" exceptions thrown on the Flutter side caused by viewport transition callback being called multiple times on Android.

### What is the motivation and context behind this change?



### Pull request checklist:
 - [ ] Add a changelog entry.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
