### PR TITLE
Bump Android compileSdk to 36 for AndroidX compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### main
 
+- [sdk] Bump compileSdk from 35 to 36 for AndroidX compatibility
+
 ### 2.25.0-rc.1
 
 * Deprecate `MapboxMap.onTapListener` and `MapboxMap.onLongTapListener` in favor of the `MapboxMap.addInterfaction` API.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,7 +38,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdk 35
+    compileSdk 36
 
     namespace 'com.mapbox.maps.mapbox_maps'
     sourceSets {


### PR DESCRIPTION
Update android/build.gradle to set compileSdk to 36 and add a CHANGELOG entry noting the SDK bump for AndroidX compatibility. This ensures the library targets API 36 for improved AndroidX support.

### What does this pull request do?
Bumps the Android `compileSdk` from 35 to 36. This resolves a build failure when a Flutter app uses `compileSdk = 36` and includes this plugin.

### What is the motivation and context behind this change?
When a Flutter app uses `compileSdk = 36`, the plugin fails to build with:
Dependency ':flutter_plugin_android_lifecycle' requires compiling against API 36, but :mapbox_maps_flutter is compiled against 35.

## Why this is safe
`compileSdk` only affects compilation – not runtime behavior or device compatibility. The plugin does not use any API 36 features.

## Testing

- I tested this change in my own Flutter app (using the plugin via local path override) – the build succeeded.
- I attempted to build the example app, but it depends on Mapbox SNAPSHOT builds that require authentication (401 Unauthorized). That pre‑existing issue is unrelated to my change.
- The change is minimal and mirrors the previous bump from 33→35 done by the maintainers.


### Pull request checklist:
- [x] Updated `CHANGELOG.md` under `### main`
- [x] Commit prefixed with `[sdk]`

Fixes #1130

