### PR TITLE
Align tap propagation behavior on Android and iOS.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # main
 
+* Align tap propagation behavior on Android and iOS.
+
 ### 2.6.0-beta.1
 
 > [!IMPORTANT]

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/annotation/AnnotationController.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/annotation/AnnotationController.kt
@@ -42,7 +42,7 @@ class AnnotationController(private val mapView: MapView) :
           this.addClickListener(
             com.mapbox.maps.plugin.annotation.generated.OnCircleAnnotationClickListener { annotation ->
               onCircleAnnotationClickListener?.onCircleAnnotationClick(annotation.toFLTCircleAnnotation()) {}
-              true
+              false
             }
           )
         }
@@ -52,7 +52,7 @@ class AnnotationController(private val mapView: MapView) :
           this.addClickListener(
             com.mapbox.maps.plugin.annotation.generated.OnPointAnnotationClickListener { annotation ->
               onPointAnnotationClickListener?.onPointAnnotationClick(annotation.toFLTPointAnnotation()) {}
-              true
+              false
             }
           )
         }
@@ -62,7 +62,7 @@ class AnnotationController(private val mapView: MapView) :
           this.addClickListener(
             com.mapbox.maps.plugin.annotation.generated.OnPolygonAnnotationClickListener { annotation ->
               onPolygonAnnotationClickListener?.onPolygonAnnotationClick(annotation.toFLTPolygonAnnotation()) {}
-              true
+              false
             }
           )
         }
@@ -72,7 +72,7 @@ class AnnotationController(private val mapView: MapView) :
           this.addClickListener(
             com.mapbox.maps.plugin.annotation.generated.OnPolylineAnnotationClickListener { annotation ->
               onPolylineAnnotationClickListener?.onPolylineAnnotationClick(annotation.toFLTPolylineAnnotation()) {}
-              true
+              false
             }
           )
         }


### PR DESCRIPTION
### What does this pull request do?

This PR changes annotation tap propagation behavior on Android to match with iOS where taps on annotations are also propagated to the map.

### What is the motivation and context behind this change?

https://github.com/mapbox/mapbox-maps-flutter/issues/793
https://mapbox.atlassian.net/browse/MAPSFLT-292

### Pull request checklist:
 - [x] Add a changelog entry.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
