### PR TITLE
Add Custom Source Header Support 

### DIFF
--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/MapboxMapController.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/MapboxMapController.kt
@@ -15,6 +15,7 @@ import com.mapbox.maps.MapInitOptions
 import com.mapbox.maps.MapView
 import com.mapbox.maps.MapboxMap
 import com.mapbox.maps.mapbox_maps.annotation.AnnotationController
+import com.mapbox.maps.mapbox_maps.http.CustomHttpServiceInterceptor
 import com.mapbox.maps.mapbox_maps.pigeons.AttributionSettingsInterface
 import com.mapbox.maps.mapbox_maps.pigeons.CompassSettingsInterface
 import com.mapbox.maps.mapbox_maps.pigeons.GesturesSettingsInterface
@@ -266,6 +267,19 @@ class MapboxMapController(
       }
       "mapView#submitViewSizeHint" -> {
         result.success(null) // no-op on this platform
+      }
+      "map#setCustomHeaders" -> {
+        try {
+          val headers = call.argument<Map<String, String>>("headers")
+          headers?.let {
+            CustomHttpServiceInterceptor.getInstance().setCustomHeaders(headers)
+            result.success(null)
+          } ?: run {
+            result.error("INVALID_ARGUMENTS", "Headers cannot be null", null)
+          }
+        } catch (e: Exception) {
+          result.error("HEADER_ERROR", e.message, null)
+        }
       }
       else -> {
         result.notImplemented()

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/http/CustomHttpServiceInterceptor.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/http/CustomHttpServiceInterceptor.kt
@@ -1,0 +1,47 @@
+package com.mapbox.maps.mapbox_maps.http
+
+import com.mapbox.common.HttpServiceFactory
+import com.mapbox.common.HttpServiceInterceptorInterface
+import com.mapbox.common.HttpRequest
+import com.mapbox.common.HttpRequestOrResponse
+import com.mapbox.common.HttpResponse
+import com.mapbox.common.HttpServiceInterceptorRequestContinuation
+import com.mapbox.common.HttpServiceInterceptorResponseContinuation
+import com.mapbox.common.NetworkRestriction
+
+class CustomHttpServiceInterceptor : HttpServiceInterceptorInterface {
+  private var customHeaders: MutableMap<String, String> = mutableMapOf()
+
+  override fun onRequest(request: HttpRequest, continuation: HttpServiceInterceptorRequestContinuation) {
+    val currentHeaders = HashMap(request.headers)
+
+    currentHeaders.putAll(customHeaders)
+    val modifiedRequest = request.toBuilder()
+      .headers(currentHeaders)
+      .networkRestriction(NetworkRestriction.NONE)
+      .build()
+    val requestOrResponse = HttpRequestOrResponse(modifiedRequest)
+    continuation.run(requestOrResponse)
+  }
+
+  override fun onResponse(response: HttpResponse, continuation: HttpServiceInterceptorResponseContinuation) {
+    continuation.run(response)
+  }
+
+  fun setCustomHeaders(headers: Map<String, String>) {
+    customHeaders.clear()
+    customHeaders.putAll(headers)
+    HttpServiceFactory.setHttpServiceInterceptor(this)
+  }
+
+  companion object {
+    private var instance: CustomHttpServiceInterceptor? = null
+
+    fun getInstance(): CustomHttpServiceInterceptor {
+      if (instance == null) {
+        instance = CustomHttpServiceInterceptor()
+      }
+      return instance!!
+    }
+  }
+}

--- a/example/lib/custom_header_example.dart
+++ b/example/lib/custom_header_example.dart
@@ -1,0 +1,73 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show ByteData, rootBundle;
+import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
+
+import 'example.dart';
+
+class CustomHeaderExample extends StatefulWidget implements Example {
+  @override
+  final Widget leading = const Icon(Icons.network_check);
+  @override
+  final String title = 'Custom Header Example';
+  @override
+  final String? subtitle = null;
+
+  @override
+  State<StatefulWidget> createState() => CustomHeaderExampleState();
+}
+
+class CustomHeaderExampleState extends State<CustomHeaderExample> {
+  CustomHeaderExampleState();
+
+  MapboxMap? mapboxMap;
+  var mapProject = StyleProjectionName.globe;
+  var locale = 'en';
+
+  _onMapCreated(MapboxMap mapboxMap) {
+    this.mapboxMap = mapboxMap;
+    mapboxMap.setCustomHeaders({'Authorization': 'Bearer your_access_token'});
+  }
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    mapboxMap?.setCustomHeaders({});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final MapWidget mapWidget = MapWidget(
+      key: ValueKey("mapWidget"),
+      onMapCreated: _onMapCreated,
+      onResourceRequestListener: (request) {
+        return null;
+      },
+    );
+
+    final List<Widget> listViewChildren = <Widget>[];
+
+    listViewChildren.addAll(
+      <Widget>[],
+    );
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Center(
+          child: SizedBox(
+              width: MediaQuery.of(context).size.width,
+              height: MediaQuery.of(context).size.height - 400,
+              child: mapWidget),
+        ),
+      ],
+    );
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:mapbox_maps_example/animation_example.dart';
 import 'package:mapbox_maps_example/camera_example.dart';
 import 'package:mapbox_maps_example/circle_annotations_example.dart';
 import 'package:mapbox_maps_example/cluster_example.dart';
