### PR TITLE
Update iPhone version to iphone16pro, 18.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,7 +208,7 @@ jobs:
           command: |
             gcloud firebase test ios run \
               --test << parameters.workspace-path >>/build_products.zip \
-              --device model=iphone13pro,version=15.7 \
+              --device model=iphone16pro,version=18.3 \
               --timeout 10m \
               --num-flaky-test-attempts 3 \
               --client-details matrixLabel="${CIRCLE_JOB}-${CIRCLE_SHA1:0:6}" 2>&1 | tee firebase_test_lab_run.log


### PR DESCRIPTION
### What does this pull request do?

We were previously `iphone13pro-15.7` for our Firebase tests, but that device was removed (after having been [deprecated](https://firebase.google.com/docs/test-lab/ios/available-testing-devices#deprecated) last year). This means are tests now don't run (see [here](https://github.com/mapbox/mapbox-maps-flutter/pull/1077)). This PR updates our device to iPhone 16 Pro running 18.3. This is the default option, but we could use others if someone has a strong opinion. 

I'll cherry-pick this to the v2.17 release branch after this merges. For any future patch release on an older version we will need to cherry-pick this in. 

### What is the motivation and context behind this change?



### Pull request checklist:
 - [ ] Add a changelog entry.
 - [ ] Write tests for all new functionality. If tests were not written, please explain why.
 - [ ] Add documentation comments for any added or updated public APIs.

PRs must be submitted under the terms of our Contributor License Agreement [CLA](../CONTRIBUTING.md#contributor-license-agreement).
