### PR TITLE
Merge increase-compile-sdk-to-34 into main - fix compileSdk 36 android build error

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdk 33
+    compileSdk 34
 
     namespace 'com.mapbox.maps.mapbox_maps'
     sourceSets {


### PR DESCRIPTION
What does this pull request do?

This PR updates the compileSdkVersion in the mapbox_maps_flutter Android module from 33 to 34.

What is the motivation and context behind this change?

Recent AndroidX dependencies (e.g., fragment:1.7.x, window:1.2.x, lifecycle:2.7.x, core-ktx:1.13.x) require a minimum compileSdkVersion of 34.
Without this change, builds fail with checkReleaseAarMetadata errors.
By bumping the compile SDK, the plugin can be built successfully alongside the latest stable Flutter and Android toolchains.

Pull request checklist:

 Add a changelog entry.
→ I can add a short note like “Bumped Android compileSdkVersion to 34 to support latest AndroidX dependencies” if maintainers confirm.

 Write tests for all new functionality.
→ No new functionality was introduced; this is a build configuration update only.

 Add documentation comments for any added or updated public APIs.
→ Not applicable, no public API changes.

This PR contains only a minimal build config update necessary to keep the project compiling with the latest AndroidX libraries.



Related to this issue https://github.com/mapbox/mapbox-maps-flutter/issues/1038