+import 'package:mapbox_maps_example/custom_header_example.dart';
 import 'package:mapbox_maps_example/offline_map_example.dart';
 import 'package:mapbox_maps_example/model_layer_example.dart';
 import 'package:mapbox_maps_example/ornaments_example.dart';
@@ -62,6 +63,7 @@ final List<Example> _allPages = <Example>[
   GesturesExample(),
   OrnamentsExample(),
   AnimatedRouteExample(),
+  CustomHeaderExample()
 ];
 
 class MapsDemo extends StatelessWidget {

--- a/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/CustomHttpServiceInterceptor.swift
+++ b/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/CustomHttpServiceInterceptor.swift
@@ -1,0 +1,31 @@
+
+import MapboxMaps
+
+final class CustomHttpServiceInterceptor: HttpServiceInterceptorInterface {
+   
+   var customHeaders: [String: String] = [:]
+
+   func onRequest(for request: HttpRequest, continuation: @escaping HttpServiceInterceptorRequestContinuation) {
+       var modifiedHeaders = request.headers
+
+       for (key, value) in customHeaders {
+           modifiedHeaders[key] = value
+       }
+
+       let modifiedRequest = HttpRequest(
+           method: request.method,
+           url: request.url,
+           headers: modifiedHeaders,
+           timeout: request.timeout,
+           networkRestriction: request.networkRestriction,
+           sdkInformation: request.sdkInformation,
+           body: request.body,
+           flags: request.flags
+       )
+       continuation(HttpRequestOrResponse.fromHttpRequest(modifiedRequest))
+   }
+
+   func onResponse(for response: HttpResponse, continuation: @escaping HttpServiceInterceptorResponseContinuation) {
+       continuation(response)
+   }
+}

--- a/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/MapboxMapController.swift
+++ b/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/MapboxMapController.swift
@@ -136,6 +136,22 @@ final class MapboxMapController: NSObject, FlutterPlatformView {
                 mapView.superview?.frame = CGRect(origin: .zero, size: size)
             }
             result(nil)
+        case "map#setCustomHeaders":
+            guard let arguments = methodCall.arguments as? [String: Any],
+              let headers = arguments["headers"] as? [String: String]
+        else {
+            result(FlutterError(
+                code: "setCustomHeaders",
+                message: "could not decode arguments",
+                details: nil
+            ))
+            return
+        }
+        let customInterceptor = CustomHttpServiceInterceptor()
+        HttpServiceFactory.setHttpServiceInterceptorForInterceptor(customInterceptor)
+            customInterceptor.customHeaders = headers
+        result(nil)
+        
         default:
             result(FlutterMethodNotImplemented)
         }

--- a/lib/mapbox_maps_flutter.dart
+++ b/lib/mapbox_maps_flutter.dart
@@ -85,3 +85,4 @@ part 'src/viewport/transitions/default_viewport_transition.dart';
 part 'src/viewport/transitions/fly_viewport_transition.dart';
 part 'src/viewport/transitions/easing_viewport_transition.dart';
 part 'src/package_info.dart';
+part 'src/http/http_service.dart';

