### PR TITLE
Revert "Use Maps SDK Android dependency with NDK 27 support (#985)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 ### main
 
-* Use Maps SDK Android dependency with NDK 27 support and [support for 16 KB page sizes](https://developer.android.com/guide/practices/page-sizes).
 * Fix crash when receiving annotation interactions.
 
 ### 2.10.0-beta.1

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -59,7 +59,7 @@ if (file("$rootDir/gradle/ktlint.gradle").exists() && file("$rootDir/gradle/lint
 }
 
 dependencies {
-    implementation "com.mapbox.maps:android-ndk27:11.14.0-beta.1"
+    implementation "com.mapbox.maps:android:11.14.0-beta.1"
 
     implementation "androidx.annotation:annotation:1.5.0"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.6.2"

--- a/scripts/license.sh
+++ b/scripts/license.sh
@@ -64,7 +64,7 @@ while read -r name version; do
 done <<< "$package_info"
 
 ios_sdk_version=$(grep -A 1 'mapbox-maps-ios' ios/mapbox_maps_flutter/Package.swift | grep 'exact' | sed -E 's/.*"([0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?)".*/\1/')
-android_sdk_version=$(grep 'com.mapbox.maps:android-ndk27' android/build.gradle | sed -E 's/.*"com\.mapbox\.maps:android-ndk27:([0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?)".*/\1/')
+android_sdk_version=$(grep 'com.mapbox.maps:android' android/build.gradle | sed -E 's/.*"com\.mapbox\.maps:android:([0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?)".*/\1/')
 ios_license_content=$(curl -s "https://raw.githubusercontent.com/mapbox/mapbox-maps-ios/v$ios_sdk_version/LICENSE.md")
 android_license_content=$(curl -s "https://raw.githubusercontent.com/mapbox/mapbox-maps-android/v$android_sdk_version/LICENSE.md")
 


### PR DESCRIPTION
This reverts commit 6453940fe9203a0fae847d9972df6df88ba4dde4.

We are pushing this change for 2.11.