### PR TITLE
Workaround for duplicate move motion events on Android (#1041)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.12.0-rc.1
+
+* Fix multi-touch gestures not working in map widget when being nested in `GestureDetector`.
+
 ### 2.12.0-beta.1
 
 * Use Maps SDK Android dependency with NDK 27 support and [support for 16 KB page sizes](https://developer.android.com/guide/practices/page-sizes).


### PR DESCRIPTION
### What does this pull request do?

Backport https://github.com/mapbox/mapbox-maps-flutter/pull/1041 into `release/v2.12`

### What is the motivation and context behind this change?



### Pull request checklist:
 - [x] Add a changelog entry.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](../CONTRIBUTING.md#contributor-license-agreement).