--- a/lib/src/http/http_service.dart
+++ b/lib/src/http/http_service.dart
@@ -1,0 +1,43 @@
+part of mapbox_maps_flutter;
+
+/// A service that handles HTTP-related functionality for Mapbox
+class MapboxHttpService {
+  late final MethodChannel _channel;
+  final BinaryMessenger binaryMessenger;
+  final int channelSuffix;
+
+  /// Creates a new MapboxHttpService instance
+  ///
+  /// [binaryMessenger] is used for platform channel communication
+  /// [channelSuffix] is used to create a unique channel identifier when multiple instances
+  /// of the service are needed. This should match the suffix used on the platform side.
+  MapboxHttpService(
+      {required this.binaryMessenger, required this.channelSuffix}) {
+    _channel = MethodChannel('plugins.flutter.io.${channelSuffix.toString()}',
+        const StandardMethodCodec(), binaryMessenger);
+  }
+
+  /// Sets custom headers for all Mapbox HTTP requests
+  ///
+  /// [headers] is a map of header names to header values
+  ///
+  /// Throws a [PlatformException] if the native implementation is not available
+  /// or if the operation fails
+  Future<void> setCustomHeaders(Map<String, String> headers) async {
+    try {
+      await _channel.invokeMethod('map#setCustomHeaders', {'headers': headers});
+    } on MissingPluginException catch (e) {
+      throw PlatformException(
+        code: 'MISSING_IMPLEMENTATION',
+        message: 'Native implementation for setCustomHeaders is not available',
+        details: e.toString(),
+      );
+    } catch (e) {
+      throw PlatformException(
+        code: 'SET_HEADERS_FAILED',
+        message: 'Failed to set custom headers',
+        details: e.toString(),
+      );
+    }
+  }
+}

--- a/lib/src/mapbox_map.dart
+++ b/lib/src/mapbox_map.dart
@@ -208,7 +208,9 @@ class MapboxMap extends ChangeNotifier {
       AttributionSettingsInterface(
           binaryMessenger: _mapboxMapsPlatform.binaryMessenger,
           messageChannelSuffix: _mapboxMapsPlatform.channelSuffix.toString());
-
+  late final MapboxHttpService httpService = MapboxHttpService(
+      binaryMessenger: _mapboxMapsPlatform.binaryMessenger,
+      channelSuffix: _mapboxMapsPlatform.channelSuffix);
   OnMapTapListener? onMapTapListener;
   OnMapLongTapListener? onMapLongTapListener;
   OnMapScrollListener? onMapScrollListener;
@@ -763,6 +765,28 @@ class MapboxMap extends ChangeNotifier {
   @experimental
   Future<void> setSnapshotLegacyMode(bool enable) =>
       _mapInterface.setSnapshotLegacyMode(enable);
+
+  /// Set custom headers for all Mapbox HTTP requests
+  ///
+  /// [headers] is a map of header names to header values
+  ///
+  /// Throws a [PlatformException] if the native implementation is not available
+  /// or if the operation fails
+  ///
+  /// Example:
+  /// ```dart
+  /// MapboxMap.setCustomHeaders({
+  ///   "Authorization": "Bearer your_secret_token",
+  /// });
+  /// ```
+  ///
+  /// Throws a [PlatformException] if the native implementation is not available
+  /// or if the operation fails
+  Future<void> setCustomHeaders(Map<String, String> headers) =>
+      MapboxHttpService(
+              binaryMessenger: _mapboxMapsPlatform.binaryMessenger,
+              channelSuffix: _mapboxMapsPlatform.channelSuffix)
+          .setCustomHeaders(headers);
 }
 
 class _GestureListener extends GestureListener {


### PR DESCRIPTION
Original pull request from @azaderdogan [here](https://github.com/mapbox/mapbox-maps-flutter/pull/870). 

> This pull request introduces a setCustomHttpHeader method to allow the plugin to modify HTTP headers dynamically. The implementation includes a CustomHttpServiceInterceptor that overrides onRequest and onResponse methods to handle custom headers. This ensures better flexibility for API requests while using mapbox_maps_flutter.
> 
> Currently, mapbox_maps_flutter does not provide a built-in way to modify HTTP headers dynamically. This change enables developers to set custom headers, such as authentication tokens or tracking headers, without modifying the core plugin. The implementation also ensures seamless integration with both iOS and Android, using interceptors where necessary.

---------

### What does this pull request do?

Adds support for custom source headers. Resolves https://github.com/mapbox/mapbox-maps-flutter/issues/853.

### What is the motivation and context behind this change?



### Pull request checklist:
 - [ ] Add a changelog entry.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.
