### PR TITLE
Update fastlane versions

### DIFF
--- a/.fastlane/Matchfile
+++ b/.fastlane/Matchfile
@@ -2,4 +2,4 @@ git_url("git@github.com:mapbox/apple-certificates.git")
 type("development") # The default type, can be: appstore, adhoc, enterprise or development
 app_identifier(["com.mapbox.maps.FlutterMapsExample", "com.mapbox.maps.FlutterRunnerTests"])
 username("applemachine@mapbox.com")
-match(force_legacy_encryption: true)
+force_legacy_encryption(true)

--- a/.fastlane/Matchfile
+++ b/.fastlane/Matchfile
@@ -2,3 +2,4 @@ git_url("git@github.com:mapbox/apple-certificates.git")
 type("development") # The default type, can be: appstore, adhoc, enterprise or development
 app_identifier(["com.mapbox.maps.FlutterMapsExample", "com.mapbox.maps.FlutterRunnerTests"])
 username("applemachine@mapbox.com")
+match(force_legacy_encryption: true)

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "fastlane", "~> 2.221.1"
+gem "fastlane", "~> 2.227.2"
 
 plugins_path = File.join(File.dirname(__FILE__), '.fastlane', 'Pluginfile')
 eval_gemfile(plugins_path) if File.exist?(plugins_path)


### PR DESCRIPTION
### What does this pull request do?

Updates minimum Fastlane [version](https://github.com/fastlane/fastlane/releases) to the latest and adds `force_legacy_encryption: true` flag in Matchfile for compatibility. 

### What is the motivation and context behind this change?

Avoid error with Fastlane 2.220.

### Pull request checklist:
 - [ ] Add a changelog entry.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](../CONTRIBUTING.md#contributor-license-agreement).
