### PR TITLE
do not handle annotation tap if there is no subscription

### DIFF
--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/annotation/AnnotationController.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/annotation/AnnotationController.kt
@@ -44,13 +44,11 @@ class AnnotationController(
           this.addClickListener(
             com.mapbox.maps.plugin.annotation.generated.OnCircleAnnotationClickListener { annotation ->
               sendTapEvent(id, annotation)
-              false
             }
           )
           this.addLongClickListener(
             OnCircleAnnotationLongClickListener { annotation ->
               sendLongPressEvent(id, annotation)
-              false
             }
           )
           this.addDragListener(object :
@@ -74,13 +72,11 @@ class AnnotationController(
           this.addClickListener(
             com.mapbox.maps.plugin.annotation.generated.OnPointAnnotationClickListener { annotation ->
               sendTapEvent(id, annotation)
-              false
             }
           )
           this.addLongClickListener(
             OnPointAnnotationLongClickListener { annotation ->
               sendLongPressEvent(id, annotation)
-              false
             }
           )
           this.addDragListener(object :
@@ -104,13 +100,11 @@ class AnnotationController(
           this.addClickListener(
             com.mapbox.maps.plugin.annotation.generated.OnPolygonAnnotationClickListener { annotation ->
               sendTapEvent(id, annotation)
-              false
             }
           )
           this.addLongClickListener(
             OnPolygonAnnotationLongClickListener { annotation ->
               sendLongPressEvent(id, annotation)
-              false
             }
           )
           this.addDragListener(object :
@@ -134,13 +128,11 @@ class AnnotationController(
           this.addClickListener(
             com.mapbox.maps.plugin.annotation.generated.OnPolylineAnnotationClickListener { annotation ->
               sendTapEvent(id, annotation)
-              false
             }
           )
           this.addLongClickListener(
             OnPolylineAnnotationLongClickListener { annotation ->
               sendLongPressEvent(id, annotation)
-              false
             }
           )
           this.addDragListener(object :
@@ -221,36 +213,47 @@ class AnnotationController(
     streamSinkMap[managerId]?.dragEventsSink?.success(context)
   }
 
-  fun sendTapEvent(managerId: String, annotation: Annotation<*>) {
-    val context: AnnotationInteractionContext = when (annotation) {
-      is com.mapbox.maps.plugin.annotation.generated.PointAnnotation ->
-        PointAnnotationInteractionContext(annotation.toFLTPointAnnotation(), GestureState.ENDED)
-      is CircleAnnotation ->
-        CircleAnnotationInteractionContext(annotation.toFLTCircleAnnotation(), GestureState.ENDED)
-      is PolygonAnnotation ->
-        PolygonAnnotationInteractionContext(annotation.toFLTPolygonAnnotation(), GestureState.ENDED)
-      is PolylineAnnotation ->
-        PolylineAnnotationInteractionContext(annotation.toFLTPolylineAnnotation(), GestureState.ENDED)
+  fun sendTapEvent(managerId: String, annotation: Annotation<*>): Boolean {
 
-      else -> throw IllegalArgumentException("$annotation is unsupported")
+    val sink = streamSinkMap[managerId]?.tapEventsSink
+    return if (sink != null) {
+      val context: AnnotationInteractionContext = when (annotation) {
+        is com.mapbox.maps.plugin.annotation.generated.PointAnnotation ->
+          PointAnnotationInteractionContext(annotation.toFLTPointAnnotation(), GestureState.ENDED)
+        is CircleAnnotation ->
+          CircleAnnotationInteractionContext(annotation.toFLTCircleAnnotation(), GestureState.ENDED)
+        is PolygonAnnotation ->
+          PolygonAnnotationInteractionContext(annotation.toFLTPolygonAnnotation(), GestureState.ENDED)
+        is PolylineAnnotation ->
+          PolylineAnnotationInteractionContext(annotation.toFLTPolylineAnnotation(), GestureState.ENDED)
+        else -> throw IllegalArgumentException("$annotation is unsupported")
+      }
+      sink.success(context)
+      true
+    } else {
+      false
     }
-    streamSinkMap[managerId]?.tapEventsSink?.success(context)
   }
 
-  fun sendLongPressEvent(managerId: String, annotation: Annotation<*>) {
-    val context: AnnotationInteractionContext = when (annotation) {
-      is com.mapbox.maps.plugin.annotation.generated.PointAnnotation ->
-        PointAnnotationInteractionContext(annotation.toFLTPointAnnotation(), GestureState.ENDED)
-      is CircleAnnotation ->
-        CircleAnnotationInteractionContext(annotation.toFLTCircleAnnotation(), GestureState.ENDED)
-      is PolygonAnnotation ->
-        PolygonAnnotationInteractionContext(annotation.toFLTPolygonAnnotation(), GestureState.ENDED)
-      is PolylineAnnotation ->
-        PolylineAnnotationInteractionContext(annotation.toFLTPolylineAnnotation(), GestureState.ENDED)
-
-      else -> throw IllegalArgumentException("$annotation is unsupported")
+  fun sendLongPressEvent(managerId: String, annotation: Annotation<*>): Boolean {
+    val sink = streamSinkMap[managerId]?.longPressEventsSink
+    return if (sink != null) {
+      val context: AnnotationInteractionContext = when (annotation) {
+        is com.mapbox.maps.plugin.annotation.generated.PointAnnotation ->
+          PointAnnotationInteractionContext(annotation.toFLTPointAnnotation(), GestureState.ENDED)
+        is CircleAnnotation ->
+          CircleAnnotationInteractionContext(annotation.toFLTCircleAnnotation(), GestureState.ENDED)
+        is PolygonAnnotation ->
+          PolygonAnnotationInteractionContext(annotation.toFLTPolygonAnnotation(), GestureState.ENDED)
+        is PolylineAnnotation ->
+          PolylineAnnotationInteractionContext(annotation.toFLTPolylineAnnotation(), GestureState.ENDED)
+        else -> throw IllegalArgumentException("$annotation is unsupported")
+      }
+      sink.success(context)
+      true
+    } else {
+      false
     }
-    streamSinkMap[managerId]?.longPressEventsSink?.success(context)
   }
 
   override fun getManager(managerId: String): AnnotationManager<*, *, *, *, *, *, *> {

--- a/example/integration_test/annotations/circle_annotation_manager_test.dart
+++ b/example/integration_test/annotations/circle_annotation_manager_test.dart
@@ -92,141 +92,220 @@ void main() {
     expect(CircleTranslateAnchor.MAP, circleTranslateAnchor);
   });
 
-  testWidgets('annotation tap events', (tester) async {
-    final mapFuture = app.main();
-    await tester.pumpAndSettle();
+  group('annotation events', () {
+    late MapboxMap mapboxMap;
+    late CircleAnnotationManager manager;
+    late CircleAnnotation createdAnnotation;
+    late EventChannel eventChannel;
 
-    final mapboxMap = await mapFuture;
-    final manager = await mapboxMap.annotations.createCircleAnnotationManager();
+    Future<void> setupMap(
+        WidgetTester tester, String eventChannelSuffix) async {
+      final mapFuture = app.main();
+      await Future.delayed(
+          Duration(milliseconds: 100)); // Ensure app.main() is started
+      await tester.pumpAndSettle();
+      mapboxMap = await mapFuture;
+      manager = await mapboxMap.annotations.createCircleAnnotationManager();
 
-    final geometry = Point(coordinates: Position(0, 0));
+      final geometry = Point(coordinates: Position(0, 0));
 
-    final createdAnnotation = await manager.create(CircleAnnotationOptions(
-      geometry: geometry,
-    ));
+      createdAnnotation = await manager.create(CircleAnnotationOptions(
+        geometry: geometry,
+        isDraggable: true,
+      ));
 
-    // Mock tap events
-    final eventChannel = EventChannel(
-        "dev.flutter.pigeon.mapbox_maps_flutter.AnnotationInteractions._annotationInteractionEvents.0/${manager.id}/tap",
-        pigeonMethodCodec);
-    IntegrationTestWidgetsFlutterBinding.instance.defaultBinaryMessenger
-        .setMockStreamHandler(eventChannel,
-            MockStreamHandler.inline(onListen: (arguments, events) {
-      events.success(CircleAnnotationInteractionContext(
+      eventChannel = EventChannel(
+        "dev.flutter.pigeon.mapbox_maps_flutter.AnnotationInteractions._annotationInteractionEvents.0/${manager.id}/${eventChannelSuffix}",
+        pigeonMethodCodec,
+      );
+    }
+
+    testWidgets('annotation tap events can be listened and canceled',
+        (tester) async {
+      // Test tap event can be listened
+      await setupMap(tester, 'tap');
+
+      final tapCompleter = Completer();
+      late MockStreamHandlerEventSink eventSink;
+      var isCanceled = false;
+
+      IntegrationTestWidgetsFlutterBinding.instance.defaultBinaryMessenger
+          .setMockStreamHandler(
+              eventChannel,
+              MockStreamHandler.inline(
+                onListen: (arguments, events) {
+                  eventSink = events;
+                },
+                onCancel: (arguments) {
+                  isCanceled = true;
+                },
+              ));
+
+      final token = manager.tapEvents(
+        onTap: (annotation) {
+          if (isCanceled) {
+            fail('This test should be canceled and not called.');
+          } else {
+            expect(annotation.id, equals(createdAnnotation.id));
+            tapCompleter.complete();
+          }
+        },
+      );
+
+      eventSink.success(CircleAnnotationInteractionContext(
         annotation: createdAnnotation,
         gestureState: GestureState.ended,
       ));
-      events.endOfStream();
-    }));
 
-    final onTap = Completer();
-    manager.tapEvents(
-      onTap: (annotation) {
-        expect(annotation.id, equals(createdAnnotation.id));
-        onTap.complete();
-      },
-    );
+      await tapCompleter.future;
+      expect(tapCompleter.isCompleted, isTrue);
+      expect(isCanceled, isFalse);
 
-    await onTap.future;
-    expect(onTap.isCompleted, isTrue);
-  });
-
-  testWidgets('annotation long press events', (tester) async {
-    final mapFuture = app.main();
-    await tester.pumpAndSettle();
-
-    final mapboxMap = await mapFuture;
-    final manager = await mapboxMap.annotations.createCircleAnnotationManager();
-
-    final geometry = Point(coordinates: Position(0, 0));
-
-    final createdAnnotation = await manager.create(CircleAnnotationOptions(
-      geometry: geometry,
-    ));
-
-    // Mock long press events
-    final eventChannel = EventChannel(
-        "dev.flutter.pigeon.mapbox_maps_flutter.AnnotationInteractions._annotationInteractionEvents.0/${manager.id}/long_press",
-        pigeonMethodCodec);
-    IntegrationTestWidgetsFlutterBinding.instance.defaultBinaryMessenger
-        .setMockStreamHandler(eventChannel,
-            MockStreamHandler.inline(onListen: (arguments, events) {
-      events.success(CircleAnnotationInteractionContext(
+      token.cancel();
+      eventSink.success(CircleAnnotationInteractionContext(
         annotation: createdAnnotation,
         gestureState: GestureState.ended,
       ));
-      events.endOfStream();
-    }));
+      expect(isCanceled, isTrue);
 
-    final onLongPress = Completer();
-    manager.longPressEvents(
-      onLongPress: (annotation) {
-        expect(annotation.id, equals(createdAnnotation.id));
-        onLongPress.complete();
-      },
-    );
+      eventSink.endOfStream();
+    });
 
-    await onLongPress.future;
-    expect(onLongPress.isCompleted, isTrue);
-  });
+    testWidgets('annotation long press events can be listened and canceled',
+        (tester) async {
+      await setupMap(tester, 'long_press');
 
-  testWidgets('annotation drag events', (WidgetTester tester) async {
-    final mapFuture = app.main();
-    await tester.pumpAndSettle();
+      final longPressCompleter = Completer();
+      late MockStreamHandlerEventSink eventSink;
+      var isCanceled = false;
 
-    final mapboxMap = await mapFuture;
-    final manager = await mapboxMap.annotations.createCircleAnnotationManager();
+      IntegrationTestWidgetsFlutterBinding.instance.defaultBinaryMessenger
+          .setMockStreamHandler(
+              eventChannel,
+              MockStreamHandler.inline(
+                onListen: (arguments, events) {
+                  eventSink = events;
+                },
+                onCancel: (arguments) {
+                  isCanceled = true;
+                },
+              ));
 
-    final geometry = Point(coordinates: Position(0, 0));
+      final token = manager.longPressEvents(
+        onLongPress: (annotation) {
+          if (isCanceled) {
+            fail('This test should be canceled and not called.');
+          } else {
+            expect(annotation.id, equals(createdAnnotation.id));
+            longPressCompleter.complete();
+          }
+        },
+      );
 
-    final createdAnnotation = await manager.create(CircleAnnotationOptions(
-      geometry: geometry,
-      isDraggable: true,
-    ));
+      eventSink.success(CircleAnnotationInteractionContext(
+        annotation: createdAnnotation,
+        gestureState: GestureState.ended,
+      ));
 
-    // Mock drag events
-    final eventChannel = EventChannel(
-        "dev.flutter.pigeon.mapbox_maps_flutter.AnnotationInteractions._annotationInteractionEvents.0/${manager.id}/drag",
-        pigeonMethodCodec);
-    IntegrationTestWidgetsFlutterBinding.instance.defaultBinaryMessenger
-        .setMockStreamHandler(eventChannel,
-            MockStreamHandler.inline(onListen: (arguments, events) {
-      events.success(CircleAnnotationInteractionContext(
+      await longPressCompleter.future;
+      expect(longPressCompleter.isCompleted, isTrue);
+      expect(isCanceled, isFalse);
+
+      token.cancel();
+      eventSink.success(CircleAnnotationInteractionContext(
+        annotation: createdAnnotation,
+        gestureState: GestureState.ended,
+      ));
+      expect(isCanceled, isTrue);
+
+      eventSink.endOfStream();
+    });
+
+    testWidgets('annotation drag events can be listened and canceled',
+        (tester) async {
+      await setupMap(tester, 'drag');
+
+      final dragBegin = Completer();
+      final dragChanged = Completer();
+      final dragEnd = Completer();
+      late MockStreamHandlerEventSink eventSink;
+      var isCanceled = false;
+
+      IntegrationTestWidgetsFlutterBinding.instance.defaultBinaryMessenger
+          .setMockStreamHandler(
+              eventChannel,
+              MockStreamHandler.inline(
+                onListen: (arguments, events) {
+                  eventSink = events;
+                },
+                onCancel: (arguments) {
+                  isCanceled = true;
+                },
+              ));
+
+      final token = manager.dragEvents(
+        onBegin: (annotation) {
+          if (isCanceled) {
+            fail('This test should be canceled and not called.');
+          } else {
+            expect(annotation.id, equals(createdAnnotation.id));
+            dragBegin.complete();
+          }
+        },
+        onChanged: (annotation) {
+          if (isCanceled) {
+            fail('This test should be canceled and not called.');
+          } else {
+            expect(annotation.id, equals(createdAnnotation.id));
+            dragChanged.complete();
+          }
+        },
+        onEnd: (annotation) {
+          if (isCanceled) {
+            fail('This test should be canceled and not called.');
+          } else {
+            expect(annotation.id, equals(createdAnnotation.id));
+            dragEnd.complete();
+          }
+        },
+      );
+
+      eventSink.success(CircleAnnotationInteractionContext(
         annotation: createdAnnotation,
         gestureState: GestureState.started,
       ));
-      events.success(CircleAnnotationInteractionContext(
+      eventSink.success(CircleAnnotationInteractionContext(
         annotation: createdAnnotation,
         gestureState: GestureState.changed,
       ));
-      events.success(CircleAnnotationInteractionContext(
+      eventSink.success(CircleAnnotationInteractionContext(
         annotation: createdAnnotation,
         gestureState: GestureState.ended,
       ));
-      events.endOfStream();
-    }));
 
-    final onDragBegin = Completer();
-    final onDragChanged = Completer();
-    final onDragEnd = Completer();
+      await Future.wait([dragBegin.future, dragChanged.future, dragEnd.future]);
+      expect(
+          [dragBegin.isCompleted, dragChanged.isCompleted, dragEnd.isCompleted],
+          everyElement(isTrue));
+      expect(isCanceled, isFalse);
 
-    manager.dragEvents(
-      onBegin: (annotation) {
-        expect(annotation.id, equals(createdAnnotation.id));
-        onDragBegin.complete();
-      },
-      onChanged: (annotation) {
-        expect(annotation.id, equals(createdAnnotation.id));
-        onDragChanged.complete();
-      },
-      onEnd: (annotation) {
-        expect(annotation.id, equals(createdAnnotation.id));
-        onDragEnd.complete();
-      },
-    );
+      token.cancel();
+      eventSink.success(CircleAnnotationInteractionContext(
+        annotation: createdAnnotation,
+        gestureState: GestureState.started,
+      ));
+      eventSink.success(CircleAnnotationInteractionContext(
+        annotation: createdAnnotation,
+        gestureState: GestureState.changed,
+      ));
+      eventSink.success(CircleAnnotationInteractionContext(
+        annotation: createdAnnotation,
+        gestureState: GestureState.ended,
+      ));
+      expect(isCanceled, isTrue);
 
-    await Future.wait(
-        [onDragBegin.future, onDragChanged.future, onDragEnd.future]);
+      eventSink.endOfStream();
+    });
   });
 }
 // End of generated file.

--- a/example/integration_test/annotations/point_annotation_manager_test.dart
+++ b/example/integration_test/annotations/point_annotation_manager_test.dart
@@ -292,141 +292,220 @@ void main() {
     expect(TextTranslateAnchor.MAP, textTranslateAnchor);
   });
 
-  testWidgets('annotation tap events', (tester) async {
-    final mapFuture = app.main();
-    await tester.pumpAndSettle();
+  group('annotation events', () {
+    late MapboxMap mapboxMap;
+    late PointAnnotationManager manager;
+    late PointAnnotation createdAnnotation;
+    late EventChannel eventChannel;
 
-    final mapboxMap = await mapFuture;
-    final manager = await mapboxMap.annotations.createPointAnnotationManager();
+    Future<void> setupMap(
+        WidgetTester tester, String eventChannelSuffix) async {
+      final mapFuture = app.main();
+      await Future.delayed(
+          Duration(milliseconds: 100)); // Ensure app.main() is started
+      await tester.pumpAndSettle();
+      mapboxMap = await mapFuture;
+      manager = await mapboxMap.annotations.createPointAnnotationManager();
 
-    final geometry = Point(coordinates: Position(0, 0));
+      final geometry = Point(coordinates: Position(0, 0));
 
-    final createdAnnotation = await manager.create(PointAnnotationOptions(
-      geometry: geometry,
-    ));
+      createdAnnotation = await manager.create(PointAnnotationOptions(
+        geometry: geometry,
+        isDraggable: true,
+      ));
 
-    // Mock tap events
-    final eventChannel = EventChannel(
-        "dev.flutter.pigeon.mapbox_maps_flutter.AnnotationInteractions._annotationInteractionEvents.0/${manager.id}/tap",
-        pigeonMethodCodec);
-    IntegrationTestWidgetsFlutterBinding.instance.defaultBinaryMessenger
-        .setMockStreamHandler(eventChannel,
-            MockStreamHandler.inline(onListen: (arguments, events) {
-      events.success(PointAnnotationInteractionContext(
+      eventChannel = EventChannel(
+        "dev.flutter.pigeon.mapbox_maps_flutter.AnnotationInteractions._annotationInteractionEvents.0/${manager.id}/${eventChannelSuffix}",
+        pigeonMethodCodec,
+      );
+    }
+
+    testWidgets('annotation tap events can be listened and canceled',
+        (tester) async {
+      // Test tap event can be listened
+      await setupMap(tester, 'tap');
+
+      final tapCompleter = Completer();
+      late MockStreamHandlerEventSink eventSink;
+      var isCanceled = false;
+
+      IntegrationTestWidgetsFlutterBinding.instance.defaultBinaryMessenger
+          .setMockStreamHandler(
+              eventChannel,
+              MockStreamHandler.inline(
+                onListen: (arguments, events) {
+                  eventSink = events;
+                },
+                onCancel: (arguments) {
+                  isCanceled = true;
+                },
+              ));
+
+      final token = manager.tapEvents(
+        onTap: (annotation) {
+          if (isCanceled) {
+            fail('This test should be canceled and not called.');
+          } else {
+            expect(annotation.id, equals(createdAnnotation.id));
+            tapCompleter.complete();
+          }
+        },
+      );
+
+      eventSink.success(PointAnnotationInteractionContext(
         annotation: createdAnnotation,
         gestureState: GestureState.ended,
       ));
-      events.endOfStream();
-    }));
 
-    final onTap = Completer();
-    manager.tapEvents(
-      onTap: (annotation) {
-        expect(annotation.id, equals(createdAnnotation.id));
-        onTap.complete();
-      },
-    );
+      await tapCompleter.future;
+      expect(tapCompleter.isCompleted, isTrue);
+      expect(isCanceled, isFalse);
 
-    await onTap.future;
-    expect(onTap.isCompleted, isTrue);
-  });
-
-  testWidgets('annotation long press events', (tester) async {
-    final mapFuture = app.main();
-    await tester.pumpAndSettle();
-
-    final mapboxMap = await mapFuture;
-    final manager = await mapboxMap.annotations.createPointAnnotationManager();
-
-    final geometry = Point(coordinates: Position(0, 0));
-
-    final createdAnnotation = await manager.create(PointAnnotationOptions(
-      geometry: geometry,
-    ));
-
-    // Mock long press events
-    final eventChannel = EventChannel(
-        "dev.flutter.pigeon.mapbox_maps_flutter.AnnotationInteractions._annotationInteractionEvents.0/${manager.id}/long_press",
-        pigeonMethodCodec);
-    IntegrationTestWidgetsFlutterBinding.instance.defaultBinaryMessenger
-        .setMockStreamHandler(eventChannel,
-            MockStreamHandler.inline(onListen: (arguments, events) {
-      events.success(PointAnnotationInteractionContext(
+      token.cancel();
+      eventSink.success(PointAnnotationInteractionContext(
         annotation: createdAnnotation,
         gestureState: GestureState.ended,
       ));
-      events.endOfStream();
-    }));
+      expect(isCanceled, isTrue);
 
-    final onLongPress = Completer();
-    manager.longPressEvents(
-      onLongPress: (annotation) {
-        expect(annotation.id, equals(createdAnnotation.id));
-        onLongPress.complete();
-      },
-    );
+      eventSink.endOfStream();
+    });
 
-    await onLongPress.future;
-    expect(onLongPress.isCompleted, isTrue);
-  });
+    testWidgets('annotation long press events can be listened and canceled',
+        (tester) async {
+      await setupMap(tester, 'long_press');
 
-  testWidgets('annotation drag events', (WidgetTester tester) async {
-    final mapFuture = app.main();
-    await tester.pumpAndSettle();
+      final longPressCompleter = Completer();
+      late MockStreamHandlerEventSink eventSink;
+      var isCanceled = false;
 
-    final mapboxMap = await mapFuture;
-    final manager = await mapboxMap.annotations.createPointAnnotationManager();
+      IntegrationTestWidgetsFlutterBinding.instance.defaultBinaryMessenger
+          .setMockStreamHandler(
+              eventChannel,
+              MockStreamHandler.inline(
+                onListen: (arguments, events) {
+                  eventSink = events;
+                },
+                onCancel: (arguments) {
+                  isCanceled = true;
+                },
+              ));
 
-    final geometry = Point(coordinates: Position(0, 0));
+      final token = manager.longPressEvents(
+        onLongPress: (annotation) {
+          if (isCanceled) {
+            fail('This test should be canceled and not called.');
+          } else {
+            expect(annotation.id, equals(createdAnnotation.id));
+            longPressCompleter.complete();
+          }
+        },
+      );
 
-    final createdAnnotation = await manager.create(PointAnnotationOptions(
-      geometry: geometry,
-      isDraggable: true,
-    ));
+      eventSink.success(PointAnnotationInteractionContext(
+        annotation: createdAnnotation,
+        gestureState: GestureState.ended,
+      ));
 
-    // Mock drag events
-    final eventChannel = EventChannel(
-        "dev.flutter.pigeon.mapbox_maps_flutter.AnnotationInteractions._annotationInteractionEvents.0/${manager.id}/drag",
-        pigeonMethodCodec);
-    IntegrationTestWidgetsFlutterBinding.instance.defaultBinaryMessenger
-        .setMockStreamHandler(eventChannel,
-            MockStreamHandler.inline(onListen: (arguments, events) {
-      events.success(PointAnnotationInteractionContext(
+      await longPressCompleter.future;
+      expect(longPressCompleter.isCompleted, isTrue);
+      expect(isCanceled, isFalse);
+
+      token.cancel();
+      eventSink.success(PointAnnotationInteractionContext(
+        annotation: createdAnnotation,
+        gestureState: GestureState.ended,
+      ));
+      expect(isCanceled, isTrue);
+
+      eventSink.endOfStream();
+    });
+
+    testWidgets('annotation drag events can be listened and canceled',
+        (tester) async {
+      await setupMap(tester, 'drag');
+
+      final dragBegin = Completer();
+      final dragChanged = Completer();
+      final dragEnd = Completer();
+      late MockStreamHandlerEventSink eventSink;
+      var isCanceled = false;
+
+      IntegrationTestWidgetsFlutterBinding.instance.defaultBinaryMessenger
+          .setMockStreamHandler(
+              eventChannel,
+              MockStreamHandler.inline(
+                onListen: (arguments, events) {
+                  eventSink = events;
+                },
+                onCancel: (arguments) {
+                  isCanceled = true;
+                },
+              ));
+
+      final token = manager.dragEvents(
+        onBegin: (annotation) {
+          if (isCanceled) {
+            fail('This test should be canceled and not called.');
+          } else {
+            expect(annotation.id, equals(createdAnnotation.id));
+            dragBegin.complete();
+          }
+        },
+        onChanged: (annotation) {
+          if (isCanceled) {
+            fail('This test should be canceled and not called.');
+          } else {
+            expect(annotation.id, equals(createdAnnotation.id));
+            dragChanged.complete();
+          }
+        },
+        onEnd: (annotation) {
+          if (isCanceled) {
+            fail('This test should be canceled and not called.');
+          } else {
+            expect(annotation.id, equals(createdAnnotation.id));
+            dragEnd.complete();
+          }
+        },
+      );
+
+      eventSink.success(PointAnnotationInteractionContext(
         annotation: createdAnnotation,
         gestureState: GestureState.started,
       ));
-      events.success(PointAnnotationInteractionContext(
+      eventSink.success(PointAnnotationInteractionContext(
         annotation: createdAnnotation,
         gestureState: GestureState.changed,
       ));
-      events.success(PointAnnotationInteractionContext(
+      eventSink.success(PointAnnotationInteractionContext(
         annotation: createdAnnotation,
         gestureState: GestureState.ended,
       ));
-      events.endOfStream();
-    }));
 
-    final onDragBegin = Completer();
-    final onDragChanged = Completer();
-    final onDragEnd = Completer();
+      await Future.wait([dragBegin.future, dragChanged.future, dragEnd.future]);
+      expect(
+          [dragBegin.isCompleted, dragChanged.isCompleted, dragEnd.isCompleted],
+          everyElement(isTrue));
+      expect(isCanceled, isFalse);
 
-    manager.dragEvents(
-      onBegin: (annotation) {
-        expect(annotation.id, equals(createdAnnotation.id));
-        onDragBegin.complete();
-      },
-      onChanged: (annotation) {
-        expect(annotation.id, equals(createdAnnotation.id));
-        onDragChanged.complete();
-      },
-      onEnd: (annotation) {
-        expect(annotation.id, equals(createdAnnotation.id));
-        onDragEnd.complete();
-      },
-    );
+      token.cancel();
+      eventSink.success(PointAnnotationInteractionContext(
+        annotation: createdAnnotation,
+        gestureState: GestureState.started,
+      ));
+      eventSink.success(PointAnnotationInteractionContext(
+        annotation: createdAnnotation,
+        gestureState: GestureState.changed,
+      ));
+      eventSink.success(PointAnnotationInteractionContext(
+        annotation: createdAnnotation,
+        gestureState: GestureState.ended,
+      ));
+      expect(isCanceled, isTrue);
 
-    await Future.wait(
-        [onDragBegin.future, onDragChanged.future, onDragEnd.future]);
+      eventSink.endOfStream();
+    });
   });
 }
 // End of generated file.

--- a/example/integration_test/annotations/polygon_annotation_manager_test.dart
+++ b/example/integration_test/annotations/polygon_annotation_manager_test.dart
@@ -94,165 +94,227 @@ void main() {
     expect(1.0, fillZOffset);
   });
 
-  testWidgets('annotation tap events', (tester) async {
-    final mapFuture = app.main();
-    await tester.pumpAndSettle();
+  group('annotation events', () {
+    late MapboxMap mapboxMap;
+    late PolygonAnnotationManager manager;
+    late PolygonAnnotation createdAnnotation;
+    late EventChannel eventChannel;
 
-    final mapboxMap = await mapFuture;
-    final manager =
-        await mapboxMap.annotations.createPolygonAnnotationManager();
+    Future<void> setupMap(
+        WidgetTester tester, String eventChannelSuffix) async {
+      final mapFuture = app.main();
+      await Future.delayed(
+          Duration(milliseconds: 100)); // Ensure app.main() is started
+      await tester.pumpAndSettle();
+      mapboxMap = await mapFuture;
+      manager = await mapboxMap.annotations.createPolygonAnnotationManager();
 
-    final geometry = Polygon(coordinates: [
-      [
-        Position(0, 0),
-        Position(1.754703, -19.716317),
-        Position(-15.747196, -21.085074),
-        Position(-3.363937, -10.733102)
-      ]
-    ]);
+      final geometry = Polygon(coordinates: [
+        [
+          Position(0, 0),
+          Position(1.754703, -19.716317),
+          Position(-15.747196, -21.085074),
+          Position(-3.363937, -10.733102)
+        ]
+      ]);
 
-    final createdAnnotation = await manager.create(PolygonAnnotationOptions(
-      geometry: geometry,
-    ));
+      createdAnnotation = await manager.create(PolygonAnnotationOptions(
+        geometry: geometry,
+        isDraggable: true,
+      ));
 
-    // Mock tap events
-    final eventChannel = EventChannel(
-        "dev.flutter.pigeon.mapbox_maps_flutter.AnnotationInteractions._annotationInteractionEvents.0/${manager.id}/tap",
-        pigeonMethodCodec);
-    IntegrationTestWidgetsFlutterBinding.instance.defaultBinaryMessenger
-        .setMockStreamHandler(eventChannel,
-            MockStreamHandler.inline(onListen: (arguments, events) {
-      events.success(PolygonAnnotationInteractionContext(
+      eventChannel = EventChannel(
+        "dev.flutter.pigeon.mapbox_maps_flutter.AnnotationInteractions._annotationInteractionEvents.0/${manager.id}/${eventChannelSuffix}",
+        pigeonMethodCodec,
+      );
+    }
+
+    testWidgets('annotation tap events can be listened and canceled',
+        (tester) async {
+      // Test tap event can be listened
+      await setupMap(tester, 'tap');
+
+      final tapCompleter = Completer();
+      late MockStreamHandlerEventSink eventSink;
+      var isCanceled = false;
+
+      IntegrationTestWidgetsFlutterBinding.instance.defaultBinaryMessenger
+          .setMockStreamHandler(
+              eventChannel,
+              MockStreamHandler.inline(
+                onListen: (arguments, events) {
+                  eventSink = events;
+                },
+                onCancel: (arguments) {
+                  isCanceled = true;
+                },
+              ));
+
+      final token = manager.tapEvents(
+        onTap: (annotation) {
+          if (isCanceled) {
+            fail('This test should be canceled and not called.');
+          } else {
+            expect(annotation.id, equals(createdAnnotation.id));
+            tapCompleter.complete();
+          }
+        },
+      );
+
+      eventSink.success(PolygonAnnotationInteractionContext(
         annotation: createdAnnotation,
         gestureState: GestureState.ended,
       ));
-      events.endOfStream();
-    }));
 
-    final onTap = Completer();
-    manager.tapEvents(
-      onTap: (annotation) {
-        expect(annotation.id, equals(createdAnnotation.id));
-        onTap.complete();
-      },
-    );
+      await tapCompleter.future;
+      expect(tapCompleter.isCompleted, isTrue);
+      expect(isCanceled, isFalse);
 
-    await onTap.future;
-    expect(onTap.isCompleted, isTrue);
-  });
-
-  testWidgets('annotation long press events', (tester) async {
-    final mapFuture = app.main();
-    await tester.pumpAndSettle();
-
-    final mapboxMap = await mapFuture;
-    final manager =
-        await mapboxMap.annotations.createPolygonAnnotationManager();
-
-    final geometry = Polygon(coordinates: [
-      [
-        Position(0, 0),
-        Position(1.754703, -19.716317),
-        Position(-15.747196, -21.085074),
-        Position(-3.363937, -10.733102)
-      ]
-    ]);
-
-    final createdAnnotation = await manager.create(PolygonAnnotationOptions(
-      geometry: geometry,
-    ));
-
-    // Mock long press events
-    final eventChannel = EventChannel(
-        "dev.flutter.pigeon.mapbox_maps_flutter.AnnotationInteractions._annotationInteractionEvents.0/${manager.id}/long_press",
-        pigeonMethodCodec);
-    IntegrationTestWidgetsFlutterBinding.instance.defaultBinaryMessenger
-        .setMockStreamHandler(eventChannel,
-            MockStreamHandler.inline(onListen: (arguments, events) {
-      events.success(PolygonAnnotationInteractionContext(
+      token.cancel();
+      eventSink.success(PolygonAnnotationInteractionContext(
         annotation: createdAnnotation,
         gestureState: GestureState.ended,
       ));
-      events.endOfStream();
-    }));
+      expect(isCanceled, isTrue);
 
-    final onLongPress = Completer();
-    manager.longPressEvents(
-      onLongPress: (annotation) {
-        expect(annotation.id, equals(createdAnnotation.id));
-        onLongPress.complete();
-      },
-    );
+      eventSink.endOfStream();
+    });
 
-    await onLongPress.future;
-    expect(onLongPress.isCompleted, isTrue);
-  });
+    testWidgets('annotation long press events can be listened and canceled',
+        (tester) async {
+      await setupMap(tester, 'long_press');
 
-  testWidgets('annotation drag events', (WidgetTester tester) async {
-    final mapFuture = app.main();
-    await tester.pumpAndSettle();
+      final longPressCompleter = Completer();
+      late MockStreamHandlerEventSink eventSink;
+      var isCanceled = false;
 
-    final mapboxMap = await mapFuture;
-    final manager =
-        await mapboxMap.annotations.createPolygonAnnotationManager();
+      IntegrationTestWidgetsFlutterBinding.instance.defaultBinaryMessenger
+          .setMockStreamHandler(
+              eventChannel,
+              MockStreamHandler.inline(
+                onListen: (arguments, events) {
+                  eventSink = events;
+                },
+                onCancel: (arguments) {
+                  isCanceled = true;
+                },
+              ));
 
-    final geometry = Polygon(coordinates: [
-      [
-        Position(0, 0),
-        Position(1.754703, -19.716317),
-        Position(-15.747196, -21.085074),
-        Position(-3.363937, -10.733102)
-      ]
-    ]);
+      final token = manager.longPressEvents(
+        onLongPress: (annotation) {
+          if (isCanceled) {
+            fail('This test should be canceled and not called.');
+          } else {
+            expect(annotation.id, equals(createdAnnotation.id));
+            longPressCompleter.complete();
+          }
+        },
+      );
 
-    final createdAnnotation = await manager.create(PolygonAnnotationOptions(
-      geometry: geometry,
-      isDraggable: true,
-    ));
+      eventSink.success(PolygonAnnotationInteractionContext(
+        annotation: createdAnnotation,
+        gestureState: GestureState.ended,
+      ));
 
-    // Mock drag events
-    final eventChannel = EventChannel(
-        "dev.flutter.pigeon.mapbox_maps_flutter.AnnotationInteractions._annotationInteractionEvents.0/${manager.id}/drag",
-        pigeonMethodCodec);
-    IntegrationTestWidgetsFlutterBinding.instance.defaultBinaryMessenger
-        .setMockStreamHandler(eventChannel,
-            MockStreamHandler.inline(onListen: (arguments, events) {
-      events.success(PolygonAnnotationInteractionContext(
+      await longPressCompleter.future;
+      expect(longPressCompleter.isCompleted, isTrue);
+      expect(isCanceled, isFalse);
+
+      token.cancel();
+      eventSink.success(PolygonAnnotationInteractionContext(
+        annotation: createdAnnotation,
+        gestureState: GestureState.ended,
+      ));
+      expect(isCanceled, isTrue);
+
+      eventSink.endOfStream();
+    });
+
+    testWidgets('annotation drag events can be listened and canceled',
+        (tester) async {
+      await setupMap(tester, 'drag');
+
+      final dragBegin = Completer();
+      final dragChanged = Completer();
+      final dragEnd = Completer();
+      late MockStreamHandlerEventSink eventSink;
+      var isCanceled = false;
+
+      IntegrationTestWidgetsFlutterBinding.instance.defaultBinaryMessenger
+          .setMockStreamHandler(
+              eventChannel,
+              MockStreamHandler.inline(
+                onListen: (arguments, events) {
+                  eventSink = events;
+                },
+                onCancel: (arguments) {
+                  isCanceled = true;
+                },
+              ));
+
+      final token = manager.dragEvents(
+        onBegin: (annotation) {
+          if (isCanceled) {
+            fail('This test should be canceled and not called.');
+          } else {
+            expect(annotation.id, equals(createdAnnotation.id));
+            dragBegin.complete();
+          }
+        },
+        onChanged: (annotation) {
+          if (isCanceled) {
+            fail('This test should be canceled and not called.');
+          } else {
+            expect(annotation.id, equals(createdAnnotation.id));
+            dragChanged.complete();
+          }
+        },
+        onEnd: (annotation) {
+          if (isCanceled) {
+            fail('This test should be canceled and not called.');
+          } else {
+            expect(annotation.id, equals(createdAnnotation.id));
+            dragEnd.complete();
+          }
+        },
+      );
+
+      eventSink.success(PolygonAnnotationInteractionContext(
         annotation: createdAnnotation,
         gestureState: GestureState.started,
       ));
-      events.success(PolygonAnnotationInteractionContext(
+      eventSink.success(PolygonAnnotationInteractionContext(
         annotation: createdAnnotation,
         gestureState: GestureState.changed,
       ));
-      events.success(PolygonAnnotationInteractionContext(
+      eventSink.success(PolygonAnnotationInteractionContext(
         annotation: createdAnnotation,
         gestureState: GestureState.ended,
       ));
-      events.endOfStream();
-    }));
 
-    final onDragBegin = Completer();
-    final onDragChanged = Completer();
-    final onDragEnd = Completer();
+      await Future.wait([dragBegin.future, dragChanged.future, dragEnd.future]);
+      expect(
+          [dragBegin.isCompleted, dragChanged.isCompleted, dragEnd.isCompleted],
+          everyElement(isTrue));
+      expect(isCanceled, isFalse);
 
-    manager.dragEvents(
-      onBegin: (annotation) {
-        expect(annotation.id, equals(createdAnnotation.id));
-        onDragBegin.complete();
-      },
-      onChanged: (annotation) {
-        expect(annotation.id, equals(createdAnnotation.id));
-        onDragChanged.complete();
-      },
-      onEnd: (annotation) {
-        expect(annotation.id, equals(createdAnnotation.id));
-        onDragEnd.complete();
-      },
-    );
+      token.cancel();
+      eventSink.success(PolygonAnnotationInteractionContext(
+        annotation: createdAnnotation,
+        gestureState: GestureState.started,
+      ));
+      eventSink.success(PolygonAnnotationInteractionContext(
+        annotation: createdAnnotation,
+        gestureState: GestureState.changed,
+      ));
+      eventSink.success(PolygonAnnotationInteractionContext(
+        annotation: createdAnnotation,
+        gestureState: GestureState.ended,
+      ));
+      expect(isCanceled, isTrue);
 
-    await Future.wait(
-        [onDragBegin.future, onDragChanged.future, onDragEnd.future]);
+      eventSink.endOfStream();
+    });
   });
 }
 // End of generated file.

--- a/example/integration_test/style/style_test.dart
+++ b/example/integration_test/style/style_test.dart
@@ -766,7 +766,8 @@ void main() {
     expect(styleImports.length, 2);
   });
 
-  testWidgets('Match expression with concat type mismatch', (WidgetTester tester) async {
+  testWidgets('Match expression with concat type mismatch',
+      (WidgetTester tester) async {
     final mapFuture = app.main();
     await tester.pumpAndSettle();
     final mapboxMap = await mapFuture;
@@ -778,10 +779,7 @@ void main() {
       "features": [
         {
           "type": "Feature",
-          "properties": {
-            "testProperty": 123,
-            "testProperty2": 456
-          },
+          "properties": {"testProperty": 123, "testProperty2": 456},
           "geometry": {
             "type": "Point",
             "coordinates": [20, 60]
@@ -790,19 +788,22 @@ void main() {
       ]
     };
 
-    var source = {
-      "type": "geojson",
-      "data": geoJsonData
-    };
+    var source = {"type": "geojson", "data": geoJsonData};
 
     await style.addStyleSource('test-source', json.encode(source));
 
     var matchExpression = [
       "match",
-      ["concat", ["get", "testProperty"], ["get", "testProperty2"]],
-      "123456", "red",      
-      "5234534", "green",  
-      "yellow"              
+      [
+        "concat",
+        ["get", "testProperty"],
+        ["get", "testProperty2"]
+      ],
+      "123456",
+      "red",
+      "5234534",
+      "green",
+      "yellow"
     ];
 
     // Create the layer without the expression
@@ -818,19 +819,21 @@ void main() {
 
     // Then set the expression using setStyleLayerProperty
     // This now works on both iOS and Android after the fix
-    await style.setStyleLayerProperty("test-layer", "circle-color", matchExpression);
-    
+    await style.setStyleLayerProperty(
+        "test-layer", "circle-color", matchExpression);
+
     // Verify that the expression was set correctly
-    var retrievedProperty = await style.getStyleLayerProperty("test-layer", "circle-color");
-    
+    var retrievedProperty =
+        await style.getStyleLayerProperty("test-layer", "circle-color");
+
     var retrievedExpression = retrievedProperty.value as List;
-    expect(retrievedExpression[0], "match");  
-    expect(retrievedExpression[1], matchExpression[1]);  
-    expect(retrievedExpression[2], "123456"); 
-    expect(retrievedExpression[3], ['rgba', 255.0, 0.0, 0.0, 1.0]);  
-    expect(retrievedExpression[4], "5234534"); 
-    expect(retrievedExpression[5], ['rgba', 0.0, 128.0, 0.0, 1.0]); 
-    expect(retrievedExpression[6], ['rgba', 255.0, 255.0, 0.0, 1.0]);  
+    expect(retrievedExpression[0], "match");
+    expect(retrievedExpression[1], matchExpression[1]);
+    expect(retrievedExpression[2], "123456");
+    expect(retrievedExpression[3], ['rgba', 255.0, 0.0, 0.0, 1.0]);
+    expect(retrievedExpression[4], "5234534");
+    expect(retrievedExpression[5], ['rgba', 0.0, 128.0, 0.0, 1.0]);
+    expect(retrievedExpression[6], ['rgba', 255.0, 255.0, 0.0, 1.0]);
   });
 }
 

--- a/example/lib/animated_route_example.dart
+++ b/example/lib/animated_route_example.dart
@@ -61,7 +61,8 @@ class AnimatedRouteExampleState extends State<AnimatedRouteExample>
     setLocationComponent();
     refreshTrackLocation();
     refreshCarAnnotations();
-    mapboxMap.style.setStyleImportConfigProperty("basemap", "theme", "monochrome");
+    mapboxMap.style
+        .setStyleImportConfigProperty("basemap", "theme", "monochrome");
   }
 
   @override

--- a/example/lib/circle_annotations_example.dart
+++ b/example/lib/circle_annotations_example.dart
@@ -21,6 +21,7 @@ class CircleAnnotationExampleState extends State<CircleAnnotationExample> {
   MapboxMap? mapboxMap;
   CircleAnnotation? circleAnnotation;
   CircleAnnotationManager? circleAnnotationManager;
+  Cancelable? tapListener;
   int styleIndex = 1;
 
   _onMapCreated(MapboxMap mapboxMap) {
@@ -41,7 +42,7 @@ class CircleAnnotationExampleState extends State<CircleAnnotationExample> {
         ));
       }
       circleAnnotationManager?.createMulti(options);
-      circleAnnotationManager?.tapEvents(onTap: (annotation) {
+      tapListener = circleAnnotationManager?.tapEvents(onTap: (annotation) {
         // ignore: avoid_print
         print("onAnnotationClick, id: ${annotation.id}");
       });
@@ -124,15 +125,34 @@ class CircleAnnotationExampleState extends State<CircleAnnotationExample> {
     );
   }
 
+  Widget _stopTapListener() {
+    return TextButton(
+      child: Text('stop tap listener'),
+      onPressed: () {
+        tapListener?.cancel();
+        tapListener = null;
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
-    final MapWidget mapWidget =
-        MapWidget(key: ValueKey("mapWidget"), onMapCreated: _onMapCreated);
+    final MapWidget mapWidget = MapWidget(
+      key: ValueKey("mapWidget"),
+      onMapCreated: _onMapCreated,
+      onTapListener: (context) => print("on map tap"),
+    );
 
     final List<Widget> listViewChildren = <Widget>[];
 
     listViewChildren.addAll(
-      <Widget>[_create(), _update(), _delete(), _deleteAll()],
+      <Widget>[
+        _create(),
+        _update(),
+        _delete(),
+        _deleteAll(),
+        _stopTapListener()
+      ],
     );
 
     final colmn = Column(

--- a/example/lib/full_map_example.dart
+++ b/example/lib/full_map_example.dart
@@ -20,7 +20,8 @@ class FullMapExampleState extends State<FullMapExample> {
 
   _onMapCreated(MapboxMap mapboxMap) {
     this.mapboxMap = mapboxMap;
-    mapboxMap.style.setStyleImportConfigProperty("basemap", "theme", "monochrome");
+    mapboxMap.style
+        .setStyleImportConfigProperty("basemap", "theme", "monochrome");
   }
 
   _onStyleLoadedCallback(StyleLoadedEventData data) {
@@ -99,9 +100,11 @@ class FullMapExampleState extends State<FullMapExample> {
                       () => isLight = !isLight,
                     );
                     if (isLight) {
-                      mapboxMap?.style.setStyleImportConfigProperty("basemap", "lightPreset", "day");
+                      mapboxMap?.style.setStyleImportConfigProperty(
+                          "basemap", "lightPreset", "day");
                     } else {
-                      mapboxMap?.style.setStyleImportConfigProperty("basemap", "lightPreset", "night");
+                      mapboxMap?.style.setStyleImportConfigProperty(
+                          "basemap", "lightPreset", "night");
                     }
                   }),
               SizedBox(height: 10),

--- a/example/lib/image_source_example.dart
+++ b/example/lib/image_source_example.dart
@@ -23,8 +23,10 @@ class ImageSourceExampleState extends State<ImageSourceExample> {
 
   _onMapCreated(MapboxMap mapboxMap) async {
     this.mapboxMap = mapboxMap;
-    mapboxMap.style.setStyleImportConfigProperty("basemap", "lightPreset", "night");
-    mapboxMap.style.setStyleImportConfigProperty("basemap", "theme", "monochrome");
+    mapboxMap.style
+        .setStyleImportConfigProperty("basemap", "lightPreset", "night");
+    mapboxMap.style
+        .setStyleImportConfigProperty("basemap", "theme", "monochrome");
   }
 
   _onStyleLoaded(StyleLoadedEventData data) async {

--- a/example/lib/offline_map_example.dart
+++ b/example/lib/offline_map_example.dart
@@ -84,7 +84,9 @@ class OfflineMapExampleState extends State<OfflineMapExample> {
           // If you are using a raster tileset you may need to set a different pixelRatio.
           // The default is UIScreen.main.scale on iOS and displayMetrics's density on Android.
           TilesetDescriptorOptions(
-              styleURI: MapboxStyles.STANDARD_SATELLITE, minZoom: 0, maxZoom: 16)
+              styleURI: MapboxStyles.STANDARD_SATELLITE,
+              minZoom: 0,
+              maxZoom: 16)
         ],
         acceptExpired: true,
         networkRestriction: NetworkRestriction.NONE);

--- a/example/lib/snapshotter_example.dart
+++ b/example/lib/snapshotter_example.dart
@@ -40,8 +40,10 @@ class SnapshotterExampleState extends State<SnapshotterExample> {
           pixelRatio: MediaQuery.of(context).devicePixelRatio),
     );
     await _snapshotter?.style.setStyleURI(MapboxStyles.STANDARD);
-    await _snapshotter?.style.setStyleImportConfigProperty("basemap", "theme", "faded");
-    await _snapshotter?.style.setStyleImportConfigProperty("basemap", "lightPreset", "night");
+    await _snapshotter?.style
+        .setStyleImportConfigProperty("basemap", "theme", "faded");
+    await _snapshotter?.style
+        .setStyleImportConfigProperty("basemap", "lightPreset", "night");
   }
 
   _onMapIdle(MapIdleEventData data) async {

--- a/example/lib/vector_tile_source_example.dart
+++ b/example/lib/vector_tile_source_example.dart
@@ -20,22 +20,23 @@ class VectorTileSourceExampleState extends State<VectorTileSourceExample> {
 
   _onMapCreated(MapboxMap mapboxMap) async {
     this.mapboxMap = mapboxMap;
-    mapboxMap.style.setStyleImportConfigProperty("basemap", "lightPreset", "day");
-    mapboxMap.style.setStyleImportConfigProperty("basemap", "theme", "monochrome");
+    mapboxMap.style
+        .setStyleImportConfigProperty("basemap", "lightPreset", "day");
+    mapboxMap.style
+        .setStyleImportConfigProperty("basemap", "theme", "monochrome");
   }
 
   _onStyleLoadedCallback(StyleLoadedEventData data) async {
     await mapboxMap?.style.addSource(VectorSource(
         id: "terrain-data", url: "mapbox://mapbox.mapbox-terrain-v2"));
-    await mapboxMap?.style.addLayer(
-        LineLayer(
-            id: "terrain-data",
-            sourceId: "terrain-data",
-            sourceLayer: "contour",
-            lineJoin: LineJoin.ROUND,
-            lineCap: LineCap.ROUND,
-            lineColor: Colors.red.value,
-            lineWidth: 1.9));
+    await mapboxMap?.style.addLayer(LineLayer(
+        id: "terrain-data",
+        sourceId: "terrain-data",
+        sourceLayer: "contour",
+        lineJoin: LineJoin.ROUND,
+        lineCap: LineCap.ROUND,
+        lineColor: Colors.red.value,
+        lineWidth: 1.9));
   }
 
   @override

--- a/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Annotations/AnnotationController.swift
+++ b/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Annotations/AnnotationController.swift
@@ -19,8 +19,11 @@ private class AnyAnnotationInteractionEventsStreamHandler: AnnotationInteraction
         sink = nil
     }
 
-    func send(event: AnnotationInteractionContext) {
-        sink?.success(event)
+    func send(event: AnnotationInteractionContext) -> Bool {
+        guard let sink else { return false }
+
+        sink.success(event)
+        return true
     }
 
     func send(error: FlutterError) {
@@ -31,9 +34,6 @@ private class AnyAnnotationInteractionEventsStreamHandler: AnnotationInteraction
         sink?.endOfStream()
     }
 }
-
-private class AnnotationTapEventsStreamHandler: AnyAnnotationInteractionEventsStreamHandler {}
-private class AnnotationDragEventsStreamHandler: AnyAnnotationInteractionEventsStreamHandler {}
 
 class AnnotationController {
     private let mapView: MapView

--- a/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Annotations/BaseAnnotationMessenger.swift
+++ b/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Annotations/BaseAnnotationMessenger.swift
@@ -14,22 +14,23 @@ extension PolygonAnnotationManager: AnnotationControllable {}
 class BaseAnnotationMessenger<C: AnnotationControllable> {
     private struct Storage {
         let controller: C
-        let onTap: (AnnotationInteractionContext) -> Void
-        let onDrag: (AnnotationInteractionContext) -> Void
-        let onLongPress: (AnnotationInteractionContext) -> Void
+        let onTap: (AnnotationInteractionContext) -> Bool
+        let onDrag: (AnnotationInteractionContext) -> Bool
+        let onLongPress: (AnnotationInteractionContext) -> Bool
     }
     private var storage: [String: Storage] = [:]
 
-    func tap(_ context: AnnotationInteractionContext, managerId: String) {
-        storage[managerId]?.onTap(context)
+    func tap(_ context: AnnotationInteractionContext, managerId: String) -> Bool {
+        storage[managerId]?.onTap(context) ?? false
     }
 
-    func drag(_ context: AnnotationInteractionContext, managerId: String) {
-        storage[managerId]?.onDrag(context)
+    @discardableResult
+    func drag(_ context: AnnotationInteractionContext, managerId: String) -> Bool {
+        storage[managerId]?.onDrag(context) ?? false
     }
 
-    func longPress(_ context: AnnotationInteractionContext, managerId: String) {
-        storage[managerId]?.onLongPress(context)
+    func longPress(_ context: AnnotationInteractionContext, managerId: String) -> Bool {
+        storage[managerId]?.onLongPress(context) ?? false
     }
 
     private subscript(id: String) -> C? {
@@ -38,9 +39,9 @@ class BaseAnnotationMessenger<C: AnnotationControllable> {
 
     func add(
         controller: C,
-        onTap: @escaping (AnnotationInteractionContext) -> Void,
-        onDrag: @escaping (AnnotationInteractionContext) -> Void,
-        onLongPress: @escaping (AnnotationInteractionContext) -> Void
+        onTap: @escaping (AnnotationInteractionContext) -> Bool,
+        onDrag: @escaping (AnnotationInteractionContext) -> Bool,
+        onLongPress: @escaping (AnnotationInteractionContext) -> Bool
     ) {
         storage[controller.id] = Storage(controller: controller, onTap: onTap, onDrag: onDrag, onLongPress: onLongPress)
     }

--- a/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Annotations/CircleAnnotationController.swift
+++ b/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Annotations/CircleAnnotationController.swift
@@ -24,25 +24,25 @@ final class CircleAnnotationController: BaseAnnotationMessenger<CircleAnnotation
             let annotations = annotationOptions.map({ options in
                 var annotation = options.toCircleAnnotation()
                 annotation.tapHandler = { [weak self] (context) in
+                    guard let self else { return false }
                     let context = CircleAnnotationInteractionContext(
                         annotation: annotation.toFLTCircleAnnotation(),
                         gestureState: .ended)
-                    self?.tap(context, managerId: managerId)
-                    return true
+                    return self.tap(context, managerId: managerId)
                 }
                 annotation.longPressHandler = { [weak self] (context) in
+                    guard let self else { return false }
                     let context = CircleAnnotationInteractionContext(
                         annotation: annotation.toFLTCircleAnnotation(),
                         gestureState: .ended)
-                    self?.longPress(context, managerId: managerId)
-                    return true
+                    return self.longPress(context, managerId: managerId)
                 }
                 annotation.dragBeginHandler = { [weak self] (annotation, context) in
+                    guard let self else { return false }
                     let context = CircleAnnotationInteractionContext(
                         annotation: annotation.toFLTCircleAnnotation(),
                         gestureState: .started)
-                    self?.drag(context, managerId: managerId)
-                    return true
+                    return self.drag(context, managerId: managerId)
                 }
                 annotation.dragChangeHandler = { [weak self] (annotation, context) in
                     let context = CircleAnnotationInteractionContext(

--- a/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Annotations/PointAnnotationController.swift
+++ b/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Annotations/PointAnnotationController.swift
@@ -24,25 +24,25 @@ final class PointAnnotationController: BaseAnnotationMessenger<PointAnnotationMa
             let annotations = annotationOptions.map({ options in
                 var annotation = options.toPointAnnotation()
                 annotation.tapHandler = { [weak self] (context) in
+                    guard let self else { return false }
                     let context = PointAnnotationInteractionContext(
                         annotation: annotation.toFLTPointAnnotation(),
                         gestureState: .ended)
-                    self?.tap(context, managerId: managerId)
-                    return true
+                    return self.tap(context, managerId: managerId)
                 }
                 annotation.longPressHandler = { [weak self] (context) in
+                    guard let self else { return false }
                     let context = PointAnnotationInteractionContext(
                         annotation: annotation.toFLTPointAnnotation(),
                         gestureState: .ended)
-                    self?.longPress(context, managerId: managerId)
-                    return true
+                    return self.longPress(context, managerId: managerId)
                 }
                 annotation.dragBeginHandler = { [weak self] (annotation, context) in
+                    guard let self else { return false }
                     let context = PointAnnotationInteractionContext(
                         annotation: annotation.toFLTPointAnnotation(),
                         gestureState: .started)
-                    self?.drag(context, managerId: managerId)
-                    return true
+                    return self.drag(context, managerId: managerId)
                 }
                 annotation.dragChangeHandler = { [weak self] (annotation, context) in
                     let context = PointAnnotationInteractionContext(

--- a/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Annotations/PolygonAnnotationController.swift
+++ b/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Annotations/PolygonAnnotationController.swift
@@ -24,25 +24,25 @@ final class PolygonAnnotationController: BaseAnnotationMessenger<PolygonAnnotati
             let annotations = annotationOptions.map({ options in
                 var annotation = options.toPolygonAnnotation()
                 annotation.tapHandler = { [weak self] (context) in
+                    guard let self else { return false }
                     let context = PolygonAnnotationInteractionContext(
                         annotation: annotation.toFLTPolygonAnnotation(),
                         gestureState: .ended)
-                    self?.tap(context, managerId: managerId)
-                    return true
+                    return self.tap(context, managerId: managerId)
                 }
                 annotation.longPressHandler = { [weak self] (context) in
+                    guard let self else { return false }
                     let context = PolygonAnnotationInteractionContext(
                         annotation: annotation.toFLTPolygonAnnotation(),
                         gestureState: .ended)
-                    self?.longPress(context, managerId: managerId)
-                    return true
+                    return self.longPress(context, managerId: managerId)
                 }
                 annotation.dragBeginHandler = { [weak self] (annotation, context) in
+                    guard let self else { return false }
                     let context = PolygonAnnotationInteractionContext(
                         annotation: annotation.toFLTPolygonAnnotation(),
                         gestureState: .started)
-                    self?.drag(context, managerId: managerId)
-                    return true
+                    return self.drag(context, managerId: managerId)
                 }
                 annotation.dragChangeHandler = { [weak self] (annotation, context) in
                     let context = PolygonAnnotationInteractionContext(

--- a/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Annotations/PolylineAnnotationController.swift
+++ b/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Annotations/PolylineAnnotationController.swift
@@ -24,25 +24,25 @@ final class PolylineAnnotationController: BaseAnnotationMessenger<PolylineAnnota
             let annotations = annotationOptions.map({ options in
                 var annotation = options.toPolylineAnnotation()
                 annotation.tapHandler = { [weak self] (context) in
+                    guard let self else { return false }
                     let context = PolylineAnnotationInteractionContext(
                         annotation: annotation.toFLTPolylineAnnotation(),
                         gestureState: .ended)
-                    self?.tap(context, managerId: managerId)
-                    return true
+                    return self.tap(context, managerId: managerId)
                 }
                 annotation.longPressHandler = { [weak self] (context) in
+                    guard let self else { return false }
                     let context = PolylineAnnotationInteractionContext(
                         annotation: annotation.toFLTPolylineAnnotation(),
                         gestureState: .ended)
-                    self?.longPress(context, managerId: managerId)
-                    return true
+                    return self.longPress(context, managerId: managerId)
                 }
                 annotation.dragBeginHandler = { [weak self] (annotation, context) in
+                    guard let self else { return false }
                     let context = PolylineAnnotationInteractionContext(
                         annotation: annotation.toFLTPolylineAnnotation(),
                         gestureState: .started)
-                    self?.drag(context, managerId: managerId)
-                    return true
+                    return self.drag(context, managerId: managerId)
                 }
                 annotation.dragChangeHandler = { [weak self] (annotation, context) in
                     let context = PolylineAnnotationInteractionContext(


### PR DESCRIPTION
### What does this pull request do?

Fix annotation's gestures listeners prevent map's gestures listeners to be triggered.

### What is the motivation and context behind this change?

Maps Flutter acts as one listener to platform's annotation gestures listener and then broadcasts the events. This means that platform's annotation will always have a listener, and in the callback where Flutter is handling these events, we always return true indicating that the gesture is being handled, this would prevent the map's gestures event to be invoked, even when Maps Flutter annotations does not have an active gesture listener. This PR addresses the issue by telling platform the gesture is not being handled when there is no listener (`sink` is not set)

### Pull request checklist:
 - [ ] Add a changelog entry.
 - [x] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](../CONTRIBUTING.md#contributor-license-agreement).
