### PR TITLE
[Feat] viewAnnotations -  create annotations from flutter widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 2.23.0-rc.1
 
+* Add `ViewAnnotationManager` for rendering arbitrary Flutter widgets (or pre-rasterized bitmaps) as native view annotations anchored to geographic coordinates. Create one with `mapboxMap.annotations.createViewAnnotationManager()` and pass a `widget:` into `ViewAnnotationOptions`; widgets are rendered once in an offscreen pipeline and reprojected natively during camera animations.
 * Deprecate `MapWidget.cameraOptions` in favor of the `viewport` API.
 * Deprecate `MapWidget.onTapListener` and `MapWidget.onLongTapListener` in favor of the `MapboxMap.addInteraction` API.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Contributions welcome!
 | Viewport | :white_check_mark: | :white_check_mark: |
 | Style DSL   | :x:                | :x: |
 | Expression DSL   | :x:                | :x: |
-| View Annotations   | :x:                | :x: |
+| View Annotations   | :white_check_mark: | :white_check_mark: |
 
 ## Requirements
 
@@ -212,6 +212,27 @@ To create 5 point annotations using custom icon:
 You can find more examples of the AnnotationManagers usage in the sample app : [point annotations](example/lib/point_annotations.dart), [circle annotations](example/lib/circle_annotations.dart), [polygon annotations](example/lib/polygon_annotations.dart), [polyline annotations](example/lib/polyline_annotations.dart).
 
 1. Use style layers. This will require writing more code but is more flexible and provides better performance for the large amount of annotations (e.g. hundreds and thousands of them). More about adding style layers in the [Map styles section](#map-styles).
+
+### View Annotations (Flutter widgets as markers)
+
+Use the `ViewAnnotationManager` to anchor any Flutter `Widget` to a geographic coordinate. Widgets are rasterized once in an offscreen pipeline and handed to the platform's native view annotation manager (Android `viewAnnotationManager`, iOS `mapView.viewAnnotations`), so they reproject natively during camera animations without re-rendering.
+
+```dart
+final manager = await mapboxMap.annotations.createViewAnnotationManager();
+
+final pin = await manager.create(ViewAnnotationOptions(
+  geometry: Point(coordinates: Position(2.349, 48.864)),
+  widget: const _PricePin(label: '€129'),
+  anchor: ViewAnnotationAnchor.BOTTOM,
+  offsetY: -4,
+));
+
+manager.tapEvents.listen((event) {
+  debugPrint('Tapped ${event.annotationId}');
+});
+```
+
+Pass `image: Uint8List` instead of `widget:` to supply pre-rasterized bytes directly. A full example lives at [view_annotation_example.dart](example/lib/view_annotation_example.dart).
 
 ## Map styles
 Additional information is available in our [Flutter](https://docs.mapbox.com/flutter/maps/guides/styles/), [Android](https://docs.mapbox.com/android/maps/guides/styles/), and [iOS](https://docs.mapbox.com/ios/maps/guides/styles/) documentation.

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/MapboxMapController.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/MapboxMapController.kt
@@ -20,6 +20,7 @@ import com.mapbox.maps.MapView
 import com.mapbox.maps.MapboxMap
 import com.mapbox.maps.mapbox_maps.annotation.AnnotationController
 import com.mapbox.maps.mapbox_maps.http.CustomHttpServiceInterceptor
+import com.mapbox.maps.mapbox_maps.viewannotation.ViewAnnotationController
 import com.mapbox.maps.mapbox_maps.pigeons.AttributionSettingsInterface
 import com.mapbox.maps.mapbox_maps.pigeons.CompassSettingsInterface
 import com.mapbox.maps.mapbox_maps.pigeons.GesturesSettingsInterface
@@ -117,6 +118,7 @@ class MapboxMapController(
   private val mapInterfaceController: MapInterfaceController
   private val animationController: AnimationController
   private val annotationController: AnnotationController
+  private val viewAnnotationController: ViewAnnotationController
   private val locationComponentController: LocationComponentController
   private val gestureController: GestureController
   private val interactionsController: InteractionsController
@@ -204,6 +206,7 @@ class MapboxMapController(
     mapInterfaceController = MapInterfaceController(mapboxMap, mapView, context)
     animationController = AnimationController(mapboxMap, context)
     annotationController = AnnotationController(mapView, messenger, this.channelSuffix)
+    viewAnnotationController = ViewAnnotationController(mapView, messenger, this.channelSuffix)
     locationComponentController = LocationComponentController(mapView, context)
     gestureController = GestureController(mapView, context)
     interactionsController = InteractionsController(mapboxMap, context)
@@ -297,6 +300,7 @@ class MapboxMapController(
     _MapInterface.setUp(messenger, null, channelSuffix)
     _AnimationManager.setUp(messenger, null, channelSuffix)
     annotationController.dispose()
+    viewAnnotationController.dispose()
     _LocationComponentSettingsInterface.setUp(messenger, null, channelSuffix)
     LogoSettingsInterface.setUp(messenger, null, channelSuffix)
     GesturesSettingsInterface.setUp(messenger, null, channelSuffix)
@@ -317,6 +321,9 @@ class MapboxMapController(
       }
       "annotation#remove_manager" -> {
         annotationController.handleRemoveManager(call, result)
+      }
+      "view_annotation#create_manager" -> {
+        viewAnnotationController.handleCreateManager(call, result)
       }
       "gesture#add_listeners" -> {
         gestureController.addListeners(messenger, channelSuffix)

--- a/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/viewannotation/ViewAnnotationController.kt
+++ b/android/src/main/kotlin/com/mapbox/maps/mapbox_maps/viewannotation/ViewAnnotationController.kt
@@ -1,0 +1,236 @@
+package com.mapbox.maps.mapbox_maps.viewannotation
+
+import android.graphics.BitmapFactory
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import com.mapbox.geojson.Point
+import com.mapbox.maps.MapView
+import com.mapbox.maps.ViewAnnotationAnchor
+import com.mapbox.maps.viewannotation.annotationAnchor
+import com.mapbox.maps.viewannotation.geometry
+import com.mapbox.maps.viewannotation.viewAnnotationOptions
+import io.flutter.plugin.common.BinaryMessenger
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugin.common.StandardMethodCodec
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Owns all [ViewAnnotationManager] instances attached to this map.
+ *
+ * Call sites are:
+ *  1. [handleCreateManager] from [MapboxMapController.onMethodCall] for the
+ *     `view_annotation#create_manager` method.
+ *  2. Per-manager [MethodChannel]s set up inside [ManagerHandle] for
+ *     `create` / `update` / `delete` / `deleteAll` / `dispose`.
+ *
+ * We keep one `MethodChannel` per manager so messages do not have to be
+ * demuxed through a shared channel and the clean-up path is trivial
+ * (disposing the manager also releases its channel).
+ */
+internal class ViewAnnotationController(
+  private val mapView: MapView,
+  private val messenger: BinaryMessenger,
+  private val channelSuffix: String,
+) {
+
+  private val managers = mutableMapOf<String, ManagerHandle>()
+  private val managerAutoId = AtomicInteger(0)
+
+  fun handleCreateManager(call: MethodCall, result: MethodChannel.Result) {
+    val requestedId = call.argument<String>("id")
+    val resolvedId = requestedId
+      ?: "view_annotation_manager_${managerAutoId.incrementAndGet()}"
+
+    if (managers.containsKey(resolvedId)) {
+      // Manager with this id already exists; reuse it.
+      result.success(resolvedId)
+      return
+    }
+
+    managers[resolvedId] = ManagerHandle(
+      managerId = resolvedId,
+      channel = MethodChannel(
+        messenger,
+        "plugins.flutter.io.mapbox_maps.view_annotations.$channelSuffix.$resolvedId",
+        StandardMethodCodec.INSTANCE,
+      ),
+    )
+    result.success(resolvedId)
+  }
+
+  fun dispose() {
+    managers.values.toList().forEach { it.dispose() }
+    managers.clear()
+  }
+
+  private inner class ManagerHandle(
+    val managerId: String,
+    val channel: MethodChannel,
+  ) : MethodChannel.MethodCallHandler {
+
+    private val annotations = linkedMapOf<String, NativeViewAnnotation>()
+
+    init {
+      channel.setMethodCallHandler(this)
+    }
+
+    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
+      when (call.method) {
+        "create" -> handleUpsert(call, result, isCreate = true)
+        "update" -> handleUpsert(call, result, isCreate = false)
+        "delete" -> handleDelete(call, result)
+        "deleteAll" -> {
+          clearAll()
+          result.success(null)
+        }
+        "dispose" -> {
+          dispose()
+          managers.remove(managerId)
+          result.success(null)
+        }
+        else -> result.notImplemented()
+      }
+    }
+
+    fun dispose() {
+      clearAll()
+      channel.setMethodCallHandler(null)
+    }
+
+    private fun clearAll() {
+      val ids = annotations.keys.toList()
+      ids.forEach(::remove)
+    }
+
+    private fun handleDelete(call: MethodCall, result: MethodChannel.Result) {
+      val id = call.argument<String>("id")
+      if (id == null) {
+        result.error("INVALID_ARGUMENTS", "delete requires an id.", null)
+        return
+      }
+      remove(id)
+      result.success(null)
+    }
+
+    private fun handleUpsert(
+      call: MethodCall,
+      result: MethodChannel.Result,
+      isCreate: Boolean,
+    ) {
+      val args = call.arguments as? Map<*, *>
+      if (args == null) {
+        result.error("INVALID_ARGUMENTS", "Missing arguments map.", null)
+        return
+      }
+
+      val id = args["id"] as? String
+      if (id == null) {
+        result.error("INVALID_ARGUMENTS", "Missing annotation id.", null)
+        return
+      }
+
+      val bitmapBytes = args["image"] as? ByteArray
+      if (bitmapBytes == null) {
+        result.error("INVALID_ARGUMENTS", "Missing image bytes.", null)
+        return
+      }
+      val bitmap = BitmapFactory.decodeByteArray(bitmapBytes, 0, bitmapBytes.size)
+      if (bitmap == null) {
+        result.error("INVALID_ARGUMENTS", "Unable to decode annotation image.", null)
+        return
+      }
+
+      val coordinates = args["coordinates"] as? List<*>
+      if (coordinates == null || coordinates.size < 2) {
+        result.error("INVALID_ARGUMENTS", "Missing or malformed coordinates.", null)
+        return
+      }
+      val longitude = (coordinates[0] as? Number)?.toDouble()
+      val latitude = (coordinates[1] as? Number)?.toDouble()
+      if (longitude == null || latitude == null) {
+        result.error("INVALID_ARGUMENTS", "coordinates must be numeric.", null)
+        return
+      }
+
+      val width = ((args["width"] as? Number)?.toDouble() ?: bitmap.width.toDouble()).toInt()
+      val height = ((args["height"] as? Number)?.toDouble() ?: bitmap.height.toDouble()).toInt()
+      val visible = (args["visible"] as? Boolean) ?: true
+      val allowOverlap = (args["allowOverlap"] as? Boolean) ?: true
+      val offsetX = (args["offsetX"] as? Number)?.toDouble() ?: 0.0
+      val offsetY = (args["offsetY"] as? Number)?.toDouble() ?: 0.0
+      val anchor = decodeAnchor((args["anchor"] as? Number)?.toInt())
+
+      val existing = annotations[id]
+      if (existing == null && !isCreate) {
+        result.error("NOT_FOUND", "No view annotation with id=$id.", null)
+        return
+      }
+
+      val options = viewAnnotationOptions {
+        geometry(Point.fromLngLat(longitude, latitude))
+        width(width.toDouble())
+        height(height.toDouble())
+        visible(visible)
+        allowOverlap(allowOverlap)
+        annotationAnchor {
+          anchor(anchor)
+          offsetX(offsetX)
+          offsetY(offsetY)
+        }
+      }
+
+      if (existing == null) {
+        val imageView = ImageView(mapView.context).apply {
+          scaleType = ImageView.ScaleType.FIT_XY
+          layoutParams = ViewGroup.LayoutParams(width, height)
+          setImageBitmap(bitmap)
+          isClickable = true
+          setOnClickListener { dispatchTap(id) }
+        }
+        mapView.viewAnnotationManager.addViewAnnotation(imageView, options)
+        annotations[id] = NativeViewAnnotation(view = imageView)
+      } else {
+        existing.view.setImageBitmap(bitmap)
+        existing.view.layoutParams = (existing.view.layoutParams ?: ViewGroup.LayoutParams(width, height)).also {
+          it.width = width
+          it.height = height
+        }
+        existing.view.visibility = if (visible) View.VISIBLE else View.GONE
+        existing.view.requestLayout()
+        mapView.viewAnnotationManager.updateViewAnnotation(existing.view, options)
+      }
+
+      result.success(null)
+    }
+
+    private fun remove(id: String) {
+      val entry = annotations.remove(id) ?: return
+      mapView.viewAnnotationManager.removeViewAnnotation(entry.view)
+      entry.view.setOnClickListener(null)
+    }
+
+    private fun dispatchTap(annotationId: String) {
+      channel.invokeMethod("onTap", mapOf("id" to annotationId))
+    }
+  }
+
+  private data class NativeViewAnnotation(val view: ImageView)
+
+  private fun decodeAnchor(rawValue: Int?): ViewAnnotationAnchor {
+    // Wire ordinals mirror lib/src/pigeons/map_interfaces.dart::ViewAnnotationAnchor.
+    return when (rawValue) {
+      0 -> ViewAnnotationAnchor.TOP
+      1 -> ViewAnnotationAnchor.LEFT
+      2 -> ViewAnnotationAnchor.BOTTOM
+      3 -> ViewAnnotationAnchor.RIGHT
+      4 -> ViewAnnotationAnchor.TOP_LEFT
+      5 -> ViewAnnotationAnchor.BOTTOM_RIGHT
+      6 -> ViewAnnotationAnchor.TOP_RIGHT
+      7 -> ViewAnnotationAnchor.BOTTOM_LEFT
+      8 -> ViewAnnotationAnchor.CENTER
+      else -> ViewAnnotationAnchor.CENTER
+    }
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -27,6 +27,7 @@ import 'package:mapbox_maps_example/traffic_route_line_example.dart';
 import 'package:mapbox_maps_example/tile_json_example.dart';
 import 'package:mapbox_maps_example/vector_tile_source_example.dart';
 import 'package:mapbox_maps_example/viewport_example.dart';
+import 'package:mapbox_maps_example/view_annotation_example.dart';
 import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
 
 import 'full_map_example.dart';
@@ -65,6 +66,7 @@ final List<Example> _allPages = <Example>[
   PolygonAnnotationExample(),
   DraggableAnnotationExample(),
   EditPolygonExample(),
+  ViewAnnotationExample(),
   VectorTileSourceExample(),
   DrawGeoJsonLineExample(),
   ImageSourceExample(),

--- a/example/lib/view_annotation_example.dart
+++ b/example/lib/view_annotation_example.dart
@@ -1,0 +1,197 @@
+import 'package:flutter/material.dart';
+import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
+
+import 'example.dart';
+
+/// Demonstrates [ViewAnnotationManager] by anchoring three custom Flutter
+/// widgets — a numbered pin, a price bubble, and an interactive avatar — to
+/// geographic coordinates. The widgets are rasterized once on creation and
+/// reprojected natively during camera animations.
+class ViewAnnotationExample extends StatefulWidget implements Example {
+  @override
+  final Widget leading = const Icon(Icons.place_outlined);
+  @override
+  final String title = 'View Annotations (Flutter widgets as markers)';
+  @override
+  final String? subtitle =
+      'Mounts custom widgets as native view annotations on the map.';
+
+  @override
+  State<ViewAnnotationExample> createState() => _ViewAnnotationExampleState();
+}
+
+class _ViewAnnotationExampleState extends State<ViewAnnotationExample> {
+  ViewAnnotationManager? _manager;
+  String? _lastTappedId;
+
+  @override
+  void dispose() {
+    _manager?.dispose();
+    super.dispose();
+  }
+
+  Future<void> _onMapCreated(MapboxMap mapboxMap) async {
+    await mapboxMap.setCamera(CameraOptions(
+      center: Point(coordinates: Position(2.349, 48.864)),
+      zoom: 12,
+    ));
+
+    final manager = await mapboxMap.annotations.createViewAnnotationManager();
+    _manager = manager;
+
+    manager.tapEvents.listen((event) {
+      setState(() => _lastTappedId = event.annotationId);
+    });
+
+    await manager.create(ViewAnnotationOptions(
+      geometry: Point(coordinates: Position(2.349, 48.864)),
+      anchor: ViewAnnotationAnchor.BOTTOM,
+      offsetY: -4,
+      widget: const _NumberedPin(label: '1'),
+    ));
+
+    await manager.create(ViewAnnotationOptions(
+      geometry: Point(coordinates: Position(2.332, 48.872)),
+      anchor: ViewAnnotationAnchor.BOTTOM,
+      offsetY: -4,
+      widget: const _PriceBubble(label: '€129'),
+    ));
+
+    await manager.create(ViewAnnotationOptions(
+      geometry: Point(coordinates: Position(2.365, 48.857)),
+      anchor: ViewAnnotationAnchor.CENTER,
+      widget: const _Avatar(initials: 'AL'),
+    ));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('View Annotations')),
+      body: Stack(
+        children: [
+          MapWidget(
+            key: const ValueKey('viewAnnotationsMap'),
+            onMapCreated: _onMapCreated,
+          ),
+          if (_lastTappedId != null)
+            Positioned(
+              left: 16,
+              right: 16,
+              bottom: 24,
+              child: Material(
+                elevation: 6,
+                borderRadius: BorderRadius.circular(12),
+                child: Padding(
+                  padding: const EdgeInsets.all(12),
+                  child: Text('Last tapped: $_lastTappedId'),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _NumberedPin extends StatelessWidget {
+  const _NumberedPin({required this.label});
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 40,
+      height: 52,
+      child: Stack(
+        alignment: Alignment.topCenter,
+        children: [
+          Positioned(
+            bottom: 0,
+            child: Container(
+              width: 10,
+              height: 10,
+              decoration: const BoxDecoration(
+                color: Colors.black87,
+                shape: BoxShape.circle,
+              ),
+            ),
+          ),
+          Container(
+            width: 40,
+            height: 40,
+            decoration: BoxDecoration(
+              color: Colors.redAccent,
+              shape: BoxShape.circle,
+              border: Border.all(color: Colors.white, width: 3),
+              boxShadow: const [
+                BoxShadow(color: Colors.black26, blurRadius: 4, offset: Offset(0, 2)),
+              ],
+            ),
+            alignment: Alignment.center,
+            child: Text(
+              label,
+              style: const TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PriceBubble extends StatelessWidget {
+  const _PriceBubble({required this.label});
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: Colors.black26),
+        boxShadow: const [
+          BoxShadow(color: Colors.black26, blurRadius: 6, offset: Offset(0, 2)),
+        ],
+      ),
+      child: Text(
+        label,
+        style: const TextStyle(fontWeight: FontWeight.w600),
+      ),
+    );
+  }
+}
+
+class _Avatar extends StatelessWidget {
+  const _Avatar({required this.initials});
+  final String initials;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 44,
+      height: 44,
+      decoration: BoxDecoration(
+        color: Colors.indigo,
+        shape: BoxShape.circle,
+        border: Border.all(color: Colors.white, width: 3),
+        boxShadow: const [
+          BoxShadow(color: Colors.black26, blurRadius: 6, offset: Offset(0, 2)),
+        ],
+      ),
+      alignment: Alignment.center,
+      child: Text(
+        initials,
+        style: const TextStyle(
+          color: Colors.white,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+    );
+  }
+}

--- a/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/MapboxMapController.swift
+++ b/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/MapboxMapController.swift
@@ -12,6 +12,7 @@ public final class MapboxMapController: NSObject, FlutterPlatformView {
     private let mapboxMap: MapboxMap
     private let channel: FlutterMethodChannel
     private let annotationController: AnnotationController?
+    private let viewAnnotationController: ViewAnnotationController?
     private let gesturesController: GesturesController?
     private let interactionsController: InteractionsController?
     private let eventHandler: MapboxEventHandler
@@ -89,6 +90,8 @@ public final class MapboxMapController: NSObject, FlutterPlatformView {
         annotationController = AnnotationController(withMapView: mapView, messenger: binaryMessenger)
         annotationController!.setup()
 
+        viewAnnotationController = ViewAnnotationController(mapView: mapView, messenger: binaryMessenger)
+
         let viewportController = ViewportController(
             viewportManager: mapView.viewport,
             cameraManager: mapView.camera,
@@ -124,6 +127,8 @@ public final class MapboxMapController: NSObject, FlutterPlatformView {
             annotationController!.handleCreateManager(methodCall: methodCall, result: result)
         case "annotation#remove_manager":
             annotationController!.handleRemoveManager(methodCall: methodCall, result: result)
+        case "view_annotation#create_manager":
+            viewAnnotationController!.handleCreateManager(methodCall: methodCall, result: result)
         case "gesture#add_listeners":
             gesturesController!.addListeners(messenger: binaryMessenger)
             result(nil)
@@ -194,6 +199,7 @@ public final class MapboxMapController: NSObject, FlutterPlatformView {
         ScaleBarSettingsInterfaceSetup.setUp(binaryMessenger: binaryMessenger.messenger, api: nil, messageChannelSuffix: binaryMessenger.suffix)
         IndoorSelectorSettingsInterfaceSetup.setUp(binaryMessenger: binaryMessenger.messenger, api: nil, messageChannelSuffix: binaryMessenger.suffix)
         annotationController?.tearDown()
+        viewAnnotationController?.tearDown()
         _ViewportMessengerSetup.setUp(binaryMessenger: binaryMessenger.messenger, api: nil, messageChannelSuffix: binaryMessenger.suffix)
         _PerformanceStatisticsApiSetup.setUp(binaryMessenger: binaryMessenger.messenger, api: nil, messageChannelSuffix: binaryMessenger.suffix)
     }

--- a/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/ViewAnnotations/ViewAnnotationController.swift
+++ b/ios/mapbox_maps_flutter/Sources/mapbox_maps_flutter/Classes/ViewAnnotations/ViewAnnotationController.swift
@@ -1,0 +1,234 @@
+import Flutter
+@_spi(Experimental) import MapboxMaps
+import UIKit
+import CoreLocation
+
+/// Owns all `ViewAnnotationManager` instances attached to a single map.
+///
+/// Mirrors the Android controller: one top-level Swift instance handles the
+/// `view_annotation#create_manager` method, and each resolved manager gets its
+/// own `FlutterMethodChannel` for per-annotation operations
+/// (`create`, `update`, `delete`, `deleteAll`, `dispose`).
+final class ViewAnnotationController: NSObject {
+    private let mapView: MapView
+    private let messenger: SuffixBinaryMessenger
+    private var managers: [String: ManagerHandle] = [:]
+    private var autoManagerId = 0
+
+    init(mapView: MapView, messenger: SuffixBinaryMessenger) {
+        self.mapView = mapView
+        self.messenger = messenger
+        super.init()
+    }
+
+    func handleCreateManager(methodCall: FlutterMethodCall, result: @escaping FlutterResult) {
+        let args = methodCall.arguments as? [String: Any]
+        let requestedId = args?["id"] as? String
+        let resolvedId: String
+        if let requestedId = requestedId {
+            resolvedId = requestedId
+        } else {
+            autoManagerId += 1
+            resolvedId = "view_annotation_manager_\(autoManagerId)"
+        }
+
+        if managers[resolvedId] != nil {
+            result(resolvedId)
+            return
+        }
+
+        let channel = FlutterMethodChannel(
+            name: "plugins.flutter.io.mapbox_maps.view_annotations.\(messenger.suffix).\(resolvedId)",
+            binaryMessenger: messenger.messenger
+        )
+        let handle = ManagerHandle(managerId: resolvedId, mapView: mapView, channel: channel)
+        handle.onDisposed = { [weak self] id in
+            self?.managers.removeValue(forKey: id)
+        }
+        managers[resolvedId] = handle
+        result(resolvedId)
+    }
+
+    func tearDown() {
+        for handle in managers.values {
+            handle.tearDown()
+        }
+        managers.removeAll()
+    }
+}
+
+private final class InteractiveImageView: UIImageView {
+    var annotationId: String?
+    weak var host: ManagerHandle?
+
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesEnded(touches, with: event)
+        if let id = annotationId {
+            host?.dispatchTap(annotationId: id)
+        }
+    }
+}
+
+final class ManagerHandle: NSObject {
+    private let managerId: String
+    private let mapView: MapView
+    private let channel: FlutterMethodChannel
+    private var annotations: [String: ViewAnnotation] = [:]
+    private var views: [String: InteractiveImageView] = [:]
+    var onDisposed: ((String) -> Void)?
+
+    init(managerId: String, mapView: MapView, channel: FlutterMethodChannel) {
+        self.managerId = managerId
+        self.mapView = mapView
+        self.channel = channel
+        super.init()
+        channel.setMethodCallHandler { [weak self] call, result in
+            self?.onMethodCall(methodCall: call, result: result)
+        }
+    }
+
+    func tearDown() {
+        clearAll()
+        channel.setMethodCallHandler(nil)
+    }
+
+    fileprivate func dispatchTap(annotationId: String) {
+        channel.invokeMethod("onTap", arguments: ["id": annotationId])
+    }
+
+    private func onMethodCall(methodCall: FlutterMethodCall, result: @escaping FlutterResult) {
+        switch methodCall.method {
+        case "create":
+            handleUpsert(methodCall: methodCall, result: result, isCreate: true)
+        case "update":
+            handleUpsert(methodCall: methodCall, result: result, isCreate: false)
+        case "delete":
+            handleDelete(methodCall: methodCall, result: result)
+        case "deleteAll":
+            clearAll()
+            result(nil)
+        case "dispose":
+            tearDown()
+            onDisposed?(managerId)
+            result(nil)
+        default:
+            result(FlutterMethodNotImplemented)
+        }
+    }
+
+    private func handleDelete(methodCall: FlutterMethodCall, result: @escaping FlutterResult) {
+        guard let args = methodCall.arguments as? [String: Any],
+              let id = args["id"] as? String else {
+            result(FlutterError(code: "INVALID_ARGUMENTS", message: "delete requires an id.", details: nil))
+            return
+        }
+        remove(id: id)
+        result(nil)
+    }
+
+    private func handleUpsert(methodCall: FlutterMethodCall, result: @escaping FlutterResult, isCreate: Bool) {
+        guard let args = methodCall.arguments as? [String: Any] else {
+            result(FlutterError(code: "INVALID_ARGUMENTS", message: "Missing arguments map.", details: nil))
+            return
+        }
+        guard let id = args["id"] as? String else {
+            result(FlutterError(code: "INVALID_ARGUMENTS", message: "Missing annotation id.", details: nil))
+            return
+        }
+
+        let imageData: Data
+        if let typed = args["image"] as? FlutterStandardTypedData {
+            imageData = typed.data
+        } else if let raw = args["image"] as? Data {
+            imageData = raw
+        } else {
+            result(FlutterError(code: "INVALID_ARGUMENTS", message: "Missing image bytes.", details: nil))
+            return
+        }
+        guard let image = UIImage(data: imageData) else {
+            result(FlutterError(code: "INVALID_ARGUMENTS", message: "Unable to decode annotation image.", details: nil))
+            return
+        }
+
+        guard let coordinates = args["coordinates"] as? [NSNumber], coordinates.count >= 2 else {
+            result(FlutterError(code: "INVALID_ARGUMENTS", message: "Missing or malformed coordinates.", details: nil))
+            return
+        }
+        let longitude = coordinates[0].doubleValue
+        let latitude = coordinates[1].doubleValue
+
+        let width = CGFloat((args["width"] as? NSNumber)?.doubleValue ?? Double(image.size.width))
+        let height = CGFloat((args["height"] as? NSNumber)?.doubleValue ?? Double(image.size.height))
+        let visible = (args["visible"] as? NSNumber)?.boolValue ?? true
+        let allowOverlap = (args["allowOverlap"] as? NSNumber)?.boolValue ?? true
+        let offsetX = CGFloat((args["offsetX"] as? NSNumber)?.doubleValue ?? 0)
+        let offsetY = CGFloat((args["offsetY"] as? NSNumber)?.doubleValue ?? 0)
+        let anchor = decodeAnchor((args["anchor"] as? NSNumber)?.intValue ?? 0)
+        let coordinate = CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+
+        if let existingAnnotation = annotations[id], let existingView = views[id] {
+            existingView.image = image
+            existingView.frame = CGRect(origin: .zero, size: CGSize(width: width, height: height))
+            existingAnnotation.annotatedFeature = .geometry(Point(coordinate))
+            existingAnnotation.allowOverlap = allowOverlap
+            existingAnnotation.visible = visible
+            existingAnnotation.variableAnchors = [
+                ViewAnnotationAnchorConfig(anchor: anchor, offsetX: offsetX, offsetY: offsetY)
+            ]
+            existingAnnotation.setNeedsUpdateSize()
+            result(nil)
+            return
+        }
+
+        if !isCreate {
+            result(FlutterError(code: "NOT_FOUND", message: "No view annotation with id=\(id).", details: nil))
+            return
+        }
+
+        let imageView = InteractiveImageView(frame: CGRect(origin: .zero, size: CGSize(width: width, height: height)))
+        imageView.contentMode = .scaleToFill
+        imageView.backgroundColor = .clear
+        imageView.isUserInteractionEnabled = true
+        imageView.image = image
+        imageView.annotationId = id
+        imageView.host = self
+
+        let annotation = ViewAnnotation(coordinate: coordinate, view: imageView)
+        annotation.allowOverlap = allowOverlap
+        annotation.visible = visible
+        annotation.variableAnchors = [
+            ViewAnnotationAnchorConfig(anchor: anchor, offsetX: offsetX, offsetY: offsetY)
+        ]
+        mapView.viewAnnotations.add(annotation)
+        annotations[id] = annotation
+        views[id] = imageView
+        result(nil)
+    }
+
+    private func clearAll() {
+        for id in Array(annotations.keys) {
+            remove(id: id)
+        }
+    }
+
+    private func remove(id: String) {
+        annotations.removeValue(forKey: id)?.remove()
+        views.removeValue(forKey: id)
+    }
+
+    private func decodeAnchor(_ rawValue: Int) -> MapboxMaps.ViewAnnotationAnchor {
+        // Wire ordinals mirror lib/src/pigeons/map_interfaces.dart::ViewAnnotationAnchor.
+        switch rawValue {
+        case 0: return .top
+        case 1: return .left
+        case 2: return .bottom
+        case 3: return .right
+        case 4: return .topLeft
+        case 5: return .bottomRight
+        case 6: return .topRight
+        case 7: return .bottomLeft
+        case 8: return .center
+        default: return .center
+        }
+    }
+}

--- a/lib/mapbox_maps_flutter.dart
+++ b/lib/mapbox_maps_flutter.dart
@@ -3,12 +3,16 @@ library mapbox_maps_flutter;
 import 'dart:async';
 import 'dart:convert';
 import 'dart:developer' as developer;
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+import 'dart:ui' show PlatformDispatcher;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
 import 'package:turf/turf.dart' as turf;
 
@@ -19,6 +23,9 @@ part 'src/annotation/point_annotation_manager.dart';
 part 'src/annotation/polygon_annotation_manager.dart';
 part 'src/annotation/polyline_annotation_manager.dart';
 part 'src/annotation/annotation_manager.dart';
+part 'src/annotation/view_annotation/view_annotation.dart';
+part 'src/annotation/view_annotation/view_annotation_manager.dart';
+part 'src/annotation/view_annotation/widget_rasterizer.dart';
 part 'src/callbacks.dart';
 part 'src/events.dart';
 part 'src/map_widget.dart';

--- a/lib/src/annotation/annotation_manager.dart
+++ b/lib/src/annotation/annotation_manager.dart
@@ -62,6 +62,27 @@ class AnnotationManager {
             channelSuffix: _mapboxMapsPlatform.channelSuffix.toString()));
   }
 
+  /// Create a [ViewAnnotationManager] to add/remove/update [ViewAnnotation]s
+  /// (Flutter widgets anchored to geographic coordinates) rendered as native
+  /// platform views above the map surface.
+  ///
+  /// Unlike layer-based annotation managers, view annotations are rendered
+  /// through the platform's Mapbox `viewAnnotationManager` (Android) or
+  /// `ViewAnnotation` (iOS) APIs, which means they reproject for free during
+  /// camera animations and support arbitrary Flutter widgets through
+  /// [ViewAnnotationOptions.widget].
+  Future<ViewAnnotationManager> createViewAnnotationManager(
+      {String? id}) async {
+    final resolvedId = await _mapboxMapsPlatform.createViewAnnotationManager(
+      id: id,
+    );
+    return ViewAnnotationManager._(
+      id: resolvedId,
+      messenger: _mapboxMapsPlatform.binaryMessenger,
+      channelSuffix: _mapboxMapsPlatform.channelSuffix.toString(),
+    );
+  }
+
   /// Remove an [AnnotationManager] and all the annotations created by it.
   Future<void> removeAnnotationManager(BaseAnnotationManager manager) async {
     return _mapboxMapsPlatform.removeAnnotationManager(manager.id);

--- a/lib/src/annotation/view_annotation/view_annotation.dart
+++ b/lib/src/annotation/view_annotation/view_annotation.dart
@@ -1,0 +1,153 @@
+part of mapbox_maps_flutter;
+
+/// Options used to create or update a [ViewAnnotation] via
+/// [ViewAnnotationManager.create] or [ViewAnnotationManager.update].
+///
+/// A view annotation is a native Android/iOS view anchored to a geographic
+/// coordinate. Unlike symbol-based [PointAnnotation]s, view annotations are
+/// rendered as platform views above the map surface and therefore support
+/// arbitrary Flutter widgets passed through [widget]. The widget is rasterized
+/// once (or whenever its visual contents change) and handed to the platform
+/// as PNG bytes.
+///
+/// The [anchor] value reuses the existing [ViewAnnotationAnchor] enum shared
+/// with the pigeon-generated map surface, so a single anchor concept applies
+/// to both style-layer annotations and view annotations.
+///
+/// If [widget] is omitted, [image] must be supplied with raw PNG/JPEG bytes.
+@immutable
+class ViewAnnotationOptions {
+  /// Creates options backed by a Flutter [widget].
+  ///
+  /// The widget is rendered offscreen at [size] (or a measured intrinsic size
+  /// if omitted) using [pixelRatio] for the platform's DPR, then uploaded to
+  /// the native view annotation manager.
+  const ViewAnnotationOptions({
+    required this.geometry,
+    this.widget,
+    this.image,
+    this.size,
+    this.pixelRatio,
+    this.anchor = ViewAnnotationAnchor.CENTER,
+    this.offsetX = 0,
+    this.offsetY = 0,
+    this.allowOverlap = true,
+    this.visible = true,
+  }) : assert(widget != null || image != null,
+            'Either widget or image must be provided.');
+
+  /// Geographic position that the annotation is anchored to.
+  final Point geometry;
+
+  /// Flutter widget rendered as the annotation's content.
+  ///
+  /// Mutually optional with [image]. If both are provided, [widget] wins and
+  /// [image] is ignored.
+  final Widget? widget;
+
+  /// Pre-rasterized bitmap bytes (PNG, JPEG, or any format decodable by the
+  /// host platform). Use this when the caller already owns a bitmap and does
+  /// not want the package to rasterize a widget.
+  final Uint8List? image;
+
+  /// Logical (DP on Android, points on iOS) size of the native view.
+  ///
+  /// When null and [widget] is provided, the widget's intrinsic size at
+  /// [pixelRatio] is used.
+  final ui.Size? size;
+
+  /// Device pixel ratio used when rasterizing [widget].
+  ///
+  /// When null, defaults to the primary view's DPR at the time of creation.
+  final double? pixelRatio;
+
+  /// Anchor point of the annotation relative to [geometry].
+  final ViewAnnotationAnchor anchor;
+
+  /// Horizontal offset in logical pixels applied after anchoring.
+  final double offsetX;
+
+  /// Vertical offset in logical pixels applied after anchoring.
+  final double offsetY;
+
+  /// Whether the annotation is allowed to overlap other view annotations.
+  final bool allowOverlap;
+
+  /// Whether the annotation is currently visible.
+  final bool visible;
+
+  ViewAnnotationOptions copyWith({
+    Point? geometry,
+    Widget? widget,
+    Uint8List? image,
+    ui.Size? size,
+    double? pixelRatio,
+    ViewAnnotationAnchor? anchor,
+    double? offsetX,
+    double? offsetY,
+    bool? allowOverlap,
+    bool? visible,
+  }) {
+    return ViewAnnotationOptions(
+      geometry: geometry ?? this.geometry,
+      widget: widget ?? this.widget,
+      image: image ?? this.image,
+      size: size ?? this.size,
+      pixelRatio: pixelRatio ?? this.pixelRatio,
+      anchor: anchor ?? this.anchor,
+      offsetX: offsetX ?? this.offsetX,
+      offsetY: offsetY ?? this.offsetY,
+      allowOverlap: allowOverlap ?? this.allowOverlap,
+      visible: visible ?? this.visible,
+    );
+  }
+}
+
+/// Represents a live view annotation managed by a [ViewAnnotationManager].
+@immutable
+class ViewAnnotation {
+  const ViewAnnotation._({
+    required this.id,
+    required this.options,
+  });
+
+  /// Stable identifier assigned by the manager at creation time.
+  final String id;
+
+  /// Options currently applied to the annotation.
+  final ViewAnnotationOptions options;
+}
+
+/// Event delivered when a view annotation is tapped on the native side.
+@immutable
+class ViewAnnotationTapEvent {
+  const ViewAnnotationTapEvent({required this.annotationId});
+
+  /// Id of the tapped annotation (matches [ViewAnnotation.id]).
+  final String annotationId;
+}
+
+/// Internal wire encoding helpers for view annotation payloads.
+///
+/// Keeping this close to the options lets us evolve the protocol without
+/// leaking it into public API surface.
+Map<String, Object?> _encodeViewAnnotationPayload({
+  required String id,
+  required ViewAnnotationOptions options,
+  required Uint8List imageBytes,
+  required ui.Size? renderedSize,
+}) {
+  final coords = options.geometry.coordinates;
+  return <String, Object?>{
+    'id': id,
+    'coordinates': <double>[coords.lng.toDouble(), coords.lat.toDouble()],
+    'image': imageBytes,
+    if (renderedSize != null) 'width': renderedSize.width,
+    if (renderedSize != null) 'height': renderedSize.height,
+    'anchor': options.anchor.index,
+    'offsetX': options.offsetX,
+    'offsetY': options.offsetY,
+    'allowOverlap': options.allowOverlap,
+    'visible': options.visible,
+  };
+}

--- a/lib/src/annotation/view_annotation/view_annotation_manager.dart
+++ b/lib/src/annotation/view_annotation/view_annotation_manager.dart
@@ -1,0 +1,236 @@
+part of mapbox_maps_flutter;
+
+/// Callback invoked when a [ViewAnnotation] is tapped on the native side.
+typedef OnViewAnnotationTap = void Function(ViewAnnotationTapEvent event);
+
+/// Manages a collection of [ViewAnnotation]s (Flutter widgets anchored to
+/// geographic coordinates) rendered natively above the map surface using the
+/// platform's Mapbox view annotation APIs.
+///
+/// Usage:
+/// ```dart
+/// final manager = await mapboxMap.annotations.createViewAnnotationManager();
+/// final annotation = await manager.create(ViewAnnotationOptions(
+///   geometry: Point(coordinates: Position(2.35, 48.85)),
+///   widget: const _PlaceMarker(),
+///   anchor: ViewAnnotationAnchor.bottom,
+/// ));
+/// manager.tapEvents.listen((e) => print('tapped ${e.annotationId}'));
+/// ```
+///
+/// ### Performance notes
+/// * Widgets are rasterized off the main render tree via [_WidgetRasterizer]
+///   and only re-rasterized on [create] / [update]. Camera movement does not
+///   re-encode bitmaps — the native view annotation manager reprojects the
+///   platform view for free.
+/// * [update] diffs the incoming [ViewAnnotationOptions] against the last
+///   committed ones and skips the rasterization step when only non-visual
+///   fields (geometry, anchor, offset, visibility, overlap policy) changed.
+/// * All platform calls go through a single [MethodChannel] scoped to the
+///   manager id, so multiple managers on the same map do not fight for a
+///   shared channel.
+class ViewAnnotationManager extends BaseAnnotationManager {
+  ViewAnnotationManager._({
+    required super.id,
+    required BinaryMessenger messenger,
+    required String channelSuffix,
+  })  : _channel = MethodChannel(
+          'plugins.flutter.io.mapbox_maps.view_annotations.$channelSuffix.$id',
+          const StandardMethodCodec(),
+          messenger,
+        ),
+        super._(messenger: messenger) {
+    _channel.setMethodCallHandler(_handleMethodCall);
+  }
+
+  final MethodChannel _channel;
+
+  final Map<String, _InternalViewAnnotation> _annotations =
+      <String, _InternalViewAnnotation>{};
+
+  final StreamController<ViewAnnotationTapEvent> _tapController =
+      StreamController<ViewAnnotationTapEvent>.broadcast();
+
+  int _autoId = 0;
+  bool _disposed = false;
+
+  /// Stream of tap events for annotations in this manager.
+  Stream<ViewAnnotationTapEvent> get tapEvents => _tapController.stream;
+
+  /// Creates a new view annotation.
+  ///
+  /// Returns the created [ViewAnnotation]. The caller should store
+  /// [ViewAnnotation.id] and pass it to [update] / [delete].
+  Future<ViewAnnotation> create(ViewAnnotationOptions options) async {
+    _ensureLive();
+    final id = 'va_${_autoId++}';
+    final payload = await _buildPayload(id, options);
+    await _channel.invokeMethod<void>('create', payload.wireArgs);
+    _annotations[id] = _InternalViewAnnotation(
+      options: options,
+      cachedRaster: payload.raster,
+    );
+    return ViewAnnotation._(id: id, options: options);
+  }
+
+  /// Updates an existing view annotation previously returned by [create].
+  ///
+  /// Throws [ArgumentError] when [id] is unknown.
+  Future<ViewAnnotation> update(
+      String id, ViewAnnotationOptions options) async {
+    _ensureLive();
+    final existing = _annotations[id];
+    if (existing == null) {
+      throw ArgumentError.value(id, 'id', 'Unknown view annotation.');
+    }
+
+    final needsRaster = _visualsChanged(existing.options, options);
+    final _PreparedPayload payload = needsRaster
+        ? await _buildPayload(id, options)
+        : _buildPayloadFromRaster(id, options, existing.cachedRaster);
+
+    await _channel.invokeMethod<void>('update', payload.wireArgs);
+    _annotations[id] = _InternalViewAnnotation(
+      options: options,
+      cachedRaster: payload.raster,
+    );
+    return ViewAnnotation._(id: id, options: options);
+  }
+
+  /// Deletes a view annotation.
+  Future<void> delete(String id) async {
+    _ensureLive();
+    if (_annotations.remove(id) == null) {
+      return;
+    }
+    await _channel.invokeMethod<void>('delete', <String, Object?>{'id': id});
+  }
+
+  /// Deletes every view annotation managed by this manager.
+  Future<void> deleteAll() async {
+    _ensureLive();
+    _annotations.clear();
+    await _channel.invokeMethod<void>('deleteAll');
+  }
+
+  /// Returns an immutable snapshot of the currently tracked annotations.
+  List<ViewAnnotation> getAnnotations() {
+    return _annotations.entries
+        .map((e) => ViewAnnotation._(id: e.key, options: e.value.options))
+        .toList(growable: false);
+  }
+
+  /// Releases native resources held by the manager. The manager becomes
+  /// unusable afterwards.
+  Future<void> dispose() async {
+    if (_disposed) {
+      return;
+    }
+    _disposed = true;
+    _channel.setMethodCallHandler(null);
+    await _tapController.close();
+    _annotations.clear();
+    try {
+      await _channel.invokeMethod<void>('dispose');
+    } on PlatformException catch (_) {
+      // Native side may already be torn down — ignore.
+    }
+  }
+
+  /// Only the visual fields require re-rasterization.
+  bool _visualsChanged(ViewAnnotationOptions a, ViewAnnotationOptions b) {
+    if (identical(a.widget, b.widget) && a.image == b.image) {
+      if (a.size == b.size && a.pixelRatio == b.pixelRatio) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  Future<_PreparedPayload> _buildPayload(
+      String id, ViewAnnotationOptions options) async {
+    _RasterizedWidget? raster;
+    Uint8List bytes;
+    ui.Size? renderedSize = options.size;
+
+    if (options.widget != null) {
+      final pixelRatio = options.pixelRatio ??
+          PlatformDispatcher.instance.views.first.devicePixelRatio;
+      raster = await _WidgetRasterizer.rasterize(
+        widget: options.widget!,
+        size: options.size,
+        pixelRatio: pixelRatio,
+      );
+      bytes = raster.bytes;
+      renderedSize = options.size ?? raster.logicalSize;
+    } else {
+      bytes = options.image!;
+    }
+
+    return _PreparedPayload(
+      raster: raster,
+      wireArgs: _encodeViewAnnotationPayload(
+        id: id,
+        options: options,
+        imageBytes: bytes,
+        renderedSize: renderedSize,
+      ),
+    );
+  }
+
+  _PreparedPayload _buildPayloadFromRaster(
+    String id,
+    ViewAnnotationOptions options,
+    _RasterizedWidget? cachedRaster,
+  ) {
+    final bytes = cachedRaster?.bytes ?? options.image;
+    if (bytes == null) {
+      // Should be unreachable when options are constructed correctly.
+      throw StateError(
+          'ViewAnnotationManager.update: no bitmap available for $id.');
+    }
+    final ui.Size? renderedSize = options.size ?? cachedRaster?.logicalSize;
+    return _PreparedPayload(
+      raster: cachedRaster,
+      wireArgs: _encodeViewAnnotationPayload(
+        id: id,
+        options: options,
+        imageBytes: bytes,
+        renderedSize: renderedSize,
+      ),
+    );
+  }
+
+  Future<dynamic> _handleMethodCall(MethodCall call) async {
+    switch (call.method) {
+      case 'onTap':
+        final args = call.arguments as Map<Object?, Object?>?;
+        final annotationId = args?['id'] as String?;
+        if (annotationId != null && !_tapController.isClosed) {
+          _tapController.add(
+              ViewAnnotationTapEvent(annotationId: annotationId));
+        }
+        return null;
+      default:
+        return null;
+    }
+  }
+
+  void _ensureLive() {
+    if (_disposed) {
+      throw StateError('ViewAnnotationManager has been disposed.');
+    }
+  }
+}
+
+class _InternalViewAnnotation {
+  _InternalViewAnnotation({required this.options, required this.cachedRaster});
+  ViewAnnotationOptions options;
+  _RasterizedWidget? cachedRaster;
+}
+
+class _PreparedPayload {
+  _PreparedPayload({required this.raster, required this.wireArgs});
+  final _RasterizedWidget? raster;
+  final Map<String, Object?> wireArgs;
+}

--- a/lib/src/annotation/view_annotation/view_annotation_manager.dart
+++ b/lib/src/annotation/view_annotation/view_annotation_manager.dart
@@ -23,6 +23,10 @@ typedef OnViewAnnotationTap = void Function(ViewAnnotationTapEvent event);
 ///   and only re-rasterized on [create] / [update]. Camera movement does not
 ///   re-encode bitmaps — the native view annotation manager reprojects the
 ///   platform view for free.
+/// * Widget-backed annotations get a short automatic refresh window after
+///   [create] / [update] so late async paints (for example network images)
+///   can replace the initial placeholder bitmap without the app having to
+///   manually call [update].
 /// * [update] diffs the incoming [ViewAnnotationOptions] against the last
 ///   committed ones and skips the rasterization step when only non-visual
 ///   fields (geometry, anchor, offset, visibility, overlap policy) changed.
@@ -47,6 +51,8 @@ class ViewAnnotationManager extends BaseAnnotationManager {
 
   final Map<String, _InternalViewAnnotation> _annotations =
       <String, _InternalViewAnnotation>{};
+  final Map<String, _WidgetRasterRefreshTask> _refreshTasks =
+      <String, _WidgetRasterRefreshTask>{};
 
   final StreamController<ViewAnnotationTapEvent> _tapController =
       StreamController<ViewAnnotationTapEvent>.broadcast();
@@ -69,6 +75,11 @@ class ViewAnnotationManager extends BaseAnnotationManager {
     _annotations[id] = _InternalViewAnnotation(
       options: options,
       cachedRaster: payload.raster,
+    );
+    _scheduleAutomaticWidgetRefresh(
+      id,
+      options,
+      payload.raster,
     );
     return ViewAnnotation._(id: id, options: options);
   }
@@ -94,6 +105,11 @@ class ViewAnnotationManager extends BaseAnnotationManager {
       options: options,
       cachedRaster: payload.raster,
     );
+    _scheduleAutomaticWidgetRefresh(
+      id,
+      options,
+      payload.raster,
+    );
     return ViewAnnotation._(id: id, options: options);
   }
 
@@ -103,6 +119,7 @@ class ViewAnnotationManager extends BaseAnnotationManager {
     if (_annotations.remove(id) == null) {
       return;
     }
+    _cancelAutomaticWidgetRefresh(id);
     await _channel.invokeMethod<void>('delete', <String, Object?>{'id': id});
   }
 
@@ -110,6 +127,7 @@ class ViewAnnotationManager extends BaseAnnotationManager {
   Future<void> deleteAll() async {
     _ensureLive();
     _annotations.clear();
+    _cancelAllAutomaticWidgetRefreshes();
     await _channel.invokeMethod<void>('deleteAll');
   }
 
@@ -129,6 +147,7 @@ class ViewAnnotationManager extends BaseAnnotationManager {
     _disposed = true;
     _channel.setMethodCallHandler(null);
     await _tapController.close();
+    _cancelAllAutomaticWidgetRefreshes();
     _annotations.clear();
     try {
       await _channel.invokeMethod<void>('dispose');
@@ -207,8 +226,8 @@ class ViewAnnotationManager extends BaseAnnotationManager {
         final args = call.arguments as Map<Object?, Object?>?;
         final annotationId = args?['id'] as String?;
         if (annotationId != null && !_tapController.isClosed) {
-          _tapController.add(
-              ViewAnnotationTapEvent(annotationId: annotationId));
+          _tapController
+              .add(ViewAnnotationTapEvent(annotationId: annotationId));
         }
         return null;
       default:
@@ -220,6 +239,84 @@ class ViewAnnotationManager extends BaseAnnotationManager {
     if (_disposed) {
       throw StateError('ViewAnnotationManager has been disposed.');
     }
+  }
+
+  void _scheduleAutomaticWidgetRefresh(
+    String id,
+    ViewAnnotationOptions options,
+    _RasterizedWidget? initialRaster,
+  ) {
+    _cancelAutomaticWidgetRefresh(id);
+
+    final Widget? widget = options.widget;
+    if (widget == null) {
+      return;
+    }
+
+    final _WidgetRasterRefreshTask task = _WidgetRasterRefreshTask(
+      options: options,
+      initialRaster: initialRaster,
+      onRasterChanged: (_RasterizedWidget raster) {
+        return _applyAutomaticWidgetRefresh(id, widget, raster);
+      },
+    );
+    _refreshTasks[id] = task;
+    unawaited(
+      task.start().whenComplete(() {
+        if (identical(_refreshTasks[id], task)) {
+          _refreshTasks.remove(id);
+        }
+      }),
+    );
+  }
+
+  void _cancelAutomaticWidgetRefresh(String id) {
+    _refreshTasks.remove(id)?.cancel();
+  }
+
+  void _cancelAllAutomaticWidgetRefreshes() {
+    for (final _WidgetRasterRefreshTask task in _refreshTasks.values) {
+      task.cancel();
+    }
+    _refreshTasks.clear();
+  }
+
+  Future<void> _applyAutomaticWidgetRefresh(
+    String id,
+    Widget originalWidget,
+    _RasterizedWidget raster,
+  ) async {
+    if (_disposed) {
+      return;
+    }
+
+    final _InternalViewAnnotation? existing = _annotations[id];
+    if (existing == null ||
+        !identical(existing.options.widget, originalWidget)) {
+      return;
+    }
+
+    final ViewAnnotationOptions currentOptions = existing.options;
+    final _PreparedPayload payload =
+        _buildPayloadFromRaster(id, currentOptions, raster);
+    try {
+      await _channel.invokeMethod<void>('update', payload.wireArgs);
+    } on PlatformException {
+      if (_disposed) {
+        return;
+      }
+      rethrow;
+    }
+
+    final _InternalViewAnnotation? latest = _annotations[id];
+    if (latest == null || !identical(latest.options.widget, originalWidget)) {
+      return;
+    }
+
+    _annotations[id] = _InternalViewAnnotation(
+      options: latest.options,
+      cachedRaster: raster,
+    );
   }
 }
 
@@ -233,4 +330,78 @@ class _PreparedPayload {
   _PreparedPayload({required this.raster, required this.wireArgs});
   final _RasterizedWidget? raster;
   final Map<String, Object?> wireArgs;
+}
+
+class _WidgetRasterRefreshTask {
+  _WidgetRasterRefreshTask({
+    required this.options,
+    required this.initialRaster,
+    required this.onRasterChanged,
+  });
+
+  static const List<Duration> _retrySchedule = <Duration>[
+    Duration(milliseconds: 80),
+    Duration(milliseconds: 160),
+    Duration(milliseconds: 320),
+    Duration(milliseconds: 640),
+    Duration(milliseconds: 1200),
+  ];
+
+  final ViewAnnotationOptions options;
+  final _RasterizedWidget? initialRaster;
+  final Future<void> Function(_RasterizedWidget raster) onRasterChanged;
+
+  bool _cancelled = false;
+  _RasterizedWidget? _lastRaster;
+
+  Future<void> start() async {
+    final Widget? widget = options.widget;
+    if (widget == null) {
+      return;
+    }
+
+    _lastRaster = initialRaster;
+    final double pixelRatio = options.pixelRatio ??
+        PlatformDispatcher.instance.views.first.devicePixelRatio;
+
+    for (final Duration delay in _retrySchedule) {
+      await Future<void>.delayed(delay);
+      if (_cancelled) {
+        return;
+      }
+
+      try {
+        final _RasterizedWidget raster = await _WidgetRasterizer.rasterize(
+          widget: widget,
+          size: options.size,
+          pixelRatio: pixelRatio,
+        );
+        if (_cancelled) {
+          return;
+        }
+
+        final _RasterizedWidget? previous = _lastRaster;
+        if (previous != null && _rasterEquals(previous, raster)) {
+          continue;
+        }
+
+        _lastRaster = raster;
+        await onRasterChanged(raster);
+      } catch (_) {
+        if (_cancelled) {
+          return;
+        }
+      }
+    }
+  }
+
+  void cancel() {
+    _cancelled = true;
+  }
+
+  bool _rasterEquals(_RasterizedWidget a, _RasterizedWidget b) {
+    return a.logicalSize == b.logicalSize &&
+        a.pixelRatio == b.pixelRatio &&
+        listEquals(a.bytes, b.bytes);
+  }
 }

--- a/lib/src/annotation/view_annotation/widget_rasterizer.dart
+++ b/lib/src/annotation/view_annotation/widget_rasterizer.dart
@@ -1,0 +1,127 @@
+part of mapbox_maps_flutter;
+
+/// Rasterizes arbitrary Flutter widgets into PNG bytes suitable for handing
+/// to the native view annotation managers.
+///
+/// The implementation mounts the widget inside a throwaway render pipeline
+/// (no interaction with the host widget tree) and captures a
+/// [RenderRepaintBoundary.toImage] frame. This keeps the pipeline on the UI
+/// isolate but avoids any visible overlay, so we do not inherit build-phase
+/// constraints of the enclosing [MapWidget].
+///
+/// The rasterizer is intentionally stateless — callers are expected to
+/// manage their own caches keyed by a visual fingerprint (widget identity,
+/// size, pixel ratio). See [ViewAnnotationManager] for the cache policy
+/// applied when widgets are handed through that API.
+abstract class _WidgetRasterizer {
+  _WidgetRasterizer._();
+
+  /// Rasterizes [widget] at the given logical [size].
+  ///
+  /// When [size] is null, the widget is measured with loose [BoxConstraints]
+  /// and rendered at its intrinsic dry layout size, capped at
+  /// [_maxUnboundedSide] logical pixels per side so runaway widgets do not
+  /// blow past GPU texture limits. [pixelRatio] controls the DPR of the
+  /// resulting bitmap and should usually match the screen's DPR or a
+  /// caller-chosen cap for zoomed-in views.
+  static Future<_RasterizedWidget> rasterize({
+    required Widget widget,
+    ui.Size? size,
+    required double pixelRatio,
+  }) async {
+    final FlutterView flutterView = PlatformDispatcher.instance.views.first;
+    final BoxConstraints logicalConstraints = size == null
+        ? const BoxConstraints(
+            minWidth: 0,
+            maxWidth: _maxUnboundedSide,
+            minHeight: 0,
+            maxHeight: _maxUnboundedSide,
+          )
+        : BoxConstraints.tight(size);
+    final ui.Size physicalCap = ui.Size(
+      (size?.width ?? _maxUnboundedSide) * pixelRatio,
+      (size?.height ?? _maxUnboundedSide) * pixelRatio,
+    );
+
+    final RenderRepaintBoundary repaintBoundary = RenderRepaintBoundary();
+
+    final RenderView renderView = RenderView(
+      view: flutterView,
+      configuration: ViewConfiguration(
+        physicalConstraints: BoxConstraints.loose(physicalCap),
+        logicalConstraints: logicalConstraints,
+        devicePixelRatio: pixelRatio,
+      ),
+      child: repaintBoundary,
+    );
+
+    final PipelineOwner pipelineOwner = PipelineOwner();
+    final BuildOwner buildOwner = BuildOwner(focusManager: FocusManager());
+    pipelineOwner.rootNode = renderView;
+    renderView.prepareInitialFrame();
+
+    final RenderObjectToWidgetElement<RenderBox> rootElement =
+        RenderObjectToWidgetAdapter<RenderBox>(
+      container: repaintBoundary,
+      child: Directionality(
+        textDirection: TextDirection.ltr,
+        child: MediaQuery(
+          data: MediaQueryData.fromView(flutterView),
+          child: widget,
+        ),
+      ),
+    ).attachToRenderTree(buildOwner);
+
+    buildOwner
+      ..buildScope(rootElement)
+      ..finalizeTree();
+
+    pipelineOwner
+      ..flushLayout()
+      ..flushCompositingBits()
+      ..flushPaint();
+
+    final ui.Image image =
+        await repaintBoundary.toImage(pixelRatio: pixelRatio);
+    try {
+      final ByteData? byteData =
+          await image.toByteData(format: ui.ImageByteFormat.png);
+      if (byteData == null) {
+        throw StateError('Failed to encode widget annotation to PNG.');
+      }
+      final ui.Size renderedLogicalSize = repaintBoundary.hasSize
+          ? repaintBoundary.size
+          : (size ?? ui.Size.zero);
+      return _RasterizedWidget(
+        bytes: byteData.buffer.asUint8List(),
+        logicalSize: renderedLogicalSize,
+        pixelRatio: pixelRatio,
+      );
+    } finally {
+      image.dispose();
+      // Detach the offscreen tree so any tickers / image streams held by the
+      // widget are released. We leave the element tree unmounted implicitly —
+      // elements without a parent become garbage after the build owner goes
+      // out of scope, matching the behaviour of the `screenshot` package.
+      pipelineOwner.rootNode = null;
+    }
+  }
+
+  static const double _maxUnboundedSide = 2048;
+}
+
+/// Carrier returned by [_WidgetRasterizer.rasterize] with the PNG payload and
+/// the logical size that the widget laid out to (needed to give the native
+/// view annotation manager the correct view dimensions).
+@immutable
+class _RasterizedWidget {
+  const _RasterizedWidget({
+    required this.bytes,
+    required this.logicalSize,
+    required this.pixelRatio,
+  });
+
+  final Uint8List bytes;
+  final ui.Size logicalSize;
+  final double pixelRatio;
+}

--- a/lib/src/mapbox_maps_platform.dart
+++ b/lib/src/mapbox_maps_platform.dart
@@ -153,6 +153,20 @@ class _MapboxMapsPlatform {
     }
   }
 
+  /// Creates a native view annotation manager on the platform side and
+  /// returns its resolved id (auto-generated when none is supplied).
+  Future<String> createViewAnnotationManager({String? id}) async {
+    final result = await _channel.invokeMethod<String>(
+      'view_annotation#create_manager',
+      <String, dynamic>{'id': id},
+    );
+    if (result == null) {
+      throw StateError(
+          'Native platform did not return an id for the view annotation manager.');
+    }
+    return result;
+  }
+
   Future<dynamic> addGestureListeners() async {
     try {
       return _channel.invokeMethod('gesture#add_listeners');


### PR DESCRIPTION
## Summary
This updates `ViewAnnotationManager` so widget-backed view annotations get a short automatic refresh window after `create` and `update`.

The current native view-annotation path captures the widget once and uploads that bitmap to the platform view annotation manager. That works for camera movement, but it misses late async paints from widget subtrees such as network-loaded images. In practice, annotations created from widgets like thumbnail markers can stay stuck on their initial placeholder bitmap unless the app manually calls `update` again.

## What changed
- track a short-lived refresh task per widget-backed annotation
- re-rasterize the widget on a small backoff schedule after `create`/`update`
- push a native `update` only when the refreshed raster actually changes
- cancel outstanding refresh tasks on `delete`, `deleteAll`, and `dispose`

## Why
This keeps the correct native Mapbox movement/reprojection behavior while allowing late async widget content to replace the initial placeholder image automatically.

## Validation
- `flutter build apk --debug --no-pub` from a host app using this vendored package
- `dart analyze packages/mapbox-maps-flutter/lib` from the host workspace (existing package infos remain)

## Notes
A standalone `flutter test` run was not possible from this vendored checkout because the package `pubspec.yaml` uses `resolution: workspace` and this local checkout is not attached to its original pub workspace root.