### PR TITLE
Correct coordinate ordering for Android (#929)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### main
+
+* Update geometry conversions on Android to use Longitude, Latitude instead of Latitude, Longitude order. This follows the order used by the GeoJSON Specification and the Turf library.
+
 ### 2.8.0-rc.1
 
 * [Android] Fix color alpha value conversion.

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/Extentions.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/Extentions.kt
@@ -444,33 +444,33 @@ fun Geometry.toMap(): Map<String?, Any?> {
   return when (this) {
     is Point -> mapOf(
       "type" to "Point",
-      "coordinates" to listOf(this.latitude(), this.longitude())
+      "coordinates" to listOf(this.longitude(), this.latitude())
     )
     is LineString -> mapOf(
       "type" to "LineString",
-      "coordinates" to this.coordinates().map { listOf(it.latitude(), it.longitude()) }
+      "coordinates" to this.coordinates().map { listOf(it.longitude(), it.latitude()) }
     )
     is Polygon -> mapOf(
       "type" to "Polygon",
       "coordinates" to this.coordinates().map { ring ->
-        ring.map { listOf(it.latitude(), it.longitude()) }
+        ring.map { listOf(it.longitude(), it.latitude()) }
       }
     )
     is MultiPoint -> mapOf(
       "type" to "MultiPoint",
-      "coordinates" to this.coordinates().map { listOf(it.latitude(), it.longitude()) }
+      "coordinates" to this.coordinates().map { listOf(it.longitude(), it.latitude()) }
     )
     is MultiLineString -> mapOf(
       "type" to "MultiLineString",
       "coordinates" to this.coordinates().map { line ->
-        line.map { listOf(it.latitude(), it.longitude()) }
+        line.map { listOf(it.longitude(), it.latitude()) }
       }
     )
     is MultiPolygon -> mapOf(
       "type" to "MultiPolygon",
       "coordinates" to this.coordinates().map { polygon ->
         polygon.map { ring ->
-          ring.map { listOf(it.latitude(), it.longitude()) }
+          ring.map { listOf(it.longitude(), it.latitude()) }
         }
       }
     )


### PR DESCRIPTION
### What does this pull request do?

Cherry pick: https://github.com/mapbox/mapbox-maps-flutter/pull/929

This PR updates coordinate ordering on Android to use Longitude, Latitude order. This aligns with iOS, the [GeoJSON Specification](https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.1), and the Turf library. 

### What is the motivation and context behind this change?
Consistency across platforms. 

### Pull request checklist:
 - [x] Add a changelog entry.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](../CONTRIBUTING.md#contributor-license-agreement).
