### PR TITLE
fix(ios): dispatch Dictionary access to main thread in offline controllers

### DIFF
--- a/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Offline/OfflineController.swift
+++ b/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Offline/OfflineController.swift
@@ -32,10 +32,14 @@ final class OfflineController: _OfflineManager {
         offlineManager.loadStylePack(
             for: styleURI,
             loadOptions: loadOptions) { [weak self] progress in
-                self?.progressHandlers[uri]?.eventSink?(progress.toFLTStylePackLoadProgress().toList())
+                DispatchQueue.main.async {
+                    self?.progressHandlers[uri]?.eventSink?(progress.toFLTStylePackLoadProgress().toList())
+                }
             } completion: { [weak self] result in
-                executeOnMainThread(completion)(result.map { $0.toFLTStylePack() })
-                self?.progressHandlers.removeValue(forKey: uri)
+                DispatchQueue.main.async {
+                    completion(result.map { $0.toFLTStylePack() })
+                    self?.progressHandlers.removeValue(forKey: uri)
+                }
             }
     }
 

--- a/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Offline/TileStoreController.swift
+++ b/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/Offline/TileStoreController.swift
@@ -26,11 +26,15 @@ final class TileStoreController: _TileStore {
         }
 
         tileStore.loadTileRegion(forId: id, loadOptions: loadOptions) { [weak self] progress in
-            guard let self else { return }
-            self.tileRegionLoadProgressHandlers[id]?.eventSink?(progress.toFLTTileRegionLoadProgress().toList())
+            DispatchQueue.main.async {
+                guard let self else { return }
+                self.tileRegionLoadProgressHandlers[id]?.eventSink?(progress.toFLTTileRegionLoadProgress().toList())
+            }
         } completion: { [weak self] result in
-            executeOnMainThread(completion)(result.map { $0.toFLTTileRegion() })
-            self?.tileRegionLoadProgressHandlers.removeValue(forKey: id)
+            DispatchQueue.main.async {
+                completion(result.map { $0.toFLTTileRegion() })
+                self?.tileRegionLoadProgressHandlers.removeValue(forKey: id)
+            }
         }
     }
 
@@ -52,11 +56,15 @@ final class TileStoreController: _TileStore {
             forId: id,
             loadOptions: loadOptions,
             estimateOptions: estimateOptions.map(MapboxCommon.TileRegionEstimateOptions.init(fltValue:))) { [weak self] progress in
-                guard let self else { return }
-                self.tileRegionEstimateProgressHandlers[id]?.eventSink?(progress.toFLTTileRegionEstimateProgress().toList())
+                DispatchQueue.main.async {
+                    guard let self else { return }
+                    self.tileRegionEstimateProgressHandlers[id]?.eventSink?(progress.toFLTTileRegionEstimateProgress().toList())
+                }
             } completion: { [weak self] result in
-                executeOnMainThread(completion)(result.map { $0.toFLTTileRegionEstimateResult() })
-                self?.tileRegionEstimateProgressHandlers.removeValue(forKey: id)
+                DispatchQueue.main.async {
+                    completion(result.map { $0.toFLTTileRegionEstimateResult() })
+                    self?.tileRegionEstimateProgressHandlers.removeValue(forKey: id)
+                }
             }
     }
 


### PR DESCRIPTION
## Summary

Fix thread-unsafe `Dictionary` access in `TileStoreController.swift` and `OfflineController.swift` that causes `EXC_BAD_ACCESS (SIGSEGV)` crashes when downloading tile regions or style packs.

Fixes #1116

## Problem

`loadTileRegion`, `estimateTileRegion`, and `loadStylePack` use progress and completion closures that are called on MapboxCommon background threads. Both closures access shared handler dictionaries without synchronization:

- **Progress callbacks**: read from the dictionary on a background thread
- **Completion callbacks**: `removeValue(forKey:)` runs on a background thread (`executeOnMainThread` only wrapped the `completion` call, not the `removeValue` that followed)

Swift's `Dictionary` is not thread-safe for concurrent read+write. When multiple regions/packs have overlapping lifetimes, this causes crashes.

## Fix

Wrap both progress and completion closure bodies in `DispatchQueue.main.async` so all dictionary access is serialized on the main thread. This also ensures Flutter event sink calls happen on the main thread, consistent with Flutter's platform channel contract.

**Files changed:**
- `TileStoreController.swift` - `loadTileRegion` and `estimateTileRegion`
- `OfflineController.swift` - `loadStylePack`

## Crash signatures (from production)

```
// Crash 1 - concurrent read during mutation
Thread 29: specialized __RawDictionaryStorage.find<A>(_:)
           specialized Dictionary.removeValue(forKey:) (TileStoreController.swift:33)

// Crash 2 - CoW uniqueness check on freed backing storage
Thread 23: swift_isUniquelyReferenced_nonNull_native
           specialized Dictionary.removeValue(forKey:) (TileStoreController.swift:33)
```