### PR TITLE
[backport] Prepare v2.8.0-rc.1 release (#923)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### main
+### 2.8.0-rc.1
 
 * [Android] Fix color alpha value conversion.
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -59,7 +59,7 @@ if (file("$rootDir/gradle/ktlint.gradle").exists() && file("$rootDir/gradle/lint
 }
 
 dependencies {
-    implementation "com.mapbox.maps:android:11.12.0-beta.1"
+    implementation "com.mapbox.maps:android:11.12.0-rc.1"
 
     implementation "androidx.annotation:annotation:1.5.0"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.6.2"

--- a/example/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/example/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "8adc99eec971b0b38cd21eb5fca54817527e35c82c903939a8dd8937f6626e89",
+  "originHash" : "6229ee23b6a8d04ad4ba0e49a721da2f667f43d03a377fe7a2cd4634e5722ba3",
   "pins" : [
     {
       "identity" : "mapbox-common-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mapbox/mapbox-common-ios.git",
       "state" : {
-        "revision" : "567851363953aa61af4a14fcb6989892eb6d4c87",
-        "version" : "24.12.0-beta.1"
+        "revision" : "6efcdd6ca3ded3647f3ff897845c679d52dd625a",
+        "version" : "24.12.0-rc.1"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mapbox/mapbox-core-maps-ios.git",
       "state" : {
-        "revision" : "4259d2fb592af14e6a7cfc8611a3144a3afcebbd",
-        "version" : "11.12.0-beta.1"
+        "revision" : "bfb41b136ecd52b45e35fe25b1b4840309a3994d",
+        "version" : "11.12.0-rc.1"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mapbox/mapbox-maps-ios.git",
       "state" : {
-        "revision" : "fd90b076ddbba66865f6d13adb4eb4a1c83ca344",
-        "version" : "11.12.0-beta.1"
+        "revision" : "5f46396a6816c6d89a4ca8df39c22db2f9f9e3d2",
+        "version" : "11.12.0-rc.1"
       }
     },
     {

--- a/example/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/example/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "8adc99eec971b0b38cd21eb5fca54817527e35c82c903939a8dd8937f6626e89",
+  "originHash" : "6229ee23b6a8d04ad4ba0e49a721da2f667f43d03a377fe7a2cd4634e5722ba3",
   "pins" : [
     {
       "identity" : "mapbox-common-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mapbox/mapbox-common-ios.git",
       "state" : {
-        "revision" : "31e1af0ebf69f4393fd7386be00dd0d19c288a7c",
-        "version" : "24.11.0"
+        "revision" : "6efcdd6ca3ded3647f3ff897845c679d52dd625a",
+        "version" : "24.12.0-rc.1"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mapbox/mapbox-core-maps-ios.git",
       "state" : {
-        "revision" : "f5e6f21925868102fc28f0eded225c7015bde626",
-        "version" : "11.11.0"
+        "revision" : "bfb41b136ecd52b45e35fe25b1b4840309a3994d",
+        "version" : "11.12.0-rc.1"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mapbox/mapbox-maps-ios.git",
       "state" : {
-        "revision" : "a0b366c558d3ba96012d348f6a8d20ee6bc50b07",
-        "version" : "11.11.0"
+        "revision" : "5f46396a6816c6d89a4ca8df39c22db2f9f9e3d2",
+        "version" : "11.12.0-rc.1"
       }
     },
     {

--- a/ios/mapbox_maps_flutter.podspec
+++ b/ios/mapbox_maps_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'mapbox_maps_flutter'
-  s.version          = '2.8.0-beta.1'
+  s.version          = '2.8.0-rc.1'
 
   s.summary          = 'Mapbox Maps SDK Flutter Plugin.'
   s.description      = 'An officially developed solution from Mapbox that enables use of our latest Maps SDK product.'
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.dependency 'Flutter'
   s.platform = :ios, '14.0'
 
-  s.dependency 'MapboxMaps', '11.12.0-beta.1'
+  s.dependency 'MapboxMaps', '11.12.0-rc.1'
   s.dependency 'Turf', '4.0.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/ios/mapbox_maps_flutter/Package.resolved
+++ b/ios/mapbox_maps_flutter/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mapbox/mapbox-common-ios.git",
       "state" : {
-        "revision" : "6ae0de3e10879c5836cdb46af084f3b8cb6a4321",
-        "version" : "24.11.0-rc.2"
+        "revision" : "6efcdd6ca3ded3647f3ff897845c679d52dd625a",
+        "version" : "24.12.0-rc.1"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mapbox/mapbox-core-maps-ios.git",
       "state" : {
-        "revision" : "ced4f326b5ebdba1fbd3ca809cdefb7635537484",
-        "version" : "11.11.0-rc.2"
+        "revision" : "bfb41b136ecd52b45e35fe25b1b4840309a3994d",
+        "version" : "11.12.0-rc.1"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mapbox/mapbox-maps-ios.git",
       "state" : {
-        "revision" : "e6885595c5f5e98a1a42d8e0189cb456f0ce4f18",
-        "version" : "11.11.0-rc.1"
+        "revision" : "5f46396a6816c6d89a4ca8df39c22db2f9f9e3d2",
+        "version" : "11.12.0-rc.1"
       }
     },
     {

--- a/ios/mapbox_maps_flutter/Package.swift
+++ b/ios/mapbox_maps_flutter/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "mapbox-maps-flutter", targets: ["mapbox_maps_flutter"])
     ],
     dependencies: [
-        .package(url: "https://github.com/mapbox/mapbox-maps-ios.git", exact: "11.12.0-beta.1"),
+        .package(url: "https://github.com/mapbox/mapbox-maps-ios.git", exact: "11.12.0-rc.1"),
     ],
     targets: [
         .target(

--- a/lib/src/package_info.dart
+++ b/lib/src/package_info.dart
@@ -1,3 +1,3 @@
 part of mapbox_maps_flutter;
 
-const String mapboxPluginVersion = '2.8.0-beta.1';
+const String mapboxPluginVersion = '2.8.0-rc.1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mapbox_maps_flutter
 description: Interactive, thoroughly customizable maps powered by Mapbox Maps mobile SDKs.
-version: 2.8.0-beta.1
+version: 2.8.0-rc.1
 homepage: https://github.com/mapbox/mapbox-maps-flutter
 
 environment:


### PR DESCRIPTION
- Update Maps SDK dependencies to v11.12.0-rc.1 (iOS and Android)
- Bump version to v2.8.0-rc.1
