### PR TITLE
Fix incorrect color alpha value conversion on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### main
+
+* [Android] Fix color alpha value conversion.
+
 ### 2.8.0-beta.1
 
 * Introduce experimental `MapboxMap.startPerformanceStatisticsCollection` / `MapboxMap.stopPerformanceStatisticsCollection` APIs allowing to start / stop collecting map rendering performance statistics.

--- a/lib/src/style/style.dart
+++ b/lib/src/style/style.dart
@@ -388,7 +388,7 @@ extension StyleColorInt on int {
   /// Convert the color from int format to a string with format "rgba(red, green, blue, alpha)".
   String toRGBA() {
     final color = Color(this);
-    return "rgba(${color.red}, ${color.green}, ${color.blue}, ${color.alpha})";
+    return "rgba(${color.red}, ${color.green}, ${color.blue}, ${color.alpha / 255})";
   }
 }
 


### PR DESCRIPTION
### What does this pull request do?

Fixes alpha value for colors being passed in 0...255 range instead of 0...1 on Android.

### What is the motivation and context behind this change?

Addresses: https://github.com/mapbox/mapbox-maps-flutter/issues/915 https://mapbox.atlassian.net/browse/MAPSFLT-324

### Pull request checklist:
 - [x] Add a changelog entry.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](../CONTRIBUTING.md#contributor-license-agreement).
