### PR TITLE
Workaround for duplicate move motion events on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### main
+
+* Fix multi-touch gestures not working in map widget when being nested in `GestureDetector`.
+
 ### 2.12.0-beta.1
 
 * Use Maps SDK Android dependency with NDK 27 support and [support for 16 KB page sizes](https://developer.android.com/guide/practices/page-sizes).


### PR DESCRIPTION
### What does this pull request do?

When map widget is wrapped in `GestureDetector` - multitouch gestures stops working because Flutter duplicates some motion events during gesture replay after gesture arena contest resolution.

I also created a report in Flutter's team issue tracker https://github.com/flutter/flutter/issues/176574

### What is the motivation and context behind this change?

https://github.com/mapbox/mapbox-maps-flutter/issues/439

### Pull request checklist:
 - [x] Add a changelog entry.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](../CONTRIBUTING.md#contributor-license-agreement).
