### PR TITLE
Bump compileSdk to 36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### main
 
+* [Android] Use flutter.compileSdkVersion to align Android compileSdk with Flutter SDK
+
 ### 2.25.0-rc.1
 
 * Deprecate `MapboxMap.onTapListener` and `MapboxMap.onLongTapListener` in favor of the `MapboxMap.addInterfaction` API.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,7 +38,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdk 36
+    compileSdk flutter.compileSdkVersion
 
     namespace 'com.mapbox.maps.mapbox_maps'
     sourceSets {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,7 +38,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdk 35
+    compileSdk 36
 
     namespace 'com.mapbox.maps.mapbox_maps'
     sourceSets {


### PR DESCRIPTION
### What does this pull request do?
Increase android compileSdk to 36.


### What is the motivation and context behind this change?
Unable to build properly:
```
Execution failed for task ':mapbox_maps_flutter:checkReleaseAarMetadata'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.CheckAarMetadataWorkAction
   > An issue was found when checking AAR metadata:

       1.  Dependency ':flutter_plugin_android_lifecycle' requires libraries and applications that
           depend on it to compile against version 36 or later of the
           Android APIs.

           :mapbox_maps_flutter is currently compiled against android-35.
```

Having the following flutter version and setup:

```
flutter doctor -v
[✓] Flutter (Channel stable, 3.44.1, on macOS 26.3.1 25D771280a darwin-arm64, locale en-US) [161ms]
    • Flutter version 3.44.1 on channel stable at /Users/robert/development/flutter
    • Upstream repository https://github.com/flutter/flutter.git
    • Framework revision 924134a44c (10 days ago), 2026-05-29 12:13:22 -0400
    • Engine revision c416acfeb8
    • Dart version 3.12.1
    • DevTools version 2.57.0
    • Feature flags: enable-web, enable-linux-desktop, enable-macos-desktop, enable-windows-desktop, enable-android, enable-ios, cli-animations, enable-native-assets, no-enable-swift-package-manager, omit-legacy-version-file, enable-lldb-debugging,
      enable-uiscene-migration

[✓] Android toolchain - develop for Android devices (Android SDK version 36.1.0) [744ms]
    • Android SDK at /Users/robert/Library/Android/sdk
    • Emulator version 36.3.10.0 (build_id 14472402) (CL:N/A)
    • Platform android-37.0, build-tools 36.1.0
    • Java binary at: /Applications/Android Studio.app/Contents/jbr/Contents/Home/bin/java
      This is the JDK bundled with the latest Android Studio installation on this machine.
      To manually set the JDK path, use: `flutter config --jdk-dir="path/to/jdk"`.
    • Java version OpenJDK Runtime Environment (build 21.0.10+-117844308-b1163.108)
    • All Android licenses accepted.
```


### Pull request checklist:
 - [x] Add a changelog entry.
   Only written here as I'm not sure when it is applicable to add a changelog entry:
   *"Bump android compileSdk version to 36"*

 - [x] Write tests for all new functionality. If tests were not written, please explain why.
   *No new functionality. Build configuration update only. No new test cases. Tested locally.*

 - [x] Add documentation comments for any added or updated public APIs.
   *Not applicable, no public API changes.*

PRs is be submitted under the terms of our Contributor License Agreement [CLA](../CONTRIBUTING.md#contributor-license-agreement).
