### PR TITLE
Add custom colorized vector icons examples for Flutter

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -4,7 +4,7 @@ import 'package:mapbox_maps_example/animation_example.dart';
 import 'package:mapbox_maps_example/camera_example.dart';
 import 'package:mapbox_maps_example/circle_annotations_example.dart';
 import 'package:mapbox_maps_example/cluster_example.dart';
-import 'package:mapbox_maps_example/custom_colorized_vector_icons_example.dart';
+import 'package:mapbox_maps_example/custom_vector_icons_example.dart';
 import 'package:mapbox_maps_example/custom_header_example.dart';
 import 'package:mapbox_maps_example/draggable-annotations-example.dart';
 import 'package:mapbox_maps_example/edit_polygon_example.dart';
@@ -75,7 +75,7 @@ final List<Example> _allPages = <Example>[
   AnimatedRouteExample(),
   CustomHeaderExample(),
   TrafficLayerExample(),
-  CustomColorizedVectorIconsExample(),
+  CustomVectorIconsExample(),
 ];
 
 class MapsDemo extends StatelessWidget {


### PR DESCRIPTION
## Summary
Ports the [custom colorized vector icons example](https://docs.mapbox.com/mapbox-gl-js/example/custom-colorized-vector-icons/) from GL JS to Flutter.

## Implementation
Example demonstrates parameterized vector icons using the `image` expression with color parameters:
- 3 flag icons at Helsinki coordinates with dynamic colors (red, yellow, purple)
- Runtime SVG icon colorization based on GeoJSON feature properties
- Uses custom style: `mapbox://styles/mapbox-map-design/cm4r19bcm00ao01qvhp3jc2gi`

Note: this is a more complex feature, and complete documentation will be added in a central place on docs.mapbox.com. We'll update these examples with a link to that when it is ready. 

<img width="400" height="900" alt="Simulator Screenshot - iPhone 17 Pro - 2025-11-21 at 14 19 45" src="https://github.com/user-attachments/assets/6fbb915e-059f-4728-ac83-42930e04a7d2" />