### PR TITLE
Release v2.12.0-rc.1

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 ## License
 
-Mapbox Maps for Flutter version 2.12.0-beta.1
+Mapbox Maps for Flutter version 2.12.0-rc.1
 Mapbox Maps Flutter SDK
 
 Copyright &copy; 2022 - 2025 Mapbox, Inc. All rights reserved.
@@ -134,7 +134,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ## License
 
-Mapbox Maps for iOS version 11.16.0-beta.1
+Mapbox Maps for iOS version 11.16.0-rc.1
 Mapbox Maps iOS SDK
 
 Copyright &copy; 2021 - 2025 Mapbox, Inc. All rights reserved.
@@ -165,7 +165,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ---
 
-### MapboxCoreMaps,11.16.0-beta.1,Mapbox ToS,Mapbox,https://www.mapbox.com/
+### MapboxCoreMaps,11.16.0-rc.1,Mapbox ToS,Mapbox,https://www.mapbox.com/
 
 ```
 Mapbox Core Maps version 11.0
@@ -1944,7 +1944,7 @@ DEALINGS IN THE SOFTWARE.
 
 ### License
 
-Mapbox Maps for Android version 11.16.0-beta.1
+Mapbox Maps for Android version 11.16.0-rc.1
 Mapbox Maps Android SDK
 
 Copyright &copy; 2021 - 2025 Mapbox, Inc. All rights reserved.
@@ -2426,7 +2426,7 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 
 ===========================================================================
 
-### MapboxCoreMaps,11.16.0-beta.1,Mapbox ToS,Mapbox,https://www.mapbox.com/
+### MapboxCoreMaps,11.16.0-rc.1,Mapbox ToS,Mapbox,https://www.mapbox.com/
 
 ```
 Mapbox Core Maps version 11.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mapbox Maps SDK Flutter SDK
 
-The Mapbox Maps SDK Flutter SDK is an officially developed solution from Mapbox that enables use of our latest Maps SDK product (v11.16.0-beta.1). The SDK allows developers to embed highly-customized maps using a Flutter widget on Android and iOS.
+The Mapbox Maps SDK Flutter SDK is an officially developed solution from Mapbox that enables use of our latest Maps SDK product (v11.16.0-rc.1). The SDK allows developers to embed highly-customized maps using a Flutter widget on Android and iOS.
 
 Web and desktop are not supported.
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -59,7 +59,7 @@ if (file("$rootDir/gradle/ktlint.gradle").exists() && file("$rootDir/gradle/lint
 }
 
 dependencies {
-    implementation "com.mapbox.maps:android-ndk27:11.16.0-beta.1"
+    implementation "com.mapbox.maps:android-ndk27:11.16.0-rc.1"
 
     implementation "androidx.annotation:annotation:1.5.0"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.6.2"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -269,7 +269,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.12.0-beta.1"
+    version: "2.12.0-rc.1"
   matcher:
     dependency: transitive
     description:

--- a/ios/mapbox_maps_flutter.podspec
+++ b/ios/mapbox_maps_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'mapbox_maps_flutter'
-  s.version          = '2.12.0-beta.1'
+  s.version          = '2.12.0-rc.1'
 
   s.summary          = 'Mapbox Maps SDK Flutter Plugin.'
   s.description      = 'An officially developed solution from Mapbox that enables use of our latest Maps SDK product.'
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.dependency 'Flutter'
   s.platform = :ios, '14.0'
 
-  s.dependency 'MapboxMaps', '11.16.0-beta.1'
+  s.dependency 'MapboxMaps', '11.16.0-rc.1'
   s.dependency 'Turf', '4.0.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/ios/mapbox_maps_flutter/Package.resolved
+++ b/ios/mapbox_maps_flutter/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mapbox/mapbox-common-ios.git",
       "state" : {
-        "revision" : "e738083ad5952972393ea5417b58a894caf7a050",
-        "version" : "24.16.0-beta.1"
+        "revision" : "dd8244e650e3389050b91665efd2941d11b93492",
+        "version" : "24.16.0-rc.1"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mapbox/mapbox-core-maps-ios.git",
       "state" : {
-        "revision" : "aa7b723c39c0662a964f992121097873d821dd07",
-        "version" : "11.16.0-beta.1"
+        "revision" : "47117c7bc111c326b9bb601ccd27d597aa8c4070",
+        "version" : "11.16.0-rc.1"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mapbox/mapbox-maps-ios.git",
       "state" : {
-        "revision" : "3280b7f782622802d40773c3f6180818e17961ea",
-        "version" : "11.16.0-beta.1"
+        "revision" : "2818b4e814334b415c48b57d870c1031145be895",
+        "version" : "11.16.0-rc.1"
       }
     },
     {

--- a/ios/mapbox_maps_flutter/Package.swift
+++ b/ios/mapbox_maps_flutter/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "mapbox-maps-flutter", targets: ["mapbox_maps_flutter"])
     ],
     dependencies: [
-        .package(url: "https://github.com/mapbox/mapbox-maps-ios.git", exact: "11.16.0-beta.1"),
+        .package(url: "https://github.com/mapbox/mapbox-maps-ios.git", exact: "11.16.0-rc.1"),
     ],
     targets: [
         .target(

--- a/lib/src/package_info.dart
+++ b/lib/src/package_info.dart
@@ -1,3 +1,3 @@
 part of mapbox_maps_flutter;
 
-const String mapboxPluginVersion = '2.12.0-beta.1';
+const String mapboxPluginVersion = '2.12.0-rc.1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mapbox_maps_flutter
 description: Interactive, thoroughly customizable maps powered by Mapbox Maps mobile SDKs.
-version: 2.12.0-beta.1
+version: 2.12.0-rc.1
 homepage: https://github.com/mapbox/mapbox-maps-flutter
 
 environment:


### PR DESCRIPTION
- Bump Maps SDK version to v11.16.0-rc.1 (iOS and Android)
