### PR TITLE
Annotation tap and long press events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@
     },
   );
   ```
+
 > [!NOTE]
+> As part of this change, `AnnotationOnClickListener` is now deprecated.
 > Tap events will now not propagate to annotations below the topmost one. If you tap on overlapping annotations, only the top annotation's tap event will be triggered.
 
 ### 2.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,7 @@
 ### main
 
 * Introduce new experimental properties: `FillLayer.fillConstructBridgeGuardRail`, `FillLayer.fillBridgeGuardRailColor`, `FillLayer.fillTunnelStructureColor`, `CircleLayer.circleElevationReference`. 
-* Introduce `tapEvents` API to the Annotation Managers to handle tap event callbacks for annotations:
-  * `onTap`: Called when an annotation is tapped.
-
+* Introduce `tapEvents` and `longPressEvents` API to the Annotation Managers to handle tap and long press event callbacks for annotations:
   Example usage:
   ```dart
   manager.tapEvents(
@@ -11,9 +9,14 @@
       print("Tapped annotation: ${annotation.id}");
     },
   );
+  manager.longPressEvents(
+    onLongPress: (annotation) {
+      print("Long press annotation: ${annotation.id}");
+    },
+  );
   ```
-  > [!NOTE]
-  > Tap events will now not propagate to annotations below the topmost one. If you tap on overlapping annotations, only the top annotation's tap event will be triggered.
+> [!NOTE]
+> Tap events will now not propagate to annotations below the topmost one. If you tap on overlapping annotations, only the top annotation's tap event will be triggered.
 
 ### 2.9.0
 

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/annotation/AnnotationController.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/annotation/AnnotationController.kt
@@ -223,24 +223,24 @@ class AnnotationController(
       var dragEventsSink: PigeonEventSink<AnnotationInteractionContext>? = null
 
       fun register(messenger: BinaryMessenger, channelName: String) {
-          val tapEvents = object : AnnotationInteractionEventsStreamHandler() {
-            override fun onListen(p0: Any?, sink: PigeonEventSink<AnnotationInteractionContext>) {
-              tapEventsSink = sink
-            }
-
-            override fun onCancel(p0: Any?) {
-              tapEventsSink = null
-            }
+        val tapEvents = object : AnnotationInteractionEventsStreamHandler() {
+          override fun onListen(p0: Any?, sink: PigeonEventSink<AnnotationInteractionContext>) {
+            tapEventsSink = sink
           }
-          val dragEvents = object : AnnotationInteractionEventsStreamHandler() {
-            override fun onListen(p0: Any?, sink: PigeonEventSink<AnnotationInteractionContext>) {
-              dragEventsSink = sink
-            }
 
-            override fun onCancel(p0: Any?) {
-              dragEventsSink = null
-            }
+          override fun onCancel(p0: Any?) {
+            tapEventsSink = null
           }
+        }
+        val dragEvents = object : AnnotationInteractionEventsStreamHandler() {
+          override fun onListen(p0: Any?, sink: PigeonEventSink<AnnotationInteractionContext>) {
+            dragEventsSink = sink
+          }
+
+          override fun onCancel(p0: Any?) {
+            dragEventsSink = null
+          }
+        }
         AnnotationInteractionEventsStreamHandler.register(messenger, tapEvents, "$channelName/tap")
         AnnotationInteractionEventsStreamHandler.register(messenger, tapEvents, "$channelName/drag")
       }

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/annotation/AnnotationController.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/annotation/AnnotationController.kt
@@ -2,10 +2,6 @@ package com.mapbox.maps.mapbox_maps.annotation
 
 import com.mapbox.maps.MapView
 import com.mapbox.maps.mapbox_maps.pigeons.*
-import com.mapbox.maps.mapbox_maps.pigeons.OnCircleAnnotationClickListener
-import com.mapbox.maps.mapbox_maps.pigeons.OnPointAnnotationClickListener
-import com.mapbox.maps.mapbox_maps.pigeons.OnPolygonAnnotationClickListener
-import com.mapbox.maps.mapbox_maps.pigeons.OnPolylineAnnotationClickListener
 import com.mapbox.maps.mapbox_maps.pigeons.PointAnnotation
 import com.mapbox.maps.plugin.annotation.Annotation
 import com.mapbox.maps.plugin.annotation.AnnotationConfig
@@ -144,6 +140,13 @@ class AnnotationController(
         return
       }
     }
+    managerMap[id] = manager
+    val eventsHandler = InteractionEventsHandler()
+    eventsHandler.register(
+      messenger,
+      "$channelSuffix/$id"
+    )
+    streamSinkMap[id] = eventsHandler
     result.success(id)
   }
 

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/CircleAnnotationMessenger.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/CircleAnnotationMessenger.kt
@@ -34,10 +34,6 @@ private fun wrapError(exception: Throwable): List<Any?> {
   }
 }
 
-private fun createConnectionError(channelName: String): FlutterError {
-  return FlutterError("channel-error", "Unable to establish connection on channel: '$channelName'.", "")
-}
-
 /**
  * Selects the base of circle-elevation. Some modes might require precomputed elevation data in the tileset.
  * Default value: "none".
@@ -376,31 +372,6 @@ private open class CircleAnnotationMessengerPigeonCodec : StandardMessageCodec()
   }
 }
 
-/** Generated class from Pigeon that represents Flutter messages that can be called from Kotlin. */
-class OnCircleAnnotationClickListener(private val binaryMessenger: BinaryMessenger, private val messageChannelSuffix: String = "") {
-  companion object {
-    /** The codec used by OnCircleAnnotationClickListener. */
-    val codec: MessageCodec<Any?> by lazy {
-      CircleAnnotationMessengerPigeonCodec()
-    }
-  }
-  fun onCircleAnnotationClick(annotationArg: CircleAnnotation, callback: (Result<Unit>) -> Unit) {
-    val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
-    val channelName = "dev.flutter.pigeon.mapbox_maps_flutter.OnCircleAnnotationClickListener.onCircleAnnotationClick$separatedMessageChannelSuffix"
-    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
-    channel.send(listOf(annotationArg)) {
-      if (it is List<*>) {
-        if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
-        } else {
-          callback(Result.success(Unit))
-        }
-      } else {
-        callback(Result.failure(createConnectionError(channelName)))
-      }
-    }
-  }
-}
 /** Generated interface from Pigeon that represents a handler of messages from Flutter. */
 interface _CircleAnnotationMessenger {
   fun create(managerId: String, annotationOption: CircleAnnotationOptions, callback: (Result<CircleAnnotation>) -> Unit)

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/GestureListeners.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/GestureListeners.kt
@@ -463,10 +463,10 @@ class PigeonEventSink<T>(private val sink: EventChannel.EventSink) {
   }
 }
 
-abstract class AnnotationDragEventsStreamHandler : GestureListenersPigeonEventChannelWrapper<AnnotationInteractionContext> {
+abstract class AnnotationInteractionEventsStreamHandler : GestureListenersPigeonEventChannelWrapper<AnnotationInteractionContext> {
   companion object {
-    fun register(messenger: BinaryMessenger, streamHandler: AnnotationDragEventsStreamHandler, instanceName: String = "") {
-      var channelName: String = "dev.flutter.pigeon.mapbox_maps_flutter.AnnotationInteractions._annotationDragEvents"
+    fun register(messenger: BinaryMessenger, streamHandler: AnnotationInteractionEventsStreamHandler, instanceName: String = "") {
+      var channelName: String = "dev.flutter.pigeon.mapbox_maps_flutter.AnnotationInteractions._annotationInteractionEvents"
       if (instanceName.isNotEmpty()) {
         channelName += ".$instanceName"
       }

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/PointAnnotationMessenger.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/PointAnnotationMessenger.kt
@@ -517,7 +517,7 @@ data class PointAnnotation(
    */
   val iconHaloWidth: Double? = null,
   /**
-   * Controls the transition progress between the image variants of icon-image. Zero means the first variant is used, one is the second, and in between they are blended together. . Both images should be the same size and have the same type (either raster or vector).
+   * Controls the transition progress between the image variants of icon-image. Zero means the first variant is used, one is the second, and in between they are blended together. Both images should be the same size and have the same type (either raster or vector).
    * Default value: 0. Value range: [0, 1]
    * Deprecated: Use `PointAnnotationManager.iconImageCrossFade` instead.
    */
@@ -838,7 +838,7 @@ data class PointAnnotationOptions(
    */
   val iconHaloWidth: Double? = null,
   /**
-   * Controls the transition progress between the image variants of icon-image. Zero means the first variant is used, one is the second, and in between they are blended together. . Both images should be the same size and have the same type (either raster or vector).
+   * Controls the transition progress between the image variants of icon-image. Zero means the first variant is used, one is the second, and in between they are blended together. Both images should be the same size and have the same type (either raster or vector).
    * Default value: 0. Value range: [0, 1]
    * Deprecated: Use `PointAnnotationManager.iconImageCrossFade` instead.
    */

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/PointAnnotationMessenger.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/PointAnnotationMessenger.kt
@@ -521,7 +521,7 @@ data class PointAnnotation(
    */
   val iconHaloWidth: Double? = null,
   /**
-   * Controls the transition progress between the image variants of icon-image. Zero means the first variant is used, one is the second, and in between they are blended together. Both images should be the same size and have the same type (either raster or vector).
+   * Controls the transition progress between the image variants of icon-image. Zero means the first variant is used, one is the second, and in between they are blended together. . Both images should be the same size and have the same type (either raster or vector).
    * Default value: 0. Value range: [0, 1]
    * Deprecated: Use `PointAnnotationManager.iconImageCrossFade` instead.
    */
@@ -842,7 +842,7 @@ data class PointAnnotationOptions(
    */
   val iconHaloWidth: Double? = null,
   /**
-   * Controls the transition progress between the image variants of icon-image. Zero means the first variant is used, one is the second, and in between they are blended together. Both images should be the same size and have the same type (either raster or vector).
+   * Controls the transition progress between the image variants of icon-image. Zero means the first variant is used, one is the second, and in between they are blended together. . Both images should be the same size and have the same type (either raster or vector).
    * Default value: 0. Value range: [0, 1]
    * Deprecated: Use `PointAnnotationManager.iconImageCrossFade` instead.
    */

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/PointAnnotationMessenger.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/PointAnnotationMessenger.kt
@@ -33,10 +33,6 @@ private fun wrapError(exception: Throwable): List<Any?> {
     )
   }
 }
-
-private fun createConnectionError(channelName: String): FlutterError {
-  return FlutterError("channel-error", "Unable to establish connection on channel: '$channelName'.", "")
-}
 private fun deepEqualsPointAnnotationMessenger(a: Any?, b: Any?): Boolean {
   if (a is ByteArray && b is ByteArray) {
     return a.contentEquals(b)
@@ -1219,31 +1215,6 @@ private open class PointAnnotationMessengerPigeonCodec : StandardMessageCodec() 
   }
 }
 
-/** Generated class from Pigeon that represents Flutter messages that can be called from Kotlin. */
-class OnPointAnnotationClickListener(private val binaryMessenger: BinaryMessenger, private val messageChannelSuffix: String = "") {
-  companion object {
-    /** The codec used by OnPointAnnotationClickListener. */
-    val codec: MessageCodec<Any?> by lazy {
-      PointAnnotationMessengerPigeonCodec()
-    }
-  }
-  fun onPointAnnotationClick(annotationArg: PointAnnotation, callback: (Result<Unit>) -> Unit) {
-    val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
-    val channelName = "dev.flutter.pigeon.mapbox_maps_flutter.OnPointAnnotationClickListener.onPointAnnotationClick$separatedMessageChannelSuffix"
-    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
-    channel.send(listOf(annotationArg)) {
-      if (it is List<*>) {
-        if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
-        } else {
-          callback(Result.success(Unit))
-        }
-      } else {
-        callback(Result.failure(createConnectionError(channelName)))
-      }
-    }
-  }
-}
 /** Generated interface from Pigeon that represents a handler of messages from Flutter. */
 interface _PointAnnotationMessenger {
   fun create(managerId: String, annotationOption: PointAnnotationOptions, callback: (Result<PointAnnotation>) -> Unit)

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/PolygonAnnotationMessenger.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/PolygonAnnotationMessenger.kt
@@ -34,10 +34,6 @@ private fun wrapError(exception: Throwable): List<Any?> {
   }
 }
 
-private fun createConnectionError(channelName: String): FlutterError {
-  return FlutterError("channel-error", "Unable to establish connection on channel: '$channelName'.", "")
-}
-
 /**
  * Selects the base of fill-elevation. Some modes might require precomputed elevation data in the tileset.
  * Default value: "none".
@@ -338,31 +334,6 @@ private open class PolygonAnnotationMessengerPigeonCodec : StandardMessageCodec(
   }
 }
 
-/** Generated class from Pigeon that represents Flutter messages that can be called from Kotlin. */
-class OnPolygonAnnotationClickListener(private val binaryMessenger: BinaryMessenger, private val messageChannelSuffix: String = "") {
-  companion object {
-    /** The codec used by OnPolygonAnnotationClickListener. */
-    val codec: MessageCodec<Any?> by lazy {
-      PolygonAnnotationMessengerPigeonCodec()
-    }
-  }
-  fun onPolygonAnnotationClick(annotationArg: PolygonAnnotation, callback: (Result<Unit>) -> Unit) {
-    val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
-    val channelName = "dev.flutter.pigeon.mapbox_maps_flutter.OnPolygonAnnotationClickListener.onPolygonAnnotationClick$separatedMessageChannelSuffix"
-    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
-    channel.send(listOf(annotationArg)) {
-      if (it is List<*>) {
-        if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
-        } else {
-          callback(Result.success(Unit))
-        }
-      } else {
-        callback(Result.failure(createConnectionError(channelName)))
-      }
-    }
-  }
-}
 /** Generated interface from Pigeon that represents a handler of messages from Flutter. */
 interface _PolygonAnnotationMessenger {
   fun create(managerId: String, annotationOption: PolygonAnnotationOptions, callback: (Result<PolygonAnnotation>) -> Unit)

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/PolylineAnnotationMessenger.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/pigeons/PolylineAnnotationMessenger.kt
@@ -34,10 +34,6 @@ private fun wrapError(exception: Throwable): List<Any?> {
   }
 }
 
-private fun createConnectionError(channelName: String): FlutterError {
-  return FlutterError("channel-error", "Unable to establish connection on channel: '$channelName'.", "")
-}
-
 /**
  * The display of line endings.
  * Default value: "butt".
@@ -486,31 +482,6 @@ private open class PolylineAnnotationMessengerPigeonCodec : StandardMessageCodec
   }
 }
 
-/** Generated class from Pigeon that represents Flutter messages that can be called from Kotlin. */
-class OnPolylineAnnotationClickListener(private val binaryMessenger: BinaryMessenger, private val messageChannelSuffix: String = "") {
-  companion object {
-    /** The codec used by OnPolylineAnnotationClickListener. */
-    val codec: MessageCodec<Any?> by lazy {
-      PolylineAnnotationMessengerPigeonCodec()
-    }
-  }
-  fun onPolylineAnnotationClick(annotationArg: PolylineAnnotation, callback: (Result<Unit>) -> Unit) {
-    val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
-    val channelName = "dev.flutter.pigeon.mapbox_maps_flutter.OnPolylineAnnotationClickListener.onPolylineAnnotationClick$separatedMessageChannelSuffix"
-    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
-    channel.send(listOf(annotationArg)) {
-      if (it is List<*>) {
-        if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
-        } else {
-          callback(Result.success(Unit))
-        }
-      } else {
-        callback(Result.failure(createConnectionError(channelName)))
-      }
-    }
-  }
-}
 /** Generated interface from Pigeon that represents a handler of messages from Flutter. */
 interface _PolylineAnnotationMessenger {
   fun create(managerId: String, annotationOption: PolylineAnnotationOptions, callback: (Result<PolylineAnnotation>) -> Unit)

--- a/example/integration_test/annotations/circle_annotation_manager_test.dart
+++ b/example/integration_test/annotations/circle_annotation_manager_test.dart
@@ -92,6 +92,45 @@ void main() {
     expect(CircleTranslateAnchor.MAP, circleTranslateAnchor);
   });
 
+  testWidgets('annotation tap events', (tester) async {
+    final mapFuture = app.main();
+    await tester.pumpAndSettle();
+
+    final mapboxMap = await mapFuture;
+    final manager = await mapboxMap.annotations.createCircleAnnotationManager();
+
+    final geometry = Point(coordinates: Position(0, 0));
+
+    final createdAnnotation = await manager.create(CircleAnnotationOptions(
+      geometry: geometry,
+    ));
+
+    // Mock tap events
+    final eventChannel = EventChannel(
+        "dev.flutter.pigeon.mapbox_maps_flutter.AnnotationInteractions._annotationInteractionEvents.0/${manager.id}/tap",
+        pigeonMethodCodec);
+    IntegrationTestWidgetsFlutterBinding.instance.defaultBinaryMessenger
+        .setMockStreamHandler(eventChannel,
+            MockStreamHandler.inline(onListen: (arguments, events) {
+      events.success(CircleAnnotationInteractionContext(
+        annotation: createdAnnotation,
+        gestureState: GestureState.ended,
+      ));
+      events.endOfStream();
+    }));
+
+    final onTap = Completer();
+    manager.tapEvents(
+      onTap: (annotation) {
+        expect(annotation.id, equals(createdAnnotation.id));
+        onTap.complete();
+      },
+    );
+
+    await onTap.future;
+    expect(onTap.isCompleted, isTrue);
+  });
+
   testWidgets('annotation drag events', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();
@@ -108,7 +147,7 @@ void main() {
 
     // Mock drag events
     final eventChannel = EventChannel(
-        "dev.flutter.pigeon.mapbox_maps_flutter.AnnotationInteractions._annotationDragEvents.0/${manager.id}",
+        "dev.flutter.pigeon.mapbox_maps_flutter.AnnotationInteractions._annotationInteractionEvents.0/${manager.id}/drag",
         pigeonMethodCodec);
     IntegrationTestWidgetsFlutterBinding.instance.defaultBinaryMessenger
         .setMockStreamHandler(eventChannel,

--- a/example/integration_test/annotations/point_annotation_manager_test.dart
+++ b/example/integration_test/annotations/point_annotation_manager_test.dart
@@ -331,6 +331,45 @@ void main() {
     expect(onTap.isCompleted, isTrue);
   });
 
+  testWidgets('annotation long press events', (tester) async {
+    final mapFuture = app.main();
+    await tester.pumpAndSettle();
+
+    final mapboxMap = await mapFuture;
+    final manager = await mapboxMap.annotations.createPointAnnotationManager();
+
+    final geometry = Point(coordinates: Position(0, 0));
+
+    final createdAnnotation = await manager.create(PointAnnotationOptions(
+      geometry: geometry,
+    ));
+
+    // Mock long press events
+    final eventChannel = EventChannel(
+        "dev.flutter.pigeon.mapbox_maps_flutter.AnnotationInteractions._annotationInteractionEvents.0/${manager.id}/long_press",
+        pigeonMethodCodec);
+    IntegrationTestWidgetsFlutterBinding.instance.defaultBinaryMessenger
+        .setMockStreamHandler(eventChannel,
+            MockStreamHandler.inline(onListen: (arguments, events) {
+      events.success(PointAnnotationInteractionContext(
+        annotation: createdAnnotation,
+        gestureState: GestureState.ended,
+      ));
+      events.endOfStream();
+    }));
+
+    final onLongPress = Completer();
+    manager.longPressEvents(
+      onLongPress: (annotation) {
+        expect(annotation.id, equals(createdAnnotation.id));
+        onLongPress.complete();
+      },
+    );
+
+    await onLongPress.future;
+    expect(onLongPress.isCompleted, isTrue);
+  });
+
   testWidgets('annotation drag events', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();

--- a/example/integration_test/annotations/polygon_annotation_manager_test.dart
+++ b/example/integration_test/annotations/polygon_annotation_manager_test.dart
@@ -94,6 +94,53 @@ void main() {
     expect(1.0, fillZOffset);
   });
 
+  testWidgets('annotation tap events', (tester) async {
+    final mapFuture = app.main();
+    await tester.pumpAndSettle();
+
+    final mapboxMap = await mapFuture;
+    final manager =
+        await mapboxMap.annotations.createPolygonAnnotationManager();
+
+    final geometry = Polygon(coordinates: [
+      [
+        Position(0, 0),
+        Position(1.754703, -19.716317),
+        Position(-15.747196, -21.085074),
+        Position(-3.363937, -10.733102)
+      ]
+    ]);
+
+    final createdAnnotation = await manager.create(PolygonAnnotationOptions(
+      geometry: geometry,
+    ));
+
+    // Mock tap events
+    final eventChannel = EventChannel(
+        "dev.flutter.pigeon.mapbox_maps_flutter.AnnotationInteractions._annotationInteractionEvents.0/${manager.id}/tap",
+        pigeonMethodCodec);
+    IntegrationTestWidgetsFlutterBinding.instance.defaultBinaryMessenger
+        .setMockStreamHandler(eventChannel,
+            MockStreamHandler.inline(onListen: (arguments, events) {
+      events.success(PolygonAnnotationInteractionContext(
+        annotation: createdAnnotation,
+        gestureState: GestureState.ended,
+      ));
+      events.endOfStream();
+    }));
+
+    final onTap = Completer();
+    manager.tapEvents(
+      onTap: (annotation) {
+        expect(annotation.id, equals(createdAnnotation.id));
+        onTap.complete();
+      },
+    );
+
+    await onTap.future;
+    expect(onTap.isCompleted, isTrue);
+  });
+
   testWidgets('annotation drag events', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();
@@ -118,7 +165,7 @@ void main() {
 
     // Mock drag events
     final eventChannel = EventChannel(
-        "dev.flutter.pigeon.mapbox_maps_flutter.AnnotationInteractions._annotationDragEvents.0/${manager.id}",
+        "dev.flutter.pigeon.mapbox_maps_flutter.AnnotationInteractions._annotationInteractionEvents.0/${manager.id}/drag",
         pigeonMethodCodec);
     IntegrationTestWidgetsFlutterBinding.instance.defaultBinaryMessenger
         .setMockStreamHandler(eventChannel,

--- a/example/integration_test/annotations/polyline_annotation_manager_test.dart
+++ b/example/integration_test/annotations/polyline_annotation_manager_test.dart
@@ -146,6 +146,47 @@ void main() {
     expect(1.0, lineWidth);
   });
 
+  testWidgets('annotation tap events', (tester) async {
+    final mapFuture = app.main();
+    await tester.pumpAndSettle();
+
+    final mapboxMap = await mapFuture;
+    final manager =
+        await mapboxMap.annotations.createPolylineAnnotationManager();
+
+    final geometry =
+        LineString(coordinates: [Position(0, 0), Position(10.0, 20.0)]);
+
+    final createdAnnotation = await manager.create(PolylineAnnotationOptions(
+      geometry: geometry,
+    ));
+
+    // Mock tap events
+    final eventChannel = EventChannel(
+        "dev.flutter.pigeon.mapbox_maps_flutter.AnnotationInteractions._annotationInteractionEvents.0/${manager.id}/tap",
+        pigeonMethodCodec);
+    IntegrationTestWidgetsFlutterBinding.instance.defaultBinaryMessenger
+        .setMockStreamHandler(eventChannel,
+            MockStreamHandler.inline(onListen: (arguments, events) {
+      events.success(PolylineAnnotationInteractionContext(
+        annotation: createdAnnotation,
+        gestureState: GestureState.ended,
+      ));
+      events.endOfStream();
+    }));
+
+    final onTap = Completer();
+    manager.tapEvents(
+      onTap: (annotation) {
+        expect(annotation.id, equals(createdAnnotation.id));
+        onTap.complete();
+      },
+    );
+
+    await onTap.future;
+    expect(onTap.isCompleted, isTrue);
+  });
+
   testWidgets('annotation drag events', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();
@@ -164,7 +205,7 @@ void main() {
 
     // Mock drag events
     final eventChannel = EventChannel(
-        "dev.flutter.pigeon.mapbox_maps_flutter.AnnotationInteractions._annotationDragEvents.0/${manager.id}",
+        "dev.flutter.pigeon.mapbox_maps_flutter.AnnotationInteractions._annotationInteractionEvents.0/${manager.id}/drag",
         pigeonMethodCodec);
     IntegrationTestWidgetsFlutterBinding.instance.defaultBinaryMessenger
         .setMockStreamHandler(eventChannel,

--- a/example/integration_test/annotations/polyline_annotation_manager_test.dart
+++ b/example/integration_test/annotations/polyline_annotation_manager_test.dart
@@ -187,6 +187,47 @@ void main() {
     expect(onTap.isCompleted, isTrue);
   });
 
+  testWidgets('annotation long press events', (tester) async {
+    final mapFuture = app.main();
+    await tester.pumpAndSettle();
+
+    final mapboxMap = await mapFuture;
+    final manager =
+        await mapboxMap.annotations.createPolylineAnnotationManager();
+
+    final geometry =
+        LineString(coordinates: [Position(0, 0), Position(10.0, 20.0)]);
+
+    final createdAnnotation = await manager.create(PolylineAnnotationOptions(
+      geometry: geometry,
+    ));
+
+    // Mock long press events
+    final eventChannel = EventChannel(
+        "dev.flutter.pigeon.mapbox_maps_flutter.AnnotationInteractions._annotationInteractionEvents.0/${manager.id}/long_press",
+        pigeonMethodCodec);
+    IntegrationTestWidgetsFlutterBinding.instance.defaultBinaryMessenger
+        .setMockStreamHandler(eventChannel,
+            MockStreamHandler.inline(onListen: (arguments, events) {
+      events.success(PolylineAnnotationInteractionContext(
+        annotation: createdAnnotation,
+        gestureState: GestureState.ended,
+      ));
+      events.endOfStream();
+    }));
+
+    final onLongPress = Completer();
+    manager.longPressEvents(
+      onLongPress: (annotation) {
+        expect(annotation.id, equals(createdAnnotation.id));
+        onLongPress.complete();
+      },
+    );
+
+    await onLongPress.future;
+    expect(onLongPress.isCompleted, isTrue);
+  });
+
   testWidgets('annotation drag events', (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();

--- a/example/integration_test/style/layer/fill_extrusion_layer_test.dart
+++ b/example/integration_test/style/layer/fill_extrusion_layer_test.dart
@@ -42,6 +42,7 @@ void main() {
       fillExtrusionLineWidth: 1.0,
       fillExtrusionOpacity: 1.0,
       fillExtrusionPattern: "abc",
+      fillExtrusionPatternCrossFade: 1.0,
       fillExtrusionRoundedRoof: true,
       fillExtrusionTranslate: [0.0, 1.0],
       fillExtrusionTranslateAnchor: FillExtrusionTranslateAnchor.MAP,
@@ -77,6 +78,7 @@ void main() {
     expect(layer.fillExtrusionLineWidth, 1.0);
     expect(layer.fillExtrusionOpacity, 1.0);
     expect(layer.fillExtrusionPattern, "abc");
+    expect(layer.fillExtrusionPatternCrossFade, 1.0);
     expect(layer.fillExtrusionRoundedRoof, true);
     expect(layer.fillExtrusionTranslate, [0.0, 1.0]);
     expect(
@@ -125,6 +127,7 @@ void main() {
       fillExtrusionLineWidthExpression: ['number', 1.0],
       fillExtrusionOpacityExpression: ['number', 1.0],
       fillExtrusionPatternExpression: ['image', "abc"],
+      fillExtrusionPatternCrossFadeExpression: ['number', 1.0],
       fillExtrusionRoundedRoofExpression: ['==', true, true],
       fillExtrusionTranslateExpression: [
         'literal',
@@ -169,6 +172,7 @@ void main() {
     expect(layer.fillExtrusionLineWidth, 1.0);
     expect(layer.fillExtrusionOpacity, 1.0);
     expect(layer.fillExtrusionPatternExpression, ['image', "abc"]);
+    expect(layer.fillExtrusionPatternCrossFade, 1.0);
     expect(layer.fillExtrusionRoundedRoof, true);
     expect(layer.fillExtrusionTranslate, [0.0, 1.0]);
     expect(

--- a/example/integration_test/style/layer/fill_extrusion_layer_test.dart
+++ b/example/integration_test/style/layer/fill_extrusion_layer_test.dart
@@ -42,7 +42,6 @@ void main() {
       fillExtrusionLineWidth: 1.0,
       fillExtrusionOpacity: 1.0,
       fillExtrusionPattern: "abc",
-      fillExtrusionPatternCrossFade: 1.0,
       fillExtrusionRoundedRoof: true,
       fillExtrusionTranslate: [0.0, 1.0],
       fillExtrusionTranslateAnchor: FillExtrusionTranslateAnchor.MAP,
@@ -78,7 +77,6 @@ void main() {
     expect(layer.fillExtrusionLineWidth, 1.0);
     expect(layer.fillExtrusionOpacity, 1.0);
     expect(layer.fillExtrusionPattern, "abc");
-    expect(layer.fillExtrusionPatternCrossFade, 1.0);
     expect(layer.fillExtrusionRoundedRoof, true);
     expect(layer.fillExtrusionTranslate, [0.0, 1.0]);
     expect(
@@ -127,7 +125,6 @@ void main() {
       fillExtrusionLineWidthExpression: ['number', 1.0],
       fillExtrusionOpacityExpression: ['number', 1.0],
       fillExtrusionPatternExpression: ['image', "abc"],
-      fillExtrusionPatternCrossFadeExpression: ['number', 1.0],
       fillExtrusionRoundedRoofExpression: ['==', true, true],
       fillExtrusionTranslateExpression: [
         'literal',
@@ -172,7 +169,6 @@ void main() {
     expect(layer.fillExtrusionLineWidth, 1.0);
     expect(layer.fillExtrusionOpacity, 1.0);
     expect(layer.fillExtrusionPatternExpression, ['image', "abc"]);
-    expect(layer.fillExtrusionPatternCrossFade, 1.0);
     expect(layer.fillExtrusionRoundedRoof, true);
     expect(layer.fillExtrusionTranslate, [0.0, 1.0]);
     expect(

--- a/example/integration_test/style/layer/fill_layer_test.dart
+++ b/example/integration_test/style/layer/fill_layer_test.dart
@@ -42,6 +42,7 @@ void main() {
       fillOpacity: 1.0,
       fillOutlineColor: Colors.red.value,
       fillPattern: "abc",
+      fillPatternCrossFade: 1.0,
       fillTranslate: [0.0, 1.0],
       fillTranslateAnchor: FillTranslateAnchor.MAP,
       fillTunnelStructureColor: Colors.red.value,
@@ -63,6 +64,7 @@ void main() {
     expect(layer.fillOpacity, 1.0);
     expect(layer.fillOutlineColor, Colors.red.value);
     expect(layer.fillPattern, "abc");
+    expect(layer.fillPatternCrossFade, 1.0);
     expect(layer.fillTranslate, [0.0, 1.0]);
     expect(layer.fillTranslateAnchor, FillTranslateAnchor.MAP);
     expect(layer.fillTunnelStructureColor, Colors.red.value);
@@ -107,6 +109,7 @@ void main() {
       fillOpacityExpression: ['number', 1.0],
       fillOutlineColorExpression: ['rgba', 255, 0, 0, 1],
       fillPatternExpression: ['image', "abc"],
+      fillPatternCrossFadeExpression: ['number', 1.0],
       fillTranslateExpression: [
         'literal',
         [0.0, 1.0]
@@ -136,6 +139,7 @@ void main() {
     expect(layer.fillOpacity, 1.0);
     expect(layer.fillOutlineColorExpression, ['rgba', 255, 0, 0, 1]);
     expect(layer.fillPatternExpression, ['image', "abc"]);
+    expect(layer.fillPatternCrossFade, 1.0);
     expect(layer.fillTranslate, [0.0, 1.0]);
     expect(layer.fillTranslateAnchor, FillTranslateAnchor.MAP);
     expect(layer.fillTunnelStructureColorExpression, ['rgba', 255, 0, 0, 1]);

--- a/example/integration_test/style/layer/fill_layer_test.dart
+++ b/example/integration_test/style/layer/fill_layer_test.dart
@@ -42,7 +42,6 @@ void main() {
       fillOpacity: 1.0,
       fillOutlineColor: Colors.red.value,
       fillPattern: "abc",
-      fillPatternCrossFade: 1.0,
       fillTranslate: [0.0, 1.0],
       fillTranslateAnchor: FillTranslateAnchor.MAP,
       fillTunnelStructureColor: Colors.red.value,
@@ -64,7 +63,6 @@ void main() {
     expect(layer.fillOpacity, 1.0);
     expect(layer.fillOutlineColor, Colors.red.value);
     expect(layer.fillPattern, "abc");
-    expect(layer.fillPatternCrossFade, 1.0);
     expect(layer.fillTranslate, [0.0, 1.0]);
     expect(layer.fillTranslateAnchor, FillTranslateAnchor.MAP);
     expect(layer.fillTunnelStructureColor, Colors.red.value);
@@ -109,7 +107,6 @@ void main() {
       fillOpacityExpression: ['number', 1.0],
       fillOutlineColorExpression: ['rgba', 255, 0, 0, 1],
       fillPatternExpression: ['image', "abc"],
-      fillPatternCrossFadeExpression: ['number', 1.0],
       fillTranslateExpression: [
         'literal',
         [0.0, 1.0]
@@ -139,7 +136,6 @@ void main() {
     expect(layer.fillOpacity, 1.0);
     expect(layer.fillOutlineColorExpression, ['rgba', 255, 0, 0, 1]);
     expect(layer.fillPatternExpression, ['image', "abc"]);
-    expect(layer.fillPatternCrossFade, 1.0);
     expect(layer.fillTranslate, [0.0, 1.0]);
     expect(layer.fillTranslateAnchor, FillTranslateAnchor.MAP);
     expect(layer.fillTunnelStructureColorExpression, ['rgba', 255, 0, 0, 1]);

--- a/example/integration_test/style/layer/line_layer_test.dart
+++ b/example/integration_test/style/layer/line_layer_test.dart
@@ -48,7 +48,6 @@ void main() {
       lineOffset: 1.0,
       lineOpacity: 1.0,
       linePattern: "abc",
-      linePatternCrossFade: 1.0,
       lineTranslate: [0.0, 1.0],
       lineTranslateAnchor: LineTranslateAnchor.MAP,
       lineTrimColor: Colors.red.value,
@@ -84,7 +83,6 @@ void main() {
     expect(layer.lineOffset, 1.0);
     expect(layer.lineOpacity, 1.0);
     expect(layer.linePattern, "abc");
-    expect(layer.linePatternCrossFade, 1.0);
     expect(layer.lineTranslate, [0.0, 1.0]);
     expect(layer.lineTranslateAnchor, LineTranslateAnchor.MAP);
     expect(layer.lineTrimColor, Colors.red.value);
@@ -140,7 +138,6 @@ void main() {
       lineOffsetExpression: ['number', 1.0],
       lineOpacityExpression: ['number', 1.0],
       linePatternExpression: ['image', "abc"],
-      linePatternCrossFadeExpression: ['number', 1.0],
       lineTranslateExpression: [
         'literal',
         [0.0, 1.0]
@@ -190,7 +187,6 @@ void main() {
     expect(layer.lineOffset, 1.0);
     expect(layer.lineOpacity, 1.0);
     expect(layer.linePatternExpression, ['image', "abc"]);
-    expect(layer.linePatternCrossFade, 1.0);
     expect(layer.lineTranslate, [0.0, 1.0]);
     expect(layer.lineTranslateAnchor, LineTranslateAnchor.MAP);
     expect(layer.lineTrimColorExpression, ['rgba', 255, 0, 0, 1]);

--- a/example/integration_test/style/layer/line_layer_test.dart
+++ b/example/integration_test/style/layer/line_layer_test.dart
@@ -48,6 +48,7 @@ void main() {
       lineOffset: 1.0,
       lineOpacity: 1.0,
       linePattern: "abc",
+      linePatternCrossFade: 1.0,
       lineTranslate: [0.0, 1.0],
       lineTranslateAnchor: LineTranslateAnchor.MAP,
       lineTrimColor: Colors.red.value,
@@ -83,6 +84,7 @@ void main() {
     expect(layer.lineOffset, 1.0);
     expect(layer.lineOpacity, 1.0);
     expect(layer.linePattern, "abc");
+    expect(layer.linePatternCrossFade, 1.0);
     expect(layer.lineTranslate, [0.0, 1.0]);
     expect(layer.lineTranslateAnchor, LineTranslateAnchor.MAP);
     expect(layer.lineTrimColor, Colors.red.value);
@@ -138,6 +140,7 @@ void main() {
       lineOffsetExpression: ['number', 1.0],
       lineOpacityExpression: ['number', 1.0],
       linePatternExpression: ['image', "abc"],
+      linePatternCrossFadeExpression: ['number', 1.0],
       lineTranslateExpression: [
         'literal',
         [0.0, 1.0]
@@ -187,6 +190,7 @@ void main() {
     expect(layer.lineOffset, 1.0);
     expect(layer.lineOpacity, 1.0);
     expect(layer.linePatternExpression, ['image', "abc"]);
+    expect(layer.linePatternCrossFade, 1.0);
     expect(layer.lineTranslate, [0.0, 1.0]);
     expect(layer.lineTranslateAnchor, LineTranslateAnchor.MAP);
     expect(layer.lineTrimColorExpression, ['rgba', 255, 0, 0, 1]);

--- a/example/lib/animated_route_example.dart
+++ b/example/lib/animated_route_example.dart
@@ -25,8 +25,7 @@ class AnimatedRouteExample extends StatefulWidget implements Example {
 }
 
 class AnimatedRouteExampleState extends State<AnimatedRouteExample>
-    with TickerProviderStateMixin
-    implements OnPointAnnotationClickListener {
+    with TickerProviderStateMixin {
   final defaultEdgeInsets =
       MbxEdgeInsets(top: 100, left: 100, bottom: 100, right: 100);
 
@@ -186,7 +185,7 @@ class AnimatedRouteExampleState extends State<AnimatedRouteExample>
         pointAnnotationManager?.addAnnotation(imageData, coordinate);
       }
 
-      pointAnnotationManager?.addOnPointAnnotationClickListener(this);
+      pointAnnotationManager?.tapEvents(onTap: onPointAnnotationClick);
 
       // animate camera to view annotations + puck position
       final camera = await mapboxMap.cameraForCoordinates(
@@ -210,7 +209,6 @@ class AnimatedRouteExampleState extends State<AnimatedRouteExample>
         null);
   }
 
-  @override
   void onPointAnnotationClick(PointAnnotation annotation) async {
     // build route from puck position to the clicked annotation
     final start = await mapboxMap.style.getPuckPosition();

--- a/example/lib/circle_annotations_example.dart
+++ b/example/lib/circle_annotations_example.dart
@@ -15,20 +15,6 @@ class CircleAnnotationExample extends StatefulWidget implements Example {
   State<StatefulWidget> createState() => CircleAnnotationExampleState();
 }
 
-class AnnotationClickListener extends OnCircleAnnotationClickListener {
-  AnnotationClickListener({
-    required this.onAnnotationClick,
-  });
-
-  final void Function(CircleAnnotation annotation) onAnnotationClick;
-
-  @override
-  void onCircleAnnotationClick(CircleAnnotation annotation) {
-    print("onAnnotationClick, id: ${annotation.id}");
-    onAnnotationClick(annotation);
-  }
-}
-
 class CircleAnnotationExampleState extends State<CircleAnnotationExample> {
   CircleAnnotationExampleState();
 
@@ -58,6 +44,10 @@ class CircleAnnotationExampleState extends State<CircleAnnotationExample> {
       circleAnnotationManager?.tapEvents(onTap: (annotation) {
         // ignore: avoid_print
         print("onAnnotationClick, id: ${annotation.id}");
+      });
+      circleAnnotationManager?.longPressEvents(onLongPress: (annotation) {
+        // ignore: avoid_print
+        print("onAnnotationLongPress, id: ${annotation.id}");
       });
     });
   }

--- a/example/lib/circle_annotations_example.dart
+++ b/example/lib/circle_annotations_example.dart
@@ -55,11 +55,10 @@ class CircleAnnotationExampleState extends State<CircleAnnotationExample> {
         ));
       }
       circleAnnotationManager?.createMulti(options);
-      circleAnnotationManager?.addOnCircleAnnotationClickListener(
-        AnnotationClickListener(
-          onAnnotationClick: (annotation) => circleAnnotation = annotation,
-        ),
-      );
+      circleAnnotationManager?.tapEvents(onTap: (annotation) {
+        // ignore: avoid_print
+        print("onAnnotationClick, id: ${annotation.id}");
+      });
     });
   }
 

--- a/example/lib/point_annotations_example.dart
+++ b/example/lib/point_annotations_example.dart
@@ -17,13 +17,6 @@ class PointAnnotationExample extends StatefulWidget implements Example {
   State<StatefulWidget> createState() => PointAnnotationExampleState();
 }
 
-class AnnotationClickListener extends OnPointAnnotationClickListener {
-  @override
-  void onPointAnnotationClick(PointAnnotation annotation) {
-    print("onAnnotationClick, id: ${annotation.id}");
-  }
-}
-
 class PointAnnotationExampleState extends State<PointAnnotationExample> {
   PointAnnotationExampleState();
 
@@ -57,6 +50,10 @@ class PointAnnotationExampleState extends State<PointAnnotationExample> {
       pointAnnotationManager?.tapEvents(onTap: (annotation) {
         // ignore: avoid_print
         print("onAnnotationClick, id: ${annotation.id}");
+      });
+      pointAnnotationManager?.longPressEvents(onLongPress: (annotation) {
+        // ignore: avoid_print
+        print("onAnnotationLongPress, id: ${annotation.id}");
       });
     });
   }

--- a/example/lib/point_annotations_example.dart
+++ b/example/lib/point_annotations_example.dart
@@ -56,6 +56,9 @@ class PointAnnotationExampleState extends State<PointAnnotationExample> {
       pointAnnotationManager?.createMulti(carOptions);
       pointAnnotationManager
           ?.addOnPointAnnotationClickListener(AnnotationClickListener());
+      pointAnnotationManager?.tapEvents(onTap: (PointAnnotation annotation) {
+        print("[mai] onTap, id: ${annotation.id}");
+      });
     });
   }
 

--- a/example/lib/point_annotations_example.dart
+++ b/example/lib/point_annotations_example.dart
@@ -54,10 +54,9 @@ class PointAnnotationExampleState extends State<PointAnnotationExample> {
             geometry: createRandomPoint(), iconImage: "car-15"));
       }
       pointAnnotationManager?.createMulti(carOptions);
-      pointAnnotationManager
-          ?.addOnPointAnnotationClickListener(AnnotationClickListener());
-      pointAnnotationManager?.tapEvents(onTap: (PointAnnotation annotation) {
-        print("[mai] onTap, id: ${annotation.id}");
+      pointAnnotationManager?.tapEvents(onTap: (annotation) {
+        // ignore: avoid_print
+        print("onAnnotationClick, id: ${annotation.id}");
       });
     });
   }

--- a/example/lib/polygon_annotations_example.dart
+++ b/example/lib/polygon_annotations_example.dart
@@ -54,11 +54,10 @@ class PolygonAnnotationExampleState extends State<PolygonAnnotationExample> {
             fillColor: createRandomColor()));
       }
       polygonAnnotationManager?.createMulti(options);
-      polygonAnnotationManager?.addOnPolygonAnnotationClickListener(
-        AnnotationClickListener(
-          onAnnotationClick: (annotation) => polygonAnnotation = annotation,
-        ),
-      );
+      polygonAnnotationManager?.tapEvents(onTap: (annotation) {
+        // ignore: avoid_print
+        print("onAnnotationClick, id: ${annotation.id}");
+      });
     });
   }
 

--- a/example/lib/polygon_annotations_example.dart
+++ b/example/lib/polygon_annotations_example.dart
@@ -16,20 +16,6 @@ class PolygonAnnotationExample extends StatefulWidget implements Example {
   State<StatefulWidget> createState() => PolygonAnnotationExampleState();
 }
 
-class AnnotationClickListener extends OnPolygonAnnotationClickListener {
-  AnnotationClickListener({
-    required this.onAnnotationClick,
-  });
-
-  final void Function(PolygonAnnotation annotation) onAnnotationClick;
-
-  @override
-  void onPolygonAnnotationClick(PolygonAnnotation annotation) {
-    print("onAnnotationClick, id: ${annotation.id}");
-    onAnnotationClick(annotation);
-  }
-}
-
 class PolygonAnnotationExampleState extends State<PolygonAnnotationExample> {
   PolygonAnnotationExampleState();
 
@@ -57,6 +43,10 @@ class PolygonAnnotationExampleState extends State<PolygonAnnotationExample> {
       polygonAnnotationManager?.tapEvents(onTap: (annotation) {
         // ignore: avoid_print
         print("onAnnotationClick, id: ${annotation.id}");
+      });
+      polygonAnnotationManager?.longPressEvents(onLongPress: (annotation) {
+        // ignore: avoid_print
+        print("onAnnotationLongPress, id: ${annotation.id}");
       });
     });
   }

--- a/example/lib/polyline_annotations_example.dart
+++ b/example/lib/polyline_annotations_example.dart
@@ -16,13 +16,6 @@ class PolylineAnnotationExample extends StatefulWidget implements Example {
   State<StatefulWidget> createState() => PolylineAnnotationExampleState();
 }
 
-class AnnotationClickListener extends OnPolylineAnnotationClickListener {
-  @override
-  void onPolylineAnnotationClick(PolylineAnnotation annotation) {
-    print("onAnnotationClick, id: ${annotation.id}");
-  }
-}
-
 class PolylineAnnotationExampleState extends State<PolylineAnnotationExample> {
   MapboxMap? mapboxMap;
   PolylineAnnotation? polylineAnnotation;
@@ -49,6 +42,10 @@ class PolylineAnnotationExampleState extends State<PolylineAnnotationExample> {
       polylineAnnotationManager?.tapEvents(onTap: (annotation) {
         // ignore: avoid_print
         print("onAnnotationClick, id: ${annotation.id}");
+      });
+      polylineAnnotationManager?.longPressEvents(onLongPress: (annotation) {
+        // ignore: avoid_print
+        print("onAnnotationLongPress, id: ${annotation.id}");
       });
     });
   }

--- a/example/lib/polyline_annotations_example.dart
+++ b/example/lib/polyline_annotations_example.dart
@@ -46,8 +46,10 @@ class PolylineAnnotationExampleState extends State<PolylineAnnotationExample> {
               geometry: LineString(coordinates: e),
               lineColor: createRandomColor()))
           .toList());
-      polylineAnnotationManager
-          ?.addOnPolylineAnnotationClickListener(AnnotationClickListener());
+      polylineAnnotationManager?.tapEvents(onTap: (annotation) {
+        // ignore: avoid_print
+        print("onAnnotationClick, id: ${annotation.id}");
+      });
     });
   }
 

--- a/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Annotations/AnnotationController.swift
+++ b/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Annotations/AnnotationController.swift
@@ -67,6 +67,7 @@ class AnnotationController {
 
         let dragStream = AnyAnnotationInteractionEventsStreamHandler()
         let tapStream = AnyAnnotationInteractionEventsStreamHandler()
+        let longPressStream = AnyAnnotationInteractionEventsStreamHandler()
 
         if let manager: AnnotationManager = {
             switch type {
@@ -78,7 +79,8 @@ class AnnotationController {
                 circleAnnotationController.add(
                     controller: circleManager,
                     onTap: tapStream.send(event:),
-                    onDrag: dragStream.send(event:)
+                    onDrag: dragStream.send(event:),
+                    onLongPress: longPressStream.send(event:)
                 )
                 disposal[id] = circleAnnotationController.removeController(id:)
                 return circleManager
@@ -89,8 +91,10 @@ class AnnotationController {
                 )
                 pointAnnotationController.add(
                     controller: pointManager,
-                    onTap: tapStream.send(event:)
-                    , onDrag: dragStream.send(event:))
+                    onTap: tapStream.send(event:),
+                    onDrag: dragStream.send(event:),
+                    onLongPress: longPressStream.send(event:)
+                )
                 disposal[id] = pointAnnotationController.removeController(id:)
                 return pointManager
             case "polygon":
@@ -101,7 +105,8 @@ class AnnotationController {
                 polygonAnnotationController.add(
                     controller: polygonManager,
                     onTap: tapStream.send(event:),
-                    onDrag: dragStream.send(event:))
+                    onDrag: dragStream.send(event:),
+                    onLongPress: longPressStream.send(event:)                )
                 disposal[id] = polygonAnnotationController.removeController(id:)
                 return polygonManager
             case "polyline":
@@ -112,8 +117,8 @@ class AnnotationController {
                 polylineAnnotationController.add(
                     controller: polylineManager,
                     onTap: tapStream.send(event:),
-                    onDrag: dragStream.send(event:)
-                )
+                    onDrag: dragStream.send(event:),
+                    onLongPress: longPressStream.send(event:)                )
                 disposal[id] = polylineAnnotationController.removeController(id:)
                 return polylineManager
             default:
@@ -128,6 +133,10 @@ class AnnotationController {
                 with: binaryMessenger.messenger,
                 instanceName: binaryMessenger.suffix + "/" + id + "/drag",
                 streamHandler: dragStream)
+            AnnotationInteractionEventsStreamHandler.register(
+                with: binaryMessenger.messenger,
+                instanceName: binaryMessenger.suffix + "/" + id + "/long_press",
+                streamHandler: longPressStream)
             result(manager.id)
         } else {
             result(AnnotationControllerError.wrongManagerType)

--- a/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Annotations/AnnotationController.swift
+++ b/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Annotations/AnnotationController.swift
@@ -8,36 +8,6 @@ enum AnnotationControllerError: Error {
     case wrongManagerType
 }
 
-extension AnnotationController: AnnotationInteractionDelegate {
-    func annotationManager(_ manager: AnnotationManager, didDetectTappedAnnotations annotations: [Annotation]) {
-        let annotation = annotations.first
-        switch annotation {
-        case let annotation as MapboxMaps.PointAnnotation:
-            self.onPointAnnotationClickListener?.onPointAnnotationClick(
-                annotation: annotation.toFLTPointAnnotation(),
-                completion: {_ in }
-            )
-        case let annotation as MapboxMaps.CircleAnnotation:
-            self.onCircleAnnotationClickListener?.onCircleAnnotationClick(
-                annotation: annotation.toFLTCircleAnnotation(),
-                completion: {_ in }
-            )
-        case let annotation as MapboxMaps.PolygonAnnotation:
-            self.onPolygonAnnotationClickListener?.onPolygonAnnotationClick(
-                annotation: annotation.toFLTPolygonAnnotation(),
-                completion: {_ in }
-            )
-        case let annotation as MapboxMaps.PolylineAnnotation:
-            self.onPolylineAnnotationClickListener?.onPolylineAnnotationClick(
-                annotation: annotation.toFLTPolylineAnnotation(),
-                completion: {_ in }
-            )
-        default:
-            print("Can't detemine the type of annotation: \(String(describing: annotation))")
-        }
-    }
-}
-
 private class AnyAnnotationInteractionEventsStreamHandler: AnnotationInteractionEventsStreamHandler {
     private var sink: PigeonEventSink<AnnotationInteractionContext>?
 
@@ -74,10 +44,6 @@ class AnnotationController {
     private let pointAnnotationController: PointAnnotationController
     private let polygonAnnotationController: PolygonAnnotationController
     private let polylineAnnotationController: PolylineAnnotationController
-    private var onPointAnnotationClickListener: OnPointAnnotationClickListener?
-    private var onCircleAnnotationClickListener: OnCircleAnnotationClickListener?
-    private var onPolygonAnnotationClickListener: OnPolygonAnnotationClickListener?
-    private var onPolylineAnnotationClickListener: OnPolylineAnnotationClickListener?
 
     init(withMapView mapView: MapView, messenger: SuffixBinaryMessenger) {
         self.mapView = mapView
@@ -183,10 +149,6 @@ class AnnotationController {
         _PointAnnotationMessengerSetup.setUp(binaryMessenger: binaryMessenger.messenger, api: pointAnnotationController, messageChannelSuffix: binaryMessenger.suffix)
         _PolygonAnnotationMessengerSetup.setUp(binaryMessenger: binaryMessenger.messenger, api: polygonAnnotationController, messageChannelSuffix: binaryMessenger.suffix)
         _PolylineAnnotationMessengerSetup.setUp(binaryMessenger: binaryMessenger.messenger, api: polylineAnnotationController, messageChannelSuffix: binaryMessenger.suffix)
-        onPointAnnotationClickListener = OnPointAnnotationClickListener(binaryMessenger: binaryMessenger.messenger, messageChannelSuffix: binaryMessenger.suffix)
-        onCircleAnnotationClickListener = OnCircleAnnotationClickListener(binaryMessenger: binaryMessenger.messenger, messageChannelSuffix: binaryMessenger.suffix)
-        onPolygonAnnotationClickListener = OnPolygonAnnotationClickListener(binaryMessenger: binaryMessenger.messenger, messageChannelSuffix: binaryMessenger.suffix)
-        onPolylineAnnotationClickListener = OnPolylineAnnotationClickListener(binaryMessenger: binaryMessenger.messenger, messageChannelSuffix: binaryMessenger.suffix)
     }
 
     func tearDown() {
@@ -194,9 +156,5 @@ class AnnotationController {
         _PointAnnotationMessengerSetup.setUp(binaryMessenger: binaryMessenger.messenger, api: nil, messageChannelSuffix: binaryMessenger.suffix)
         _PolygonAnnotationMessengerSetup.setUp(binaryMessenger: binaryMessenger.messenger, api: nil, messageChannelSuffix: binaryMessenger.suffix)
         _PolylineAnnotationMessengerSetup.setUp(binaryMessenger: binaryMessenger.messenger, api: nil, messageChannelSuffix: binaryMessenger.suffix)
-        onPointAnnotationClickListener = nil
-        onCircleAnnotationClickListener = nil
-        onPolygonAnnotationClickListener = nil
-        onPolylineAnnotationClickListener = nil
     }
 }

--- a/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Annotations/BaseAnnotationMessenger.swift
+++ b/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Annotations/BaseAnnotationMessenger.swift
@@ -16,6 +16,7 @@ class BaseAnnotationMessenger<C: AnnotationControllable> {
         let controller: C
         let onTap: (AnnotationInteractionContext) -> Void
         let onDrag: (AnnotationInteractionContext) -> Void
+        let onLongPress: (AnnotationInteractionContext) -> Void
     }
     private var storage: [String: Storage] = [:]
 
@@ -27,6 +28,10 @@ class BaseAnnotationMessenger<C: AnnotationControllable> {
         storage[managerId]?.onDrag(context)
     }
 
+    func longPress(_ context: AnnotationInteractionContext, managerId: String) {
+        storage[managerId]?.onLongPress(context)
+    }
+
     private subscript(id: String) -> C? {
         return storage[id]?.controller
     }
@@ -34,9 +39,10 @@ class BaseAnnotationMessenger<C: AnnotationControllable> {
     func add(
         controller: C,
         onTap: @escaping (AnnotationInteractionContext) -> Void,
-        onDrag: @escaping (AnnotationInteractionContext) -> Void
+        onDrag: @escaping (AnnotationInteractionContext) -> Void,
+        onLongPress: @escaping (AnnotationInteractionContext) -> Void
     ) {
-        storage[controller.id] = Storage(controller: controller, onTap: onTap, onDrag: onDrag)
+        storage[controller.id] = Storage(controller: controller, onTap: onTap, onDrag: onDrag, onLongPress: onLongPress)
     }
 
     func removeController(id: String) {

--- a/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Annotations/BaseAnnotationMessenger.swift
+++ b/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Annotations/BaseAnnotationMessenger.swift
@@ -1,12 +1,6 @@
 import MapboxMaps
 import Flutter
 
-protocol InteractableAnnotation: Annotation {
-    var dragBeginHandler: ((inout Self, InteractionContext) -> Bool)? { get set }
-    var dragChangeHandler: ((inout Self, InteractionContext) -> Void)? { get set }
-    var dragEndHandler: ((inout Self, InteractionContext) -> Void)? { get set }
-}
-
 protocol AnnotationControllable: AnnotationManager {
     associatedtype Child: Annotation
     var annotations: [Child] { get set }
@@ -20,31 +14,40 @@ extension PolygonAnnotationManager: AnnotationControllable {}
 class BaseAnnotationMessenger<C: AnnotationControllable> {
     private struct Storage {
         let controller: C
-        let sendGestureEvents: (AnnotationInteractionContext) -> Void
+        let onTap: (AnnotationInteractionContext) -> Void
+        let onDrag: (AnnotationInteractionContext) -> Void
     }
     private var storage: [String: Storage] = [:]
 
-    func sendGestureEvent(_ context: AnnotationInteractionContext, managerId: String) {
-        storage[managerId]?.sendGestureEvents(context)
+    func tap(_ context: AnnotationInteractionContext, managerId: String) {
+        storage[managerId]?.onTap(context)
+    }
+
+    func drag(_ context: AnnotationInteractionContext, managerId: String) {
+        storage[managerId]?.onDrag(context)
     }
 
     private subscript(id: String) -> C? {
         return storage[id]?.controller
     }
 
-    func add(controller: C, sendGestureEvents: @escaping (AnnotationInteractionContext) -> Void) {
-        storage[controller.id] = Storage(controller: controller, sendGestureEvents: sendGestureEvents)
+    func add(
+        controller: C,
+        onTap: @escaping (AnnotationInteractionContext) -> Void,
+        onDrag: @escaping (AnnotationInteractionContext) -> Void
+    ) {
+        storage[controller.id] = Storage(controller: controller, onTap: onTap, onDrag: onDrag)
     }
 
     func removeController(id: String) {
         storage[id] = nil
     }
 
-    func append<T: InteractableAnnotation>(_ annotation: T, managerId: String) throws where T == C.Child {
+    func append(_ annotation: C.Child, managerId: String) throws {
         try append([annotation], managerId: managerId)
     }
 
-    func append<T: InteractableAnnotation>(_ annotations: [T], managerId: String) throws where T == C.Child {
+    func append(_ annotations: [C.Child], managerId: String) throws {
         guard let annotationManager = self[managerId] else {
             throw AnnotationControllerError.noManagerFound
         }

--- a/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Annotations/CircleAnnotationController.swift
+++ b/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Annotations/CircleAnnotationController.swift
@@ -4,8 +4,6 @@
 import Foundation
 import Flutter
 
-extension MapboxMaps.CircleAnnotation: InteractableAnnotation {}
-
 final class CircleAnnotationController: BaseAnnotationMessenger<CircleAnnotationManager>, _CircleAnnotationMessenger {
     private static let errorCode = "0"
     private typealias AnnotationManager = CircleAnnotationManager
@@ -25,24 +23,31 @@ final class CircleAnnotationController: BaseAnnotationMessenger<CircleAnnotation
         do {
             let annotations = annotationOptions.map({ options in
                 var annotation = options.toCircleAnnotation()
+                annotation.tapHandler = { [weak self] (context) in
+                    let context = CircleAnnotationInteractionContext(
+                        annotation: annotation.toFLTCircleAnnotation(),
+                        gestureState: .ended)
+                    self?.tap(context, managerId: managerId)
+                    return true
+                }
                 annotation.dragBeginHandler = { [weak self] (annotation, context) in
                     let context = CircleAnnotationInteractionContext(
                         annotation: annotation.toFLTCircleAnnotation(),
                         gestureState: .started)
-                    self?.sendGestureEvent(context, managerId: managerId)
+                    self?.drag(context, managerId: managerId)
                     return true
                 }
                 annotation.dragChangeHandler = { [weak self] (annotation, context) in
                     let context = CircleAnnotationInteractionContext(
                         annotation: annotation.toFLTCircleAnnotation(),
                         gestureState: .changed)
-                    self?.sendGestureEvent(context, managerId: managerId)
+                    self?.drag(context, managerId: managerId)
                 }
 				annotation.dragEndHandler = { [weak self] (annotation, context) in
               	    let context = CircleAnnotationInteractionContext(
                 	    annotation: annotation.toFLTCircleAnnotation(),
                         gestureState: .ended)
-                    self?.sendGestureEvent(context, managerId: managerId)
+                    self?.drag(context, managerId: managerId)
                 }
                 return annotation
             })

--- a/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Annotations/CircleAnnotationController.swift
+++ b/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Annotations/CircleAnnotationController.swift
@@ -30,6 +30,13 @@ final class CircleAnnotationController: BaseAnnotationMessenger<CircleAnnotation
                     self?.tap(context, managerId: managerId)
                     return true
                 }
+                annotation.longPressHandler = { [weak self] (context) in
+                    let context = CircleAnnotationInteractionContext(
+                        annotation: annotation.toFLTCircleAnnotation(),
+                        gestureState: .ended)
+                    self?.longPress(context, managerId: managerId)
+                    return true
+                }
                 annotation.dragBeginHandler = { [weak self] (annotation, context) in
                     let context = CircleAnnotationInteractionContext(
                         annotation: annotation.toFLTCircleAnnotation(),

--- a/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Annotations/PointAnnotationController.swift
+++ b/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Annotations/PointAnnotationController.swift
@@ -4,8 +4,6 @@
 import Foundation
 import Flutter
 
-extension MapboxMaps.PointAnnotation: InteractableAnnotation {}
-
 final class PointAnnotationController: BaseAnnotationMessenger<PointAnnotationManager>, _PointAnnotationMessenger {
     private static let errorCode = "0"
     private typealias AnnotationManager = PointAnnotationManager
@@ -25,24 +23,31 @@ final class PointAnnotationController: BaseAnnotationMessenger<PointAnnotationMa
         do {
             let annotations = annotationOptions.map({ options in
                 var annotation = options.toPointAnnotation()
+                annotation.tapHandler = { [weak self] (context) in
+                    let context = PointAnnotationInteractionContext(
+                        annotation: annotation.toFLTPointAnnotation(),
+                        gestureState: .ended)
+                    self?.tap(context, managerId: managerId)
+                    return true
+                }
                 annotation.dragBeginHandler = { [weak self] (annotation, context) in
                     let context = PointAnnotationInteractionContext(
                         annotation: annotation.toFLTPointAnnotation(),
                         gestureState: .started)
-                    self?.sendGestureEvent(context, managerId: managerId)
+                    self?.drag(context, managerId: managerId)
                     return true
                 }
                 annotation.dragChangeHandler = { [weak self] (annotation, context) in
                     let context = PointAnnotationInteractionContext(
                         annotation: annotation.toFLTPointAnnotation(),
                         gestureState: .changed)
-                    self?.sendGestureEvent(context, managerId: managerId)
+                    self?.drag(context, managerId: managerId)
                 }
 				annotation.dragEndHandler = { [weak self] (annotation, context) in
               	    let context = PointAnnotationInteractionContext(
                 	    annotation: annotation.toFLTPointAnnotation(),
                         gestureState: .ended)
-                    self?.sendGestureEvent(context, managerId: managerId)
+                    self?.drag(context, managerId: managerId)
                 }
                 return annotation
             })

--- a/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Annotations/PointAnnotationController.swift
+++ b/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Annotations/PointAnnotationController.swift
@@ -30,6 +30,13 @@ final class PointAnnotationController: BaseAnnotationMessenger<PointAnnotationMa
                     self?.tap(context, managerId: managerId)
                     return true
                 }
+                annotation.longPressHandler = { [weak self] (context) in
+                    let context = PointAnnotationInteractionContext(
+                        annotation: annotation.toFLTPointAnnotation(),
+                        gestureState: .ended)
+                    self?.longPress(context, managerId: managerId)
+                    return true
+                }
                 annotation.dragBeginHandler = { [weak self] (annotation, context) in
                     let context = PointAnnotationInteractionContext(
                         annotation: annotation.toFLTPointAnnotation(),

--- a/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Annotations/PolygonAnnotationController.swift
+++ b/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Annotations/PolygonAnnotationController.swift
@@ -4,8 +4,6 @@
 import Foundation
 import Flutter
 
-extension MapboxMaps.PolygonAnnotation: InteractableAnnotation {}
-
 final class PolygonAnnotationController: BaseAnnotationMessenger<PolygonAnnotationManager>, _PolygonAnnotationMessenger {
     private static let errorCode = "0"
     private typealias AnnotationManager = PolygonAnnotationManager
@@ -25,24 +23,31 @@ final class PolygonAnnotationController: BaseAnnotationMessenger<PolygonAnnotati
         do {
             let annotations = annotationOptions.map({ options in
                 var annotation = options.toPolygonAnnotation()
+                annotation.tapHandler = { [weak self] (context) in
+                    let context = PolygonAnnotationInteractionContext(
+                        annotation: annotation.toFLTPolygonAnnotation(),
+                        gestureState: .ended)
+                    self?.tap(context, managerId: managerId)
+                    return true
+                }
                 annotation.dragBeginHandler = { [weak self] (annotation, context) in
                     let context = PolygonAnnotationInteractionContext(
                         annotation: annotation.toFLTPolygonAnnotation(),
                         gestureState: .started)
-                    self?.sendGestureEvent(context, managerId: managerId)
+                    self?.drag(context, managerId: managerId)
                     return true
                 }
                 annotation.dragChangeHandler = { [weak self] (annotation, context) in
                     let context = PolygonAnnotationInteractionContext(
                         annotation: annotation.toFLTPolygonAnnotation(),
                         gestureState: .changed)
-                    self?.sendGestureEvent(context, managerId: managerId)
+                    self?.drag(context, managerId: managerId)
                 }
 				annotation.dragEndHandler = { [weak self] (annotation, context) in
               	    let context = PolygonAnnotationInteractionContext(
                 	    annotation: annotation.toFLTPolygonAnnotation(),
                         gestureState: .ended)
-                    self?.sendGestureEvent(context, managerId: managerId)
+                    self?.drag(context, managerId: managerId)
                 }
                 return annotation
             })

--- a/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Annotations/PolygonAnnotationController.swift
+++ b/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Annotations/PolygonAnnotationController.swift
@@ -30,6 +30,13 @@ final class PolygonAnnotationController: BaseAnnotationMessenger<PolygonAnnotati
                     self?.tap(context, managerId: managerId)
                     return true
                 }
+                annotation.longPressHandler = { [weak self] (context) in
+                    let context = PolygonAnnotationInteractionContext(
+                        annotation: annotation.toFLTPolygonAnnotation(),
+                        gestureState: .ended)
+                    self?.longPress(context, managerId: managerId)
+                    return true
+                }
                 annotation.dragBeginHandler = { [weak self] (annotation, context) in
                     let context = PolygonAnnotationInteractionContext(
                         annotation: annotation.toFLTPolygonAnnotation(),

--- a/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Annotations/PolylineAnnotationController.swift
+++ b/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Annotations/PolylineAnnotationController.swift
@@ -4,8 +4,6 @@
 import Foundation
 import Flutter
 
-extension MapboxMaps.PolylineAnnotation: InteractableAnnotation {}
-
 final class PolylineAnnotationController: BaseAnnotationMessenger<PolylineAnnotationManager>, _PolylineAnnotationMessenger {
     private static let errorCode = "0"
     private typealias AnnotationManager = PolylineAnnotationManager
@@ -25,24 +23,31 @@ final class PolylineAnnotationController: BaseAnnotationMessenger<PolylineAnnota
         do {
             let annotations = annotationOptions.map({ options in
                 var annotation = options.toPolylineAnnotation()
+                annotation.tapHandler = { [weak self] (context) in
+                    let context = PolylineAnnotationInteractionContext(
+                        annotation: annotation.toFLTPolylineAnnotation(),
+                        gestureState: .ended)
+                    self?.tap(context, managerId: managerId)
+                    return true
+                }
                 annotation.dragBeginHandler = { [weak self] (annotation, context) in
                     let context = PolylineAnnotationInteractionContext(
                         annotation: annotation.toFLTPolylineAnnotation(),
                         gestureState: .started)
-                    self?.sendGestureEvent(context, managerId: managerId)
+                    self?.drag(context, managerId: managerId)
                     return true
                 }
                 annotation.dragChangeHandler = { [weak self] (annotation, context) in
                     let context = PolylineAnnotationInteractionContext(
                         annotation: annotation.toFLTPolylineAnnotation(),
                         gestureState: .changed)
-                    self?.sendGestureEvent(context, managerId: managerId)
+                    self?.drag(context, managerId: managerId)
                 }
 				annotation.dragEndHandler = { [weak self] (annotation, context) in
               	    let context = PolylineAnnotationInteractionContext(
                 	    annotation: annotation.toFLTPolylineAnnotation(),
                         gestureState: .ended)
-                    self?.sendGestureEvent(context, managerId: managerId)
+                    self?.drag(context, managerId: managerId)
                 }
                 return annotation
             })

--- a/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Annotations/PolylineAnnotationController.swift
+++ b/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Annotations/PolylineAnnotationController.swift
@@ -30,6 +30,13 @@ final class PolylineAnnotationController: BaseAnnotationMessenger<PolylineAnnota
                     self?.tap(context, managerId: managerId)
                     return true
                 }
+                annotation.longPressHandler = { [weak self] (context) in
+                    let context = PolylineAnnotationInteractionContext(
+                        annotation: annotation.toFLTPolylineAnnotation(),
+                        gestureState: .ended)
+                    self?.longPress(context, managerId: managerId)
+                    return true
+                }
                 annotation.dragBeginHandler = { [weak self] (annotation, context) in
                     let context = PolylineAnnotationInteractionContext(
                         annotation: annotation.toFLTPolylineAnnotation(),

--- a/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Generated/CircleAnnotationMessenger.swift
+++ b/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Generated/CircleAnnotationMessenger.swift
@@ -56,10 +56,6 @@ private func wrapError(_ error: Any) -> [Any?] {
   ]
 }
 
-private func createConnectionError(withChannelName channelName: String) -> CircleAnnotationMessengerError {
-  return CircleAnnotationMessengerError(code: "channel-error", message: "Unable to establish connection on channel: '\(channelName)'.", details: "")
-}
-
 private func isNullish(_ value: Any?) -> Bool {
   return value is NSNull || value == nil
 }
@@ -338,39 +334,6 @@ class CircleAnnotationMessengerPigeonCodec: FlutterStandardMessageCodec, @unchec
   static let shared = CircleAnnotationMessengerPigeonCodec(readerWriter: CircleAnnotationMessengerPigeonCodecReaderWriter())
 }
 
-/// Generated protocol from Pigeon that represents Flutter messages that can be called from Swift.
-protocol OnCircleAnnotationClickListenerProtocol {
-  func onCircleAnnotationClick(annotation annotationArg: CircleAnnotation, completion: @escaping (Result<Void, CircleAnnotationMessengerError>) -> Void)
-}
-class OnCircleAnnotationClickListener: OnCircleAnnotationClickListenerProtocol {
-  private let binaryMessenger: FlutterBinaryMessenger
-  private let messageChannelSuffix: String
-  init(binaryMessenger: FlutterBinaryMessenger, messageChannelSuffix: String = "") {
-    self.binaryMessenger = binaryMessenger
-    self.messageChannelSuffix = messageChannelSuffix.count > 0 ? ".\(messageChannelSuffix)" : ""
-  }
-  var codec: CircleAnnotationMessengerPigeonCodec {
-    return CircleAnnotationMessengerPigeonCodec.shared
-  }
-  func onCircleAnnotationClick(annotation annotationArg: CircleAnnotation, completion: @escaping (Result<Void, CircleAnnotationMessengerError>) -> Void) {
-    let channelName: String = "dev.flutter.pigeon.mapbox_maps_flutter.OnCircleAnnotationClickListener.onCircleAnnotationClick\(messageChannelSuffix)"
-    let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
-    channel.sendMessage([annotationArg] as [Any?]) { response in
-      guard let listResponse = response as? [Any?] else {
-        completion(.failure(createConnectionError(withChannelName: channelName)))
-        return
-      }
-      if listResponse.count > 1 {
-        let code: String = listResponse[0] as! String
-        let message: String? = nilOrValue(listResponse[1])
-        let details: String? = nilOrValue(listResponse[2])
-        completion(.failure(CircleAnnotationMessengerError(code: code, message: message, details: details)))
-      } else {
-        completion(.success(()))
-      }
-    }
-  }
-}
 /// Generated protocol from Pigeon that represents a handler of messages from Flutter.
 protocol _CircleAnnotationMessenger {
   func create(managerId: String, annotationOption: CircleAnnotationOptions, completion: @escaping (Result<CircleAnnotation, Error>) -> Void)

--- a/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Generated/GestureListeners.swift
+++ b/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Generated/GestureListeners.swift
@@ -435,11 +435,11 @@ class PigeonEventSink<ReturnType> {
 
 }
 
-class AnnotationDragEventsStreamHandler: PigeonEventChannelWrapper<AnnotationInteractionContext> {
+class AnnotationInteractionEventsStreamHandler: PigeonEventChannelWrapper<AnnotationInteractionContext> {
   static func register(with messenger: FlutterBinaryMessenger,
                       instanceName: String = "",
-                      streamHandler: AnnotationDragEventsStreamHandler) {
-    var channelName = "dev.flutter.pigeon.mapbox_maps_flutter.AnnotationInteractions._annotationDragEvents"
+                      streamHandler: AnnotationInteractionEventsStreamHandler) {
+    var channelName = "dev.flutter.pigeon.mapbox_maps_flutter.AnnotationInteractions._annotationInteractionEvents"
     if !instanceName.isEmpty {
       channelName += ".\(instanceName)"
     }

--- a/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Generated/PointAnnotationMessenger.swift
+++ b/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Generated/PointAnnotationMessenger.swift
@@ -352,7 +352,7 @@ struct PointAnnotation {
   /// Distance of halo to the icon outline.
   /// Default value: 0. Minimum value: 0. The unit of iconHaloWidth is in pixels.
   var iconHaloWidth: Double? = nil
-  /// Controls the transition progress between the image variants of icon-image. Zero means the first variant is used, one is the second, and in between they are blended together. . Both images should be the same size and have the same type (either raster or vector).
+  /// Controls the transition progress between the image variants of icon-image. Zero means the first variant is used, one is the second, and in between they are blended together. Both images should be the same size and have the same type (either raster or vector).
   /// Default value: 0. Value range: [0, 1]
   /// Deprecated: Use `PointAnnotationManager.iconImageCrossFade` instead.
   var iconImageCrossFade: Double? = nil
@@ -597,7 +597,7 @@ struct PointAnnotationOptions {
   /// Distance of halo to the icon outline.
   /// Default value: 0. Minimum value: 0. The unit of iconHaloWidth is in pixels.
   var iconHaloWidth: Double? = nil
-  /// Controls the transition progress between the image variants of icon-image. Zero means the first variant is used, one is the second, and in between they are blended together. . Both images should be the same size and have the same type (either raster or vector).
+  /// Controls the transition progress between the image variants of icon-image. Zero means the first variant is used, one is the second, and in between they are blended together. Both images should be the same size and have the same type (either raster or vector).
   /// Default value: 0. Value range: [0, 1]
   /// Deprecated: Use `PointAnnotationManager.iconImageCrossFade` instead.
   var iconImageCrossFade: Double? = nil

--- a/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Generated/PointAnnotationMessenger.swift
+++ b/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Generated/PointAnnotationMessenger.swift
@@ -56,10 +56,6 @@ private func wrapError(_ error: Any) -> [Any?] {
   ]
 }
 
-private func createConnectionError(withChannelName channelName: String) -> PointAnnotationMessengerError {
-  return PointAnnotationMessengerError(code: "channel-error", message: "Unable to establish connection on channel: '\(channelName)'.", details: "")
-}
-
 private func isNullish(_ value: Any?) -> Bool {
   return value is NSNull || value == nil
 }
@@ -956,39 +952,6 @@ class PointAnnotationMessengerPigeonCodec: FlutterStandardMessageCodec, @uncheck
   static let shared = PointAnnotationMessengerPigeonCodec(readerWriter: PointAnnotationMessengerPigeonCodecReaderWriter())
 }
 
-/// Generated protocol from Pigeon that represents Flutter messages that can be called from Swift.
-protocol OnPointAnnotationClickListenerProtocol {
-  func onPointAnnotationClick(annotation annotationArg: PointAnnotation, completion: @escaping (Result<Void, PointAnnotationMessengerError>) -> Void)
-}
-class OnPointAnnotationClickListener: OnPointAnnotationClickListenerProtocol {
-  private let binaryMessenger: FlutterBinaryMessenger
-  private let messageChannelSuffix: String
-  init(binaryMessenger: FlutterBinaryMessenger, messageChannelSuffix: String = "") {
-    self.binaryMessenger = binaryMessenger
-    self.messageChannelSuffix = messageChannelSuffix.count > 0 ? ".\(messageChannelSuffix)" : ""
-  }
-  var codec: PointAnnotationMessengerPigeonCodec {
-    return PointAnnotationMessengerPigeonCodec.shared
-  }
-  func onPointAnnotationClick(annotation annotationArg: PointAnnotation, completion: @escaping (Result<Void, PointAnnotationMessengerError>) -> Void) {
-    let channelName: String = "dev.flutter.pigeon.mapbox_maps_flutter.OnPointAnnotationClickListener.onPointAnnotationClick\(messageChannelSuffix)"
-    let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
-    channel.sendMessage([annotationArg] as [Any?]) { response in
-      guard let listResponse = response as? [Any?] else {
-        completion(.failure(createConnectionError(withChannelName: channelName)))
-        return
-      }
-      if listResponse.count > 1 {
-        let code: String = listResponse[0] as! String
-        let message: String? = nilOrValue(listResponse[1])
-        let details: String? = nilOrValue(listResponse[2])
-        completion(.failure(PointAnnotationMessengerError(code: code, message: message, details: details)))
-      } else {
-        completion(.success(()))
-      }
-    }
-  }
-}
 /// Generated protocol from Pigeon that represents a handler of messages from Flutter.
 protocol _PointAnnotationMessenger {
   func create(managerId: String, annotationOption: PointAnnotationOptions, completion: @escaping (Result<PointAnnotation, Error>) -> Void)

--- a/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Generated/PointAnnotationMessenger.swift
+++ b/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Generated/PointAnnotationMessenger.swift
@@ -356,7 +356,7 @@ struct PointAnnotation {
   /// Distance of halo to the icon outline.
   /// Default value: 0. Minimum value: 0. The unit of iconHaloWidth is in pixels.
   var iconHaloWidth: Double? = nil
-  /// Controls the transition progress between the image variants of icon-image. Zero means the first variant is used, one is the second, and in between they are blended together. Both images should be the same size and have the same type (either raster or vector).
+  /// Controls the transition progress between the image variants of icon-image. Zero means the first variant is used, one is the second, and in between they are blended together. . Both images should be the same size and have the same type (either raster or vector).
   /// Default value: 0. Value range: [0, 1]
   /// Deprecated: Use `PointAnnotationManager.iconImageCrossFade` instead.
   var iconImageCrossFade: Double? = nil
@@ -601,7 +601,7 @@ struct PointAnnotationOptions {
   /// Distance of halo to the icon outline.
   /// Default value: 0. Minimum value: 0. The unit of iconHaloWidth is in pixels.
   var iconHaloWidth: Double? = nil
-  /// Controls the transition progress between the image variants of icon-image. Zero means the first variant is used, one is the second, and in between they are blended together. Both images should be the same size and have the same type (either raster or vector).
+  /// Controls the transition progress between the image variants of icon-image. Zero means the first variant is used, one is the second, and in between they are blended together. . Both images should be the same size and have the same type (either raster or vector).
   /// Default value: 0. Value range: [0, 1]
   /// Deprecated: Use `PointAnnotationManager.iconImageCrossFade` instead.
   var iconImageCrossFade: Double? = nil

--- a/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Generated/PolygonAnnotationMessenger.swift
+++ b/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Generated/PolygonAnnotationMessenger.swift
@@ -56,10 +56,6 @@ private func wrapError(_ error: Any) -> [Any?] {
   ]
 }
 
-private func createConnectionError(withChannelName channelName: String) -> PolygonAnnotationMessengerError {
-  return PolygonAnnotationMessengerError(code: "channel-error", message: "Unable to establish connection on channel: '\(channelName)'.", details: "")
-}
-
 private func isNullish(_ value: Any?) -> Bool {
   return value is NSNull || value == nil
 }
@@ -320,39 +316,6 @@ class PolygonAnnotationMessengerPigeonCodec: FlutterStandardMessageCodec, @unche
   static let shared = PolygonAnnotationMessengerPigeonCodec(readerWriter: PolygonAnnotationMessengerPigeonCodecReaderWriter())
 }
 
-/// Generated protocol from Pigeon that represents Flutter messages that can be called from Swift.
-protocol OnPolygonAnnotationClickListenerProtocol {
-  func onPolygonAnnotationClick(annotation annotationArg: PolygonAnnotation, completion: @escaping (Result<Void, PolygonAnnotationMessengerError>) -> Void)
-}
-class OnPolygonAnnotationClickListener: OnPolygonAnnotationClickListenerProtocol {
-  private let binaryMessenger: FlutterBinaryMessenger
-  private let messageChannelSuffix: String
-  init(binaryMessenger: FlutterBinaryMessenger, messageChannelSuffix: String = "") {
-    self.binaryMessenger = binaryMessenger
-    self.messageChannelSuffix = messageChannelSuffix.count > 0 ? ".\(messageChannelSuffix)" : ""
-  }
-  var codec: PolygonAnnotationMessengerPigeonCodec {
-    return PolygonAnnotationMessengerPigeonCodec.shared
-  }
-  func onPolygonAnnotationClick(annotation annotationArg: PolygonAnnotation, completion: @escaping (Result<Void, PolygonAnnotationMessengerError>) -> Void) {
-    let channelName: String = "dev.flutter.pigeon.mapbox_maps_flutter.OnPolygonAnnotationClickListener.onPolygonAnnotationClick\(messageChannelSuffix)"
-    let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
-    channel.sendMessage([annotationArg] as [Any?]) { response in
-      guard let listResponse = response as? [Any?] else {
-        completion(.failure(createConnectionError(withChannelName: channelName)))
-        return
-      }
-      if listResponse.count > 1 {
-        let code: String = listResponse[0] as! String
-        let message: String? = nilOrValue(listResponse[1])
-        let details: String? = nilOrValue(listResponse[2])
-        completion(.failure(PolygonAnnotationMessengerError(code: code, message: message, details: details)))
-      } else {
-        completion(.success(()))
-      }
-    }
-  }
-}
 /// Generated protocol from Pigeon that represents a handler of messages from Flutter.
 protocol _PolygonAnnotationMessenger {
   func create(managerId: String, annotationOption: PolygonAnnotationOptions, completion: @escaping (Result<PolygonAnnotation, Error>) -> Void)

--- a/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Generated/PolylineAnnotationMessenger.swift
+++ b/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Generated/PolylineAnnotationMessenger.swift
@@ -56,10 +56,6 @@ private func wrapError(_ error: Any) -> [Any?] {
   ]
 }
 
-private func createConnectionError(withChannelName channelName: String) -> PolylineAnnotationMessengerError {
-  return PolylineAnnotationMessengerError(code: "channel-error", message: "Unable to establish connection on channel: '\(channelName)'.", details: "")
-}
-
 private func isNullish(_ value: Any?) -> Bool {
   return value is NSNull || value == nil
 }
@@ -428,39 +424,6 @@ class PolylineAnnotationMessengerPigeonCodec: FlutterStandardMessageCodec, @unch
   static let shared = PolylineAnnotationMessengerPigeonCodec(readerWriter: PolylineAnnotationMessengerPigeonCodecReaderWriter())
 }
 
-/// Generated protocol from Pigeon that represents Flutter messages that can be called from Swift.
-protocol OnPolylineAnnotationClickListenerProtocol {
-  func onPolylineAnnotationClick(annotation annotationArg: PolylineAnnotation, completion: @escaping (Result<Void, PolylineAnnotationMessengerError>) -> Void)
-}
-class OnPolylineAnnotationClickListener: OnPolylineAnnotationClickListenerProtocol {
-  private let binaryMessenger: FlutterBinaryMessenger
-  private let messageChannelSuffix: String
-  init(binaryMessenger: FlutterBinaryMessenger, messageChannelSuffix: String = "") {
-    self.binaryMessenger = binaryMessenger
-    self.messageChannelSuffix = messageChannelSuffix.count > 0 ? ".\(messageChannelSuffix)" : ""
-  }
-  var codec: PolylineAnnotationMessengerPigeonCodec {
-    return PolylineAnnotationMessengerPigeonCodec.shared
-  }
-  func onPolylineAnnotationClick(annotation annotationArg: PolylineAnnotation, completion: @escaping (Result<Void, PolylineAnnotationMessengerError>) -> Void) {
-    let channelName: String = "dev.flutter.pigeon.mapbox_maps_flutter.OnPolylineAnnotationClickListener.onPolylineAnnotationClick\(messageChannelSuffix)"
-    let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
-    channel.sendMessage([annotationArg] as [Any?]) { response in
-      guard let listResponse = response as? [Any?] else {
-        completion(.failure(createConnectionError(withChannelName: channelName)))
-        return
-      }
-      if listResponse.count > 1 {
-        let code: String = listResponse[0] as! String
-        let message: String? = nilOrValue(listResponse[1])
-        let details: String? = nilOrValue(listResponse[2])
-        completion(.failure(PolylineAnnotationMessengerError(code: code, message: message, details: details)))
-      } else {
-        completion(.success(()))
-      }
-    }
-  }
-}
 /// Generated protocol from Pigeon that represents a handler of messages from Flutter.
 protocol _PolylineAnnotationMessenger {
   func create(managerId: String, annotationOption: PolylineAnnotationOptions, completion: @escaping (Result<PolylineAnnotation, Error>) -> Void)

--- a/lib/mapbox_maps_flutter.dart
+++ b/lib/mapbox_maps_flutter.dart
@@ -88,3 +88,4 @@ part 'src/viewport/transitions/easing_viewport_transition.dart';
 part 'src/package_info.dart';
 part 'src/http/http_service.dart';
 part 'src/cancelable.dart';
+part 'src/deprecated.dart';

--- a/lib/src/annotation/annotation_manager.dart
+++ b/lib/src/annotation/annotation_manager.dart
@@ -76,9 +76,8 @@ class AnnotationManager {
 /// The super class for all AnnotationManagers.
 class BaseAnnotationManager {
   BaseAnnotationManager._(
-      {required String id, required BinaryMessenger messenger})
-      : this.id = id,
-        _messenger = messenger;
+      {required this.id, required BinaryMessenger messenger})
+      : _messenger = messenger;
   final String id;
   final BinaryMessenger _messenger;
 }

--- a/lib/src/annotation/annotation_manager.dart
+++ b/lib/src/annotation/annotation_manager.dart
@@ -76,6 +76,6 @@ class AnnotationManager {
 /// The super class for all AnnotationManagers.
 class BaseAnnotationManager {
   BaseAnnotationManager._(
-      {required this.id, required BinaryMessenger messenger})
+      {required this.id, required BinaryMessenger messenger});
   final String id;
 }

--- a/lib/src/annotation/annotation_manager.dart
+++ b/lib/src/annotation/annotation_manager.dart
@@ -77,7 +77,5 @@ class AnnotationManager {
 class BaseAnnotationManager {
   BaseAnnotationManager._(
       {required this.id, required BinaryMessenger messenger})
-      : _messenger = messenger;
   final String id;
-  final BinaryMessenger _messenger;
 }

--- a/lib/src/annotation/circle_annotation_manager.dart
+++ b/lib/src/annotation/circle_annotation_manager.dart
@@ -23,7 +23,7 @@ class CircleAnnotationManager extends BaseAnnotationManager {
         tapEvents(onTap: listener.onCircleAnnotationClick), _channelSuffix);
   }
 
-  /// Registers tap event callbacks for the annotations managed by this instance.
+  /// Registers tap event callbacks for the annotations managed by this manager.
   ///
   /// Note: Tap events will now not propagate to annotations below the topmost one. If you tap on overlapping annotations, only the top annotation's tap event will be triggered.
   Cancelable tapEvents({required Function(CircleAnnotation) onTap}) {
@@ -33,7 +33,7 @@ class CircleAnnotationManager extends BaseAnnotationManager {
         .asCancelable();
   }
 
-  /// Registers long press event callbacks for the annotations managed by this instance.
+  /// Registers long press event callbacks for the annotations managed by this manager.
   ///
   /// Note: This event will be triggered simultaneously with the [dragEvents] `onBegin` if the annotation is draggable.
   Cancelable longPressEvents(
@@ -45,7 +45,7 @@ class CircleAnnotationManager extends BaseAnnotationManager {
         .asCancelable();
   }
 
-  /// Registers drag event callbacks for the annotations managed by this instance.
+  /// Registers drag event callbacks for the annotations managed by this manager.
   ///
   /// - [onBegin]: Triggered when a drag gesture begins on an annotation.
   /// - [onChanged]: Triggered continuously as the annotation is being dragged.

--- a/lib/src/annotation/circle_annotation_manager.dart
+++ b/lib/src/annotation/circle_annotation_manager.dart
@@ -16,16 +16,16 @@ class CircleAnnotationManager extends BaseAnnotationManager {
   final String _channelSuffix;
 
   /// Add a listener to receive the callback when an annotation is clicked.
+  @Deprecated('Use [tapEvents] instead.')
   void addOnCircleAnnotationClickListener(
       OnCircleAnnotationClickListener listener) {
-    tapEvents(
-        onTap: (CircleAnnotation annotation) =>
-            listener.onCircleAnnotationClick(annotation));
+    OnCircleAnnotationClickListener.setUp(listener,
+        binaryMessenger: _messenger, messageChannelSuffix: _channelSuffix);
   }
 
   /// Registers tap event callbacks for the annotations managed by this instance.
   Cancelable tapEvents({required Function(CircleAnnotation) onTap}) {
-    return _annotationInteractionEvents(instanceName: "$_channelSuffix/tap/$id")
+    return _annotationInteractionEvents(instanceName: "$_channelSuffix/$id/tap")
         .cast<CircleAnnotationInteractionContext>()
         .listen((data) => onTap(data.annotation))
         .asCancelable();
@@ -59,7 +59,7 @@ class CircleAnnotationManager extends BaseAnnotationManager {
     Function(CircleAnnotation)? onEnd,
   }) {
     return _annotationInteractionEvents(
-            instanceName: "$_channelSuffix/drag/$id")
+            instanceName: "$_channelSuffix/$id/drag")
         .cast<CircleAnnotationInteractionContext>()
         .listen((data) {
       switch (data.gestureState) {

--- a/lib/src/annotation/circle_annotation_manager.dart
+++ b/lib/src/annotation/circle_annotation_manager.dart
@@ -18,8 +18,17 @@ class CircleAnnotationManager extends BaseAnnotationManager {
   /// Add a listener to receive the callback when an annotation is clicked.
   void addOnCircleAnnotationClickListener(
       OnCircleAnnotationClickListener listener) {
-    OnCircleAnnotationClickListener.setUp(listener,
-        binaryMessenger: _messenger, messageChannelSuffix: _channelSuffix);
+    tapEvents(
+        onTap: (CircleAnnotation annotation) =>
+            listener.onCircleAnnotationClick(annotation));
+  }
+
+  /// Registers tap event callbacks for the annotations managed by this instance.
+  Cancelable tapEvents({required Function(CircleAnnotation) onTap}) {
+    return _annotationInteractionEvents(instanceName: "$_channelSuffix/tap/$id")
+        .cast<CircleAnnotationInteractionContext>()
+        .listen((data) => onTap(data.annotation))
+        .asCancelable();
   }
 
   /// Registers drag event callbacks for the annotations managed by this instance.
@@ -49,7 +58,8 @@ class CircleAnnotationManager extends BaseAnnotationManager {
     Function(CircleAnnotation)? onChanged,
     Function(CircleAnnotation)? onEnd,
   }) {
-    return _annotationDragEvents(instanceName: "$_channelSuffix/$id")
+    return _annotationInteractionEvents(
+            instanceName: "$_channelSuffix/drag/$id")
         .cast<CircleAnnotationInteractionContext>()
         .listen((data) {
       switch (data.gestureState) {

--- a/lib/src/annotation/circle_annotation_manager.dart
+++ b/lib/src/annotation/circle_annotation_manager.dart
@@ -24,10 +24,24 @@ class CircleAnnotationManager extends BaseAnnotationManager {
   }
 
   /// Registers tap event callbacks for the annotations managed by this instance.
+  ///
+  /// Note: Tap events will now not propagate to annotations below the topmost one. If you tap on overlapping annotations, only the top annotation's tap event will be triggered.
   Cancelable tapEvents({required Function(CircleAnnotation) onTap}) {
     return _annotationInteractionEvents(instanceName: "$_channelSuffix/$id/tap")
         .cast<CircleAnnotationInteractionContext>()
         .listen((data) => onTap(data.annotation))
+        .asCancelable();
+  }
+
+  /// Registers long press event callbacks for the annotations managed by this instance.
+  ///
+  /// Note: This event will be triggered simultaneously with the [dragEvents] `onBegin` if the annotation is draggable.
+  Cancelable longPressEvents(
+      {required Function(CircleAnnotation) onLongPress}) {
+    return _annotationInteractionEvents(
+            instanceName: "$_channelSuffix/$id/long_press")
+        .cast<CircleAnnotationInteractionContext>()
+        .listen((data) => onLongPress(data.annotation))
         .asCancelable();
   }
 

--- a/lib/src/annotation/circle_annotation_manager.dart
+++ b/lib/src/annotation/circle_annotation_manager.dart
@@ -19,8 +19,8 @@ class CircleAnnotationManager extends BaseAnnotationManager {
   @Deprecated('Use [tapEvents] instead.')
   void addOnCircleAnnotationClickListener(
       OnCircleAnnotationClickListener listener) {
-    OnCircleAnnotationClickListener.setUp(listener,
-        binaryMessenger: _messenger, messageChannelSuffix: _channelSuffix);
+    OnCircleAnnotationClickListener._withCancelable(
+        tapEvents(onTap: listener.onCircleAnnotationClick), _channelSuffix);
   }
 
   /// Registers tap event callbacks for the annotations managed by this instance.

--- a/lib/src/annotation/point_annotation_manager.dart
+++ b/lib/src/annotation/point_annotation_manager.dart
@@ -22,6 +22,14 @@ class PointAnnotationManager extends BaseAnnotationManager {
         binaryMessenger: _messenger, messageChannelSuffix: _channelSuffix);
   }
 
+  /// Registers tap event callbacks for the annotations managed by this instance.
+  Cancelable tapEvents({required Function(PointAnnotation) onTap}) {
+    return _annotationInteractionEvents(instanceName: "$_channelSuffix/tap/$id")
+        .cast<PointAnnotationInteractionContext>()
+        .listen((data) => onTap(data.annotation))
+        .asCancelable();
+  }
+
   /// Registers drag event callbacks for the annotations managed by this instance.
   ///
   /// - [onBegin]: Triggered when a drag gesture begins on an annotation.
@@ -49,7 +57,8 @@ class PointAnnotationManager extends BaseAnnotationManager {
     Function(PointAnnotation)? onChanged,
     Function(PointAnnotation)? onEnd,
   }) {
-    return _annotationDragEvents(instanceName: "$_channelSuffix/$id")
+    return _annotationInteractionEvents(
+            instanceName: "$_channelSuffix/drag/$id")
         .cast<PointAnnotationInteractionContext>()
         .listen((data) {
       switch (data.gestureState) {
@@ -469,11 +478,11 @@ class PointAnnotationManager extends BaseAnnotationManager {
   Future<double?> getIconHaloWidth() =>
       _annotationMessenger.getIconHaloWidth(id);
 
-  /// Controls the transition progress between the image variants of icon-image. Zero means the first variant is used, one is the second, and in between they are blended together. Both images should be the same size and have the same type (either raster or vector). Default value: 0. Value range: [0, 1]
+  /// Controls the transition progress between the image variants of icon-image. Zero means the first variant is used, one is the second, and in between they are blended together. . Both images should be the same size and have the same type (either raster or vector). Default value: 0. Value range: [0, 1]
   Future<void> setIconImageCrossFade(double iconImageCrossFade) =>
       _annotationMessenger.setIconImageCrossFade(id, iconImageCrossFade);
 
-  /// Controls the transition progress between the image variants of icon-image. Zero means the first variant is used, one is the second, and in between they are blended together. Both images should be the same size and have the same type (either raster or vector). Default value: 0. Value range: [0, 1]
+  /// Controls the transition progress between the image variants of icon-image. Zero means the first variant is used, one is the second, and in between they are blended together. . Both images should be the same size and have the same type (either raster or vector). Default value: 0. Value range: [0, 1]
   Future<double?> getIconImageCrossFade() =>
       _annotationMessenger.getIconImageCrossFade(id);
 

--- a/lib/src/annotation/point_annotation_manager.dart
+++ b/lib/src/annotation/point_annotation_manager.dart
@@ -24,10 +24,23 @@ class PointAnnotationManager extends BaseAnnotationManager {
   }
 
   /// Registers tap event callbacks for the annotations managed by this instance.
+  ///
+  /// Note: Tap events will now not propagate to annotations below the topmost one. If you tap on overlapping annotations, only the top annotation's tap event will be triggered.
   Cancelable tapEvents({required Function(PointAnnotation) onTap}) {
     return _annotationInteractionEvents(instanceName: "$_channelSuffix/$id/tap")
         .cast<PointAnnotationInteractionContext>()
         .listen((data) => onTap(data.annotation))
+        .asCancelable();
+  }
+
+  /// Registers long press event callbacks for the annotations managed by this instance.
+  ///
+  /// Note: This event will be triggered simultaneously with the [dragEvents] `onBegin` if the annotation is draggable.
+  Cancelable longPressEvents({required Function(PointAnnotation) onLongPress}) {
+    return _annotationInteractionEvents(
+            instanceName: "$_channelSuffix/$id/long_press")
+        .cast<PointAnnotationInteractionContext>()
+        .listen((data) => onLongPress(data.annotation))
         .asCancelable();
   }
 

--- a/lib/src/annotation/point_annotation_manager.dart
+++ b/lib/src/annotation/point_annotation_manager.dart
@@ -19,8 +19,8 @@ class PointAnnotationManager extends BaseAnnotationManager {
   @Deprecated('Use [tapEvents] instead.')
   void addOnPointAnnotationClickListener(
       OnPointAnnotationClickListener listener) {
-    OnPointAnnotationClickListener.setUp(listener,
-        binaryMessenger: _messenger, messageChannelSuffix: _channelSuffix);
+    OnPointAnnotationClickListener._withCancelable(
+        tapEvents(onTap: listener.onPointAnnotationClick), _channelSuffix);
   }
 
   /// Registers tap event callbacks for the annotations managed by this instance.

--- a/lib/src/annotation/point_annotation_manager.dart
+++ b/lib/src/annotation/point_annotation_manager.dart
@@ -16,6 +16,7 @@ class PointAnnotationManager extends BaseAnnotationManager {
   final String _channelSuffix;
 
   /// Add a listener to receive the callback when an annotation is clicked.
+  @Deprecated('Use [tapEvents] instead.')
   void addOnPointAnnotationClickListener(
       OnPointAnnotationClickListener listener) {
     OnPointAnnotationClickListener.setUp(listener,
@@ -24,7 +25,7 @@ class PointAnnotationManager extends BaseAnnotationManager {
 
   /// Registers tap event callbacks for the annotations managed by this instance.
   Cancelable tapEvents({required Function(PointAnnotation) onTap}) {
-    return _annotationInteractionEvents(instanceName: "$_channelSuffix/tap/$id")
+    return _annotationInteractionEvents(instanceName: "$_channelSuffix/$id/tap")
         .cast<PointAnnotationInteractionContext>()
         .listen((data) => onTap(data.annotation))
         .asCancelable();
@@ -58,7 +59,7 @@ class PointAnnotationManager extends BaseAnnotationManager {
     Function(PointAnnotation)? onEnd,
   }) {
     return _annotationInteractionEvents(
-            instanceName: "$_channelSuffix/drag/$id")
+            instanceName: "$_channelSuffix/$id/drag")
         .cast<PointAnnotationInteractionContext>()
         .listen((data) {
       switch (data.gestureState) {

--- a/lib/src/annotation/point_annotation_manager.dart
+++ b/lib/src/annotation/point_annotation_manager.dart
@@ -23,7 +23,7 @@ class PointAnnotationManager extends BaseAnnotationManager {
         tapEvents(onTap: listener.onPointAnnotationClick), _channelSuffix);
   }
 
-  /// Registers tap event callbacks for the annotations managed by this instance.
+  /// Registers tap event callbacks for the annotations managed by this manager.
   ///
   /// Note: Tap events will now not propagate to annotations below the topmost one. If you tap on overlapping annotations, only the top annotation's tap event will be triggered.
   Cancelable tapEvents({required Function(PointAnnotation) onTap}) {
@@ -33,7 +33,7 @@ class PointAnnotationManager extends BaseAnnotationManager {
         .asCancelable();
   }
 
-  /// Registers long press event callbacks for the annotations managed by this instance.
+  /// Registers long press event callbacks for the annotations managed by this manager.
   ///
   /// Note: This event will be triggered simultaneously with the [dragEvents] `onBegin` if the annotation is draggable.
   Cancelable longPressEvents({required Function(PointAnnotation) onLongPress}) {
@@ -44,7 +44,7 @@ class PointAnnotationManager extends BaseAnnotationManager {
         .asCancelable();
   }
 
-  /// Registers drag event callbacks for the annotations managed by this instance.
+  /// Registers drag event callbacks for the annotations managed by this manager.
   ///
   /// - [onBegin]: Triggered when a drag gesture begins on an annotation.
   /// - [onChanged]: Triggered continuously as the annotation is being dragged.
@@ -492,11 +492,11 @@ class PointAnnotationManager extends BaseAnnotationManager {
   Future<double?> getIconHaloWidth() =>
       _annotationMessenger.getIconHaloWidth(id);
 
-  /// Controls the transition progress between the image variants of icon-image. Zero means the first variant is used, one is the second, and in between they are blended together. . Both images should be the same size and have the same type (either raster or vector). Default value: 0. Value range: [0, 1]
+  /// Controls the transition progress between the image variants of icon-image. Zero means the first variant is used, one is the second, and in between they are blended together. Both images should be the same size and have the same type (either raster or vector). Default value: 0. Value range: [0, 1]
   Future<void> setIconImageCrossFade(double iconImageCrossFade) =>
       _annotationMessenger.setIconImageCrossFade(id, iconImageCrossFade);
 
-  /// Controls the transition progress between the image variants of icon-image. Zero means the first variant is used, one is the second, and in between they are blended together. . Both images should be the same size and have the same type (either raster or vector). Default value: 0. Value range: [0, 1]
+  /// Controls the transition progress between the image variants of icon-image. Zero means the first variant is used, one is the second, and in between they are blended together. Both images should be the same size and have the same type (either raster or vector). Default value: 0. Value range: [0, 1]
   Future<double?> getIconImageCrossFade() =>
       _annotationMessenger.getIconImageCrossFade(id);
 

--- a/lib/src/annotation/polygon_annotation_manager.dart
+++ b/lib/src/annotation/polygon_annotation_manager.dart
@@ -19,8 +19,8 @@ class PolygonAnnotationManager extends BaseAnnotationManager {
   @Deprecated('Use [tapEvents] instead.')
   void addOnPolygonAnnotationClickListener(
       OnPolygonAnnotationClickListener listener) {
-    OnPolygonAnnotationClickListener.setUp(listener,
-        binaryMessenger: _messenger, messageChannelSuffix: _channelSuffix);
+    OnPolygonAnnotationClickListener._withCancelable(
+        tapEvents(onTap: listener.onPolygonAnnotationClick), _channelSuffix);
   }
 
   /// Registers tap event callbacks for the annotations managed by this instance.

--- a/lib/src/annotation/polygon_annotation_manager.dart
+++ b/lib/src/annotation/polygon_annotation_manager.dart
@@ -22,6 +22,14 @@ class PolygonAnnotationManager extends BaseAnnotationManager {
         binaryMessenger: _messenger, messageChannelSuffix: _channelSuffix);
   }
 
+  /// Registers tap event callbacks for the annotations managed by this instance.
+  Cancelable tapEvents({required Function(PolygonAnnotation) onTap}) {
+    return _annotationInteractionEvents(instanceName: "$_channelSuffix/tap/$id")
+        .cast<PolygonAnnotationInteractionContext>()
+        .listen((data) => onTap(data.annotation))
+        .asCancelable();
+  }
+
   /// Registers drag event callbacks for the annotations managed by this instance.
   ///
   /// - [onBegin]: Triggered when a drag gesture begins on an annotation.
@@ -49,7 +57,8 @@ class PolygonAnnotationManager extends BaseAnnotationManager {
     Function(PolygonAnnotation)? onChanged,
     Function(PolygonAnnotation)? onEnd,
   }) {
-    return _annotationDragEvents(instanceName: "$_channelSuffix/$id")
+    return _annotationInteractionEvents(
+            instanceName: "$_channelSuffix/drag/$id")
         .cast<PolygonAnnotationInteractionContext>()
         .listen((data) {
       switch (data.gestureState) {

--- a/lib/src/annotation/polygon_annotation_manager.dart
+++ b/lib/src/annotation/polygon_annotation_manager.dart
@@ -23,7 +23,7 @@ class PolygonAnnotationManager extends BaseAnnotationManager {
         tapEvents(onTap: listener.onPolygonAnnotationClick), _channelSuffix);
   }
 
-  /// Registers tap event callbacks for the annotations managed by this instance.
+  /// Registers tap event callbacks for the annotations managed by this manager.
   ///
   /// Note: Tap events will now not propagate to annotations below the topmost one. If you tap on overlapping annotations, only the top annotation's tap event will be triggered.
   Cancelable tapEvents({required Function(PolygonAnnotation) onTap}) {
@@ -33,7 +33,7 @@ class PolygonAnnotationManager extends BaseAnnotationManager {
         .asCancelable();
   }
 
-  /// Registers long press event callbacks for the annotations managed by this instance.
+  /// Registers long press event callbacks for the annotations managed by this manager.
   ///
   /// Note: This event will be triggered simultaneously with the [dragEvents] `onBegin` if the annotation is draggable.
   Cancelable longPressEvents(
@@ -45,7 +45,7 @@ class PolygonAnnotationManager extends BaseAnnotationManager {
         .asCancelable();
   }
 
-  /// Registers drag event callbacks for the annotations managed by this instance.
+  /// Registers drag event callbacks for the annotations managed by this manager.
   ///
   /// - [onBegin]: Triggered when a drag gesture begins on an annotation.
   /// - [onChanged]: Triggered continuously as the annotation is being dragged.

--- a/lib/src/annotation/polygon_annotation_manager.dart
+++ b/lib/src/annotation/polygon_annotation_manager.dart
@@ -24,10 +24,24 @@ class PolygonAnnotationManager extends BaseAnnotationManager {
   }
 
   /// Registers tap event callbacks for the annotations managed by this instance.
+  ///
+  /// Note: Tap events will now not propagate to annotations below the topmost one. If you tap on overlapping annotations, only the top annotation's tap event will be triggered.
   Cancelable tapEvents({required Function(PolygonAnnotation) onTap}) {
     return _annotationInteractionEvents(instanceName: "$_channelSuffix/$id/tap")
         .cast<PolygonAnnotationInteractionContext>()
         .listen((data) => onTap(data.annotation))
+        .asCancelable();
+  }
+
+  /// Registers long press event callbacks for the annotations managed by this instance.
+  ///
+  /// Note: This event will be triggered simultaneously with the [dragEvents] `onBegin` if the annotation is draggable.
+  Cancelable longPressEvents(
+      {required Function(PolygonAnnotation) onLongPress}) {
+    return _annotationInteractionEvents(
+            instanceName: "$_channelSuffix/$id/long_press")
+        .cast<PolygonAnnotationInteractionContext>()
+        .listen((data) => onLongPress(data.annotation))
         .asCancelable();
   }
 

--- a/lib/src/annotation/polygon_annotation_manager.dart
+++ b/lib/src/annotation/polygon_annotation_manager.dart
@@ -16,6 +16,7 @@ class PolygonAnnotationManager extends BaseAnnotationManager {
   final String _channelSuffix;
 
   /// Add a listener to receive the callback when an annotation is clicked.
+  @Deprecated('Use [tapEvents] instead.')
   void addOnPolygonAnnotationClickListener(
       OnPolygonAnnotationClickListener listener) {
     OnPolygonAnnotationClickListener.setUp(listener,
@@ -24,7 +25,7 @@ class PolygonAnnotationManager extends BaseAnnotationManager {
 
   /// Registers tap event callbacks for the annotations managed by this instance.
   Cancelable tapEvents({required Function(PolygonAnnotation) onTap}) {
-    return _annotationInteractionEvents(instanceName: "$_channelSuffix/tap/$id")
+    return _annotationInteractionEvents(instanceName: "$_channelSuffix/$id/tap")
         .cast<PolygonAnnotationInteractionContext>()
         .listen((data) => onTap(data.annotation))
         .asCancelable();
@@ -58,7 +59,7 @@ class PolygonAnnotationManager extends BaseAnnotationManager {
     Function(PolygonAnnotation)? onEnd,
   }) {
     return _annotationInteractionEvents(
-            instanceName: "$_channelSuffix/drag/$id")
+            instanceName: "$_channelSuffix/$id/drag")
         .cast<PolygonAnnotationInteractionContext>()
         .listen((data) {
       switch (data.gestureState) {

--- a/lib/src/annotation/polyline_annotation_manager.dart
+++ b/lib/src/annotation/polyline_annotation_manager.dart
@@ -16,6 +16,7 @@ class PolylineAnnotationManager extends BaseAnnotationManager {
   final String _channelSuffix;
 
   /// Add a listener to receive the callback when an annotation is clicked.
+  @Deprecated('Use [tapEvents] instead.')
   void addOnPolylineAnnotationClickListener(
       OnPolylineAnnotationClickListener listener) {
     OnPolylineAnnotationClickListener.setUp(listener,
@@ -24,7 +25,7 @@ class PolylineAnnotationManager extends BaseAnnotationManager {
 
   /// Registers tap event callbacks for the annotations managed by this instance.
   Cancelable tapEvents({required Function(PolylineAnnotation) onTap}) {
-    return _annotationInteractionEvents(instanceName: "$_channelSuffix/tap/$id")
+    return _annotationInteractionEvents(instanceName: "$_channelSuffix/$id/tap")
         .cast<PolylineAnnotationInteractionContext>()
         .listen((data) => onTap(data.annotation))
         .asCancelable();
@@ -58,7 +59,7 @@ class PolylineAnnotationManager extends BaseAnnotationManager {
     Function(PolylineAnnotation)? onEnd,
   }) {
     return _annotationInteractionEvents(
-            instanceName: "$_channelSuffix/drag/$id")
+            instanceName: "$_channelSuffix/$id/drag")
         .cast<PolylineAnnotationInteractionContext>()
         .listen((data) {
       switch (data.gestureState) {

--- a/lib/src/annotation/polyline_annotation_manager.dart
+++ b/lib/src/annotation/polyline_annotation_manager.dart
@@ -23,7 +23,7 @@ class PolylineAnnotationManager extends BaseAnnotationManager {
         tapEvents(onTap: listener.onPolylineAnnotationClick), _channelSuffix);
   }
 
-  /// Registers tap event callbacks for the annotations managed by this instance.
+  /// Registers tap event callbacks for the annotations managed by this manager.
   ///
   /// Note: Tap events will now not propagate to annotations below the topmost one. If you tap on overlapping annotations, only the top annotation's tap event will be triggered.
   Cancelable tapEvents({required Function(PolylineAnnotation) onTap}) {
@@ -33,7 +33,7 @@ class PolylineAnnotationManager extends BaseAnnotationManager {
         .asCancelable();
   }
 
-  /// Registers long press event callbacks for the annotations managed by this instance.
+  /// Registers long press event callbacks for the annotations managed by this manager.
   ///
   /// Note: This event will be triggered simultaneously with the [dragEvents] `onBegin` if the annotation is draggable.
   Cancelable longPressEvents(
@@ -45,7 +45,7 @@ class PolylineAnnotationManager extends BaseAnnotationManager {
         .asCancelable();
   }
 
-  /// Registers drag event callbacks for the annotations managed by this instance.
+  /// Registers drag event callbacks for the annotations managed by this manager.
   ///
   /// - [onBegin]: Triggered when a drag gesture begins on an annotation.
   /// - [onChanged]: Triggered continuously as the annotation is being dragged.

--- a/lib/src/annotation/polyline_annotation_manager.dart
+++ b/lib/src/annotation/polyline_annotation_manager.dart
@@ -24,10 +24,24 @@ class PolylineAnnotationManager extends BaseAnnotationManager {
   }
 
   /// Registers tap event callbacks for the annotations managed by this instance.
+  ///
+  /// Note: Tap events will now not propagate to annotations below the topmost one. If you tap on overlapping annotations, only the top annotation's tap event will be triggered.
   Cancelable tapEvents({required Function(PolylineAnnotation) onTap}) {
     return _annotationInteractionEvents(instanceName: "$_channelSuffix/$id/tap")
         .cast<PolylineAnnotationInteractionContext>()
         .listen((data) => onTap(data.annotation))
+        .asCancelable();
+  }
+
+  /// Registers long press event callbacks for the annotations managed by this instance.
+  ///
+  /// Note: This event will be triggered simultaneously with the [dragEvents] `onBegin` if the annotation is draggable.
+  Cancelable longPressEvents(
+      {required Function(PolylineAnnotation) onLongPress}) {
+    return _annotationInteractionEvents(
+            instanceName: "$_channelSuffix/$id/long_press")
+        .cast<PolylineAnnotationInteractionContext>()
+        .listen((data) => onLongPress(data.annotation))
         .asCancelable();
   }
 

--- a/lib/src/annotation/polyline_annotation_manager.dart
+++ b/lib/src/annotation/polyline_annotation_manager.dart
@@ -22,6 +22,14 @@ class PolylineAnnotationManager extends BaseAnnotationManager {
         binaryMessenger: _messenger, messageChannelSuffix: _channelSuffix);
   }
 
+  /// Registers tap event callbacks for the annotations managed by this instance.
+  Cancelable tapEvents({required Function(PolylineAnnotation) onTap}) {
+    return _annotationInteractionEvents(instanceName: "$_channelSuffix/tap/$id")
+        .cast<PolylineAnnotationInteractionContext>()
+        .listen((data) => onTap(data.annotation))
+        .asCancelable();
+  }
+
   /// Registers drag event callbacks for the annotations managed by this instance.
   ///
   /// - [onBegin]: Triggered when a drag gesture begins on an annotation.
@@ -49,7 +57,8 @@ class PolylineAnnotationManager extends BaseAnnotationManager {
     Function(PolylineAnnotation)? onChanged,
     Function(PolylineAnnotation)? onEnd,
   }) {
-    return _annotationDragEvents(instanceName: "$_channelSuffix/$id")
+    return _annotationInteractionEvents(
+            instanceName: "$_channelSuffix/drag/$id")
         .cast<PolylineAnnotationInteractionContext>()
         .listen((data) {
       switch (data.gestureState) {

--- a/lib/src/annotation/polyline_annotation_manager.dart
+++ b/lib/src/annotation/polyline_annotation_manager.dart
@@ -19,8 +19,8 @@ class PolylineAnnotationManager extends BaseAnnotationManager {
   @Deprecated('Use [tapEvents] instead.')
   void addOnPolylineAnnotationClickListener(
       OnPolylineAnnotationClickListener listener) {
-    OnPolylineAnnotationClickListener.setUp(listener,
-        binaryMessenger: _messenger, messageChannelSuffix: _channelSuffix);
+    OnPolylineAnnotationClickListener._withCancelable(
+        tapEvents(onTap: listener.onPolylineAnnotationClick), _channelSuffix);
   }
 
   /// Registers tap event callbacks for the annotations managed by this instance.

--- a/lib/src/deprecated.dart
+++ b/lib/src/deprecated.dart
@@ -1,0 +1,153 @@
+part of '../mapbox_maps_flutter.dart';
+
+@Deprecated(
+    'This is deprecated and will be removed in future releases. Use annotations [tapEvents] instead.')
+abstract class OnCircleAnnotationClickListener {
+  static const MessageCodec<Object?> pigeonChannelCodec =
+      CircleAnnotationMessenger_PigeonCodec();
+
+  void onCircleAnnotationClick(CircleAnnotation annotation);
+
+  static final _cancelables = <String, Cancelable>{};
+
+  static void setUp(
+    OnCircleAnnotationClickListener? api, {
+    BinaryMessenger? binaryMessenger,
+    String messageChannelSuffix = '',
+  }) {
+    var channelName =
+        'dev.flutter.pigeon.mapbox_maps_flutter.OnCircleAnnotationClickListener.onCircleAnnotationClick';
+    if (messageChannelSuffix.isNotEmpty) {
+      channelName += '.$messageChannelSuffix';
+    }
+
+    if (api == null) {
+      _cancelables[channelName]?.cancel();
+      _cancelables.remove(channelName);
+    }
+  }
+
+  static void _withCancelable(
+      Cancelable cancelable, String messageChannelSuffix) {
+    var channelName =
+        'dev.flutter.pigeon.mapbox_maps_flutter.OnCircleAnnotationClickListener.onCircleAnnotationClick';
+    if (messageChannelSuffix.isNotEmpty) {
+      channelName += '.$messageChannelSuffix';
+    }
+    _cancelables[channelName] = cancelable;
+  }
+}
+
+@Deprecated(
+    'This is deprecated and will be removed in future releases. Use annotations [tapEvents] instead.')
+abstract class OnPointAnnotationClickListener {
+  static const MessageCodec<Object?> pigeonChannelCodec =
+      PointAnnotationMessenger_PigeonCodec();
+
+  void onPointAnnotationClick(PointAnnotation annotation);
+
+  static final _cancelables = <String, Cancelable>{};
+
+  static void setUp(
+    OnPointAnnotationClickListener? api, {
+    BinaryMessenger? binaryMessenger,
+    String messageChannelSuffix = '',
+  }) {
+    var channelName =
+        'dev.flutter.pigeon.mapbox_maps_flutter.OnPointAnnotationClickListener.onPointAnnotationClick';
+    if (messageChannelSuffix.isNotEmpty) {
+      channelName += '.$messageChannelSuffix';
+    }
+
+    if (api == null) {
+      _cancelables[channelName]?.cancel();
+      _cancelables.remove(channelName);
+    }
+  }
+
+  static void _withCancelable(
+      Cancelable cancelable, String messageChannelSuffix) {
+    var channelName =
+        'dev.flutter.pigeon.mapbox_maps_flutter.OnCircleAnnotationClickListener.onCircleAnnotationClick';
+    if (messageChannelSuffix.isNotEmpty) {
+      channelName += '.$messageChannelSuffix';
+    }
+    _cancelables[channelName] = cancelable;
+  }
+}
+
+@Deprecated(
+    'This is deprecated and will be removed in future releases. Use annotations [tapEvents] instead.')
+abstract class OnPolygonAnnotationClickListener {
+  static const MessageCodec<Object?> pigeonChannelCodec =
+      PolygonAnnotationMessenger_PigeonCodec();
+
+  void onPolygonAnnotationClick(PolygonAnnotation annotation);
+
+  static final _cancelables = <String, Cancelable>{};
+
+  static void setUp(
+    OnPolygonAnnotationClickListener? api, {
+    BinaryMessenger? binaryMessenger,
+    String messageChannelSuffix = '',
+  }) {
+    var channelName =
+        'dev.flutter.pigeon.mapbox_maps_flutter.OnPolygonAnnotationClickListener.onPolygonAnnotationClick';
+    if (messageChannelSuffix.isNotEmpty) {
+      channelName += '.$messageChannelSuffix';
+    }
+
+    if (api == null) {
+      _cancelables[channelName]?.cancel();
+      _cancelables.remove(channelName);
+    }
+  }
+
+  static void _withCancelable(
+      Cancelable cancelable, String messageChannelSuffix) {
+    var channelName =
+        'dev.flutter.pigeon.mapbox_maps_flutter.OnCircleAnnotationClickListener.onCircleAnnotationClick';
+    if (messageChannelSuffix.isNotEmpty) {
+      channelName += '.$messageChannelSuffix';
+    }
+    _cancelables[channelName] = cancelable;
+  }
+}
+
+@Deprecated(
+    'This is deprecated and will be removed in future releases. Use annotations [tapEvents] instead.')
+abstract class OnPolylineAnnotationClickListener {
+  static const MessageCodec<Object?> pigeonChannelCodec =
+      PolylineAnnotationMessenger_PigeonCodec();
+
+  void onPolylineAnnotationClick(PolylineAnnotation annotation);
+
+  static final _cancelables = <String, Cancelable>{};
+
+  static void setUp(
+    OnPolylineAnnotationClickListener? api, {
+    BinaryMessenger? binaryMessenger,
+    String messageChannelSuffix = '',
+  }) {
+    var channelName =
+        'dev.flutter.pigeon.mapbox_maps_flutter.OnPolylineAnnotationClickListener.onPolylineAnnotationClick';
+    if (messageChannelSuffix.isNotEmpty) {
+      channelName += '.$messageChannelSuffix';
+    }
+
+    if (api == null) {
+      _cancelables[channelName]?.cancel();
+      _cancelables.remove(channelName);
+    }
+  }
+
+  static void _withCancelable(
+      Cancelable cancelable, String messageChannelSuffix) {
+    var channelName =
+        'dev.flutter.pigeon.mapbox_maps_flutter.OnCircleAnnotationClickListener.onCircleAnnotationClick';
+    if (messageChannelSuffix.isNotEmpty) {
+      channelName += '.$messageChannelSuffix';
+    }
+    _cancelables[channelName] = cancelable;
+  }
+}

--- a/lib/src/pigeons/circle_annotation_messenger.dart
+++ b/lib/src/pigeons/circle_annotation_messenger.dart
@@ -335,52 +335,6 @@ class CircleAnnotationMessenger_PigeonCodec extends StandardMessageCodec {
   }
 }
 
-abstract class OnCircleAnnotationClickListener {
-  static const MessageCodec<Object?> pigeonChannelCodec =
-      CircleAnnotationMessenger_PigeonCodec();
-
-  void onCircleAnnotationClick(CircleAnnotation annotation);
-
-  static void setUp(
-    OnCircleAnnotationClickListener? api, {
-    BinaryMessenger? binaryMessenger,
-    String messageChannelSuffix = '',
-  }) {
-    messageChannelSuffix =
-        messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
-    {
-      final BasicMessageChannel<
-          Object?> pigeonVar_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.mapbox_maps_flutter.OnCircleAnnotationClickListener.onCircleAnnotationClick$messageChannelSuffix',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
-      if (api == null) {
-        pigeonVar_channel.setMessageHandler(null);
-      } else {
-        pigeonVar_channel.setMessageHandler((Object? message) async {
-          assert(message != null,
-              'Argument for dev.flutter.pigeon.mapbox_maps_flutter.OnCircleAnnotationClickListener.onCircleAnnotationClick was null.');
-          final List<Object?> args = (message as List<Object?>?)!;
-          final CircleAnnotation? arg_annotation =
-              (args[0] as CircleAnnotation?);
-          assert(arg_annotation != null,
-              'Argument for dev.flutter.pigeon.mapbox_maps_flutter.OnCircleAnnotationClickListener.onCircleAnnotationClick was null, expected non-null CircleAnnotation.');
-          try {
-            api.onCircleAnnotationClick(arg_annotation!);
-            return wrapResponse(empty: true);
-          } on PlatformException catch (e) {
-            return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
-          }
-        });
-      }
-    }
-  }
-}
-
 class _CircleAnnotationMessenger {
   /// Constructor for [_CircleAnnotationMessenger].  The [binaryMessenger] named argument is
   /// available for dependency injection.  If it is left null, the default

--- a/lib/src/pigeons/gesture_listeners.dart
+++ b/lib/src/pigeons/gesture_listeners.dart
@@ -502,15 +502,15 @@ abstract class GestureListener {
   }
 }
 
-Stream<AnnotationInteractionContext> _annotationDragEvents(
+Stream<AnnotationInteractionContext> _annotationInteractionEvents(
     {String instanceName = ''}) {
   if (instanceName.isNotEmpty) {
     instanceName = '.$instanceName';
   }
-  final EventChannel _annotationDragEventsChannel = EventChannel(
-      'dev.flutter.pigeon.mapbox_maps_flutter.AnnotationInteractions._annotationDragEvents$instanceName',
+  final EventChannel _annotationInteractionEventsChannel = EventChannel(
+      'dev.flutter.pigeon.mapbox_maps_flutter.AnnotationInteractions._annotationInteractionEvents$instanceName',
       pigeonMethodCodec);
-  return _annotationDragEventsChannel
+  return _annotationInteractionEventsChannel
       .receiveBroadcastStream()
       .map((dynamic event) {
     return event as AnnotationInteractionContext;

--- a/lib/src/pigeons/point_annotation_messenger.dart
+++ b/lib/src/pigeons/point_annotation_messenger.dart
@@ -408,7 +408,7 @@ class PointAnnotation {
   /// Default value: 0. Minimum value: 0. The unit of iconHaloWidth is in pixels.
   double? iconHaloWidth;
 
-  /// Controls the transition progress between the image variants of icon-image. Zero means the first variant is used, one is the second, and in between they are blended together. . Both images should be the same size and have the same type (either raster or vector).
+  /// Controls the transition progress between the image variants of icon-image. Zero means the first variant is used, one is the second, and in between they are blended together. Both images should be the same size and have the same type (either raster or vector).
   /// Default value: 0. Value range: [0, 1]
   /// Deprecated: Use `PointAnnotationManager.iconImageCrossFade` instead.
   double? iconImageCrossFade;
@@ -748,7 +748,7 @@ class PointAnnotationOptions {
   /// Default value: 0. Minimum value: 0. The unit of iconHaloWidth is in pixels.
   double? iconHaloWidth;
 
-  /// Controls the transition progress between the image variants of icon-image. Zero means the first variant is used, one is the second, and in between they are blended together. . Both images should be the same size and have the same type (either raster or vector).
+  /// Controls the transition progress between the image variants of icon-image. Zero means the first variant is used, one is the second, and in between they are blended together. Both images should be the same size and have the same type (either raster or vector).
   /// Default value: 0. Value range: [0, 1]
   /// Deprecated: Use `PointAnnotationManager.iconImageCrossFade` instead.
   double? iconImageCrossFade;

--- a/lib/src/pigeons/point_annotation_messenger.dart
+++ b/lib/src/pigeons/point_annotation_messenger.dart
@@ -1074,51 +1074,6 @@ class PointAnnotationMessenger_PigeonCodec extends StandardMessageCodec {
   }
 }
 
-abstract class OnPointAnnotationClickListener {
-  static const MessageCodec<Object?> pigeonChannelCodec =
-      PointAnnotationMessenger_PigeonCodec();
-
-  void onPointAnnotationClick(PointAnnotation annotation);
-
-  static void setUp(
-    OnPointAnnotationClickListener? api, {
-    BinaryMessenger? binaryMessenger,
-    String messageChannelSuffix = '',
-  }) {
-    messageChannelSuffix =
-        messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
-    {
-      final BasicMessageChannel<
-          Object?> pigeonVar_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.mapbox_maps_flutter.OnPointAnnotationClickListener.onPointAnnotationClick$messageChannelSuffix',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
-      if (api == null) {
-        pigeonVar_channel.setMessageHandler(null);
-      } else {
-        pigeonVar_channel.setMessageHandler((Object? message) async {
-          assert(message != null,
-              'Argument for dev.flutter.pigeon.mapbox_maps_flutter.OnPointAnnotationClickListener.onPointAnnotationClick was null.');
-          final List<Object?> args = (message as List<Object?>?)!;
-          final PointAnnotation? arg_annotation = (args[0] as PointAnnotation?);
-          assert(arg_annotation != null,
-              'Argument for dev.flutter.pigeon.mapbox_maps_flutter.OnPointAnnotationClickListener.onPointAnnotationClick was null, expected non-null PointAnnotation.');
-          try {
-            api.onPointAnnotationClick(arg_annotation!);
-            return wrapResponse(empty: true);
-          } on PlatformException catch (e) {
-            return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
-          }
-        });
-      }
-    }
-  }
-}
-
 class _PointAnnotationMessenger {
   /// Constructor for [_PointAnnotationMessenger].  The [binaryMessenger] named argument is
   /// available for dependency injection.  If it is left null, the default

--- a/lib/src/pigeons/point_annotation_messenger.dart
+++ b/lib/src/pigeons/point_annotation_messenger.dart
@@ -290,7 +290,6 @@ class PointAnnotation {
     this.iconHaloBlur,
     this.iconHaloColor,
     this.iconHaloWidth,
-    @Deprecated('Use [PointAnnotationManager.iconImageCrossFade] instead.')
     this.iconImageCrossFade,
     this.iconOcclusionOpacity,
     this.iconOpacity,
@@ -409,9 +408,9 @@ class PointAnnotation {
   /// Default value: 0. Minimum value: 0. The unit of iconHaloWidth is in pixels.
   double? iconHaloWidth;
 
-  /// Controls the transition progress between the image variants of icon-image. Zero means the first variant is used, one is the second, and in between they are blended together. Both images should be the same size and have the same type (either raster or vector).
+  /// Controls the transition progress between the image variants of icon-image. Zero means the first variant is used, one is the second, and in between they are blended together. . Both images should be the same size and have the same type (either raster or vector).
   /// Default value: 0. Value range: [0, 1]
-  @Deprecated('Use [PointAnnotationManager.iconImageCrossFade] instead.')
+  /// Deprecated: Use `PointAnnotationManager.iconImageCrossFade` instead.
   double? iconImageCrossFade;
 
   /// The opacity at which the icon will be drawn in case of being depth occluded. Absent value means full occlusion against terrain only.
@@ -634,7 +633,6 @@ class PointAnnotationOptions {
     this.iconHaloBlur,
     this.iconHaloColor,
     this.iconHaloWidth,
-    @Deprecated('Use [PointAnnotationManager.iconImageCrossFade] instead.')
     this.iconImageCrossFade,
     this.iconOcclusionOpacity,
     this.iconOpacity,
@@ -750,9 +748,9 @@ class PointAnnotationOptions {
   /// Default value: 0. Minimum value: 0. The unit of iconHaloWidth is in pixels.
   double? iconHaloWidth;
 
-  /// Controls the transition progress between the image variants of icon-image. Zero means the first variant is used, one is the second, and in between they are blended together. Both images should be the same size and have the same type (either raster or vector).
+  /// Controls the transition progress between the image variants of icon-image. Zero means the first variant is used, one is the second, and in between they are blended together. . Both images should be the same size and have the same type (either raster or vector).
   /// Default value: 0. Value range: [0, 1]
-  @Deprecated('Use [PointAnnotationManager.iconImageCrossFade] instead.')
+  /// Deprecated: Use `PointAnnotationManager.iconImageCrossFade` instead.
   double? iconImageCrossFade;
 
   /// The opacity at which the icon will be drawn in case of being depth occluded. Absent value means full occlusion against terrain only.

--- a/lib/src/pigeons/polygon_annotation_messenger.dart
+++ b/lib/src/pigeons/polygon_annotation_messenger.dart
@@ -327,52 +327,6 @@ class PolygonAnnotationMessenger_PigeonCodec extends StandardMessageCodec {
   }
 }
 
-abstract class OnPolygonAnnotationClickListener {
-  static const MessageCodec<Object?> pigeonChannelCodec =
-      PolygonAnnotationMessenger_PigeonCodec();
-
-  void onPolygonAnnotationClick(PolygonAnnotation annotation);
-
-  static void setUp(
-    OnPolygonAnnotationClickListener? api, {
-    BinaryMessenger? binaryMessenger,
-    String messageChannelSuffix = '',
-  }) {
-    messageChannelSuffix =
-        messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
-    {
-      final BasicMessageChannel<
-          Object?> pigeonVar_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.mapbox_maps_flutter.OnPolygonAnnotationClickListener.onPolygonAnnotationClick$messageChannelSuffix',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
-      if (api == null) {
-        pigeonVar_channel.setMessageHandler(null);
-      } else {
-        pigeonVar_channel.setMessageHandler((Object? message) async {
-          assert(message != null,
-              'Argument for dev.flutter.pigeon.mapbox_maps_flutter.OnPolygonAnnotationClickListener.onPolygonAnnotationClick was null.');
-          final List<Object?> args = (message as List<Object?>?)!;
-          final PolygonAnnotation? arg_annotation =
-              (args[0] as PolygonAnnotation?);
-          assert(arg_annotation != null,
-              'Argument for dev.flutter.pigeon.mapbox_maps_flutter.OnPolygonAnnotationClickListener.onPolygonAnnotationClick was null, expected non-null PolygonAnnotation.');
-          try {
-            api.onPolygonAnnotationClick(arg_annotation!);
-            return wrapResponse(empty: true);
-          } on PlatformException catch (e) {
-            return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
-          }
-        });
-      }
-    }
-  }
-}
-
 class _PolygonAnnotationMessenger {
   /// Constructor for [_PolygonAnnotationMessenger].  The [binaryMessenger] named argument is
   /// available for dependency injection.  If it is left null, the default

--- a/lib/src/pigeons/polyline_annotation_messenger.dart
+++ b/lib/src/pigeons/polyline_annotation_messenger.dart
@@ -445,52 +445,6 @@ class PolylineAnnotationMessenger_PigeonCodec extends StandardMessageCodec {
   }
 }
 
-abstract class OnPolylineAnnotationClickListener {
-  static const MessageCodec<Object?> pigeonChannelCodec =
-      PolylineAnnotationMessenger_PigeonCodec();
-
-  void onPolylineAnnotationClick(PolylineAnnotation annotation);
-
-  static void setUp(
-    OnPolylineAnnotationClickListener? api, {
-    BinaryMessenger? binaryMessenger,
-    String messageChannelSuffix = '',
-  }) {
-    messageChannelSuffix =
-        messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
-    {
-      final BasicMessageChannel<
-          Object?> pigeonVar_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.mapbox_maps_flutter.OnPolylineAnnotationClickListener.onPolylineAnnotationClick$messageChannelSuffix',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
-      if (api == null) {
-        pigeonVar_channel.setMessageHandler(null);
-      } else {
-        pigeonVar_channel.setMessageHandler((Object? message) async {
-          assert(message != null,
-              'Argument for dev.flutter.pigeon.mapbox_maps_flutter.OnPolylineAnnotationClickListener.onPolylineAnnotationClick was null.');
-          final List<Object?> args = (message as List<Object?>?)!;
-          final PolylineAnnotation? arg_annotation =
-              (args[0] as PolylineAnnotation?);
-          assert(arg_annotation != null,
-              'Argument for dev.flutter.pigeon.mapbox_maps_flutter.OnPolylineAnnotationClickListener.onPolylineAnnotationClick was null, expected non-null PolylineAnnotation.');
-          try {
-            api.onPolylineAnnotationClick(arg_annotation!);
-            return wrapResponse(empty: true);
-          } on PlatformException catch (e) {
-            return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
-          }
-        });
-      }
-    }
-  }
-}
-
 class _PolylineAnnotationMessenger {
   /// Constructor for [_PolylineAnnotationMessenger].  The [binaryMessenger] named argument is
   /// available for dependency injection.  If it is left null, the default


### PR DESCRIPTION
### What does this pull request do?

This PR adds `tapEvents` and `longPressEvents` to Annotations API, allowing users to provide a callback to be invoked and an annotation is tapped or long pressed.
Both API will return a Cancelable token, which can be used to stop listening to interaction events.

With `tapEvents`, we are now aligning with platform implementation that use IME underlying, instead of using old API in iOS and observe interaction events via delegation, and since the tap interaction is now not propagated to the annotation below the topmost one, you will get exactly one callback when you tap on overlapping annotations as described in #791 

### What is the motivation and context behind this change?



### Pull request checklist:
 - [x] Add a changelog entry.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [x] Add documentation comments for any added or updated public APIs.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](../CONTRIBUTING.md#contributor-license-agreement).